### PR TITLE
Restore default phases for attach sources and sign jars (#3184)

### DIFF
--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -444,7 +444,6 @@
             <executions>
               <execution>
                 <id>attach-sources</id>
-                <phase>deploy</phase>
                 <goals>
                   <goal>jar-no-fork</goal>
                 </goals>
@@ -472,7 +471,6 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
-                <phase>deploy</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.activiti</groupId>
+  <groupId>org.activiti.cloud</groupId>
   <artifactId>activiti-cloud-mono-aggregator</artifactId>
   <packaging>pom</packaging>
   <name>Activiti Cloud Mono :: Parent</name>
@@ -212,7 +212,6 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
-                <phase>deploy</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
Changing the default phases is causing issues while signing artifacts (sources jars and some pom files are not signed)
Ref https://github.com/Activiti/Activiti/issues/3184