### PR TITLE
fix(AAE-1291): add transaction support for integration context event handlers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
             sh "mvn versions:set -DprocessAllModules=true -DgenerateBackupPoms=false -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
             sh 'export VERSION=$PREVIEW_VERSION'
+            sh "mvn deploy -DskipITs -DskipTests"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
             sh "mvn versions:set -DprocessAllModules=true -DgenerateBackupPoms=false -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
             sh 'export VERSION=$PREVIEW_VERSION'
-            sh "mvn deploy -DskipITs -DskipTests"
           }
         }
       }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImpl.java
@@ -32,10 +32,14 @@ public class IntegrationErrorHandlerImpl implements IntegrationErrorHandler {
         logger.debug("Error Message exception occurred: {}", errorMessage);
 
         MessagingException throwablePayload = MessagingException.class.cast(errorMessage.getPayload());
-        Message<?> failedMessage = throwablePayload.getFailedMessage();
+        Message<?> originalMessage= errorMessage.getOriginalMessage();
 
-        if (failedMessage != null) {
-            byte[] data = (byte[]) failedMessage.getPayload();
+        if(originalMessage == null) {
+            originalMessage = throwablePayload.getFailedMessage();
+        }
+
+        if (originalMessage != null) {
+            byte[] data = (byte[]) originalMessage.getPayload();
             IntegrationRequest integrationRequest = null;
 
             try {

--- a/activiti-cloud-notifications-graphql-service/services/web/src/main/java/org/activiti/cloud/services/graphql/autoconfigure/ActivitiGraphQLAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/web/src/main/java/org/activiti/cloud/services/graphql/autoconfigure/ActivitiGraphQLAutoConfiguration.java
@@ -15,12 +15,16 @@
  */
 package org.activiti.cloud.services.graphql.autoconfigure;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
 import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaExecutor;
 import graphql.GraphQL;
@@ -39,6 +43,15 @@ public class ActivitiGraphQLAutoConfiguration {
      */
     @Configuration
     public static class DefaultActivitiGraphQLJpaConfiguration {
+
+        /**
+         * This is needed because the graphql spec says that null values should be present
+         */
+        @Autowired
+        public void configureObjectMapper(ObjectMapper objectMapper) {
+            objectMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, true)
+                        .setSerializationInclusion(Include.ALWAYS);
+        }
 
         @Bean
         @ConditionalOnMissingBean(GraphQLExecutor.class)

--- a/activiti-cloud-notifications-graphql-service/services/web/src/main/java/org/activiti/cloud/services/graphql/autoconfigure/ActivitiGraphQLAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/web/src/main/java/org/activiti/cloud/services/graphql/autoconfigure/ActivitiGraphQLAutoConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.activiti.cloud.services.graphql.autoconfigure;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -22,7 +24,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonInclude.Value;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.introproventures.graphql.jpa.query.schema.GraphQLExecutor;
@@ -49,8 +53,9 @@ public class ActivitiGraphQLAutoConfiguration {
          */
         @Autowired
         public void configureObjectMapper(ObjectMapper objectMapper) {
-            objectMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, true)
-                        .setSerializationInclusion(Include.ALWAYS);
+            objectMapper.configOverride(Map.class)
+                        .setInclude(Value.construct(JsonInclude.Include.ALWAYS,
+                                                    JsonInclude.Include.ALWAYS));
         }
 
         @Bean

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -29,7 +29,9 @@ import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity.IntegrationContextStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHandler implements QueryEventHandler {
 
     public IntegrationErrorReceivedEventHandler(IntegrationContextRepository repository,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -53,6 +53,8 @@ public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHa
         entity.setErrorMessage(integrationEvent.getErrorMessage());
         entity.setErrorClassName(integrationEvent.getErrorClassName());
         entity.setStackTraceElements(integrationEvent.getStackTraceElements());
+        entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
+        entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
 
         BPMNActivityEntity bpmnActivityEntity = entity.getBpmnActivity();
         bpmnActivityEntity.setStatus(BPMNActivityStatus.ERROR);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
@@ -27,10 +27,14 @@ import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity.IntegrationContextStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandler implements QueryEventHandler {
+
+    private final static Logger logger = LoggerFactory.getLogger(IntegrationRequestedEventHandler.class);
 
     public IntegrationRequestedEventHandler(IntegrationContextRepository repository,
                                             BPMNActivityRepository bpmnActivityRepository,
@@ -48,8 +52,7 @@ public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandle
 
         entity.setRequestDate(new Date(integrationEvent.getTimestamp()));
         entity.setStatus(IntegrationContextStatus.INTEGRATION_REQUESTED);
-        entity.setInboundVariables(entity.getInboundVariables());
-
+        entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
@@ -27,7 +27,9 @@ import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity.IntegrationContextStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandler implements QueryEventHandler {
 
     public IntegrationRequestedEventHandler(IntegrationContextRepository repository,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
@@ -48,8 +48,7 @@ public class IntegrationResultReceivedEventHandler extends BaseIntegrationEventH
 
         entity.setResultDate(new Date(integrationEvent.getTimestamp()));
         entity.setStatus(IntegrationContextStatus.INTEGRATION_RESULT_RECEIVED);
-        entity.setOutBoundVariables(entity.getOutBoundVariables());
-
+        entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
@@ -27,7 +27,9 @@ import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity.IntegrationContextStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class IntegrationResultReceivedEventHandler extends BaseIntegrationEventHandler implements QueryEventHandler {
 
     public IntegrationResultReceivedEventHandler(IntegrationContextRepository integrationContextRepository,


### PR DESCRIPTION
This PR fixes the following:

- persisting integration context entity with related Bpmn activity entity mapping. 
- persisting inbound and outbound variables for integration context
- enable object mapper null value serialization for Map in Graphql controller

Part of https://github.com/Activiti/Activiti/issues/2712