### PR TITLE
AAE-2144 add missing swagger ui

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
@@ -42,6 +42,10 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
After another test on a test environment, I noticed that the Swagger UI is missing. Before on my local environment it works, I think cause of some locally built snapshot version.