### PR TITLE
Explicitly sign artifacts in verify phase

### DIFF
--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -471,6 +471,7 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
+                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
+                <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
When no phase is specified some of the artifacts are signed too late
Ref https://github.com/Activiti/Activiti/issues/3184