### PR TITLE
feat(AAE-1291): add support for CloudBpmnError propagation 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
             sh "mvn versions:set -DprocessAllModules=true -DgenerateBackupPoms=false -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
             sh 'export VERSION=$PREVIEW_VERSION'
+            sh "mvn deploy -DskipTests -DskipITs"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
             sh "mvn versions:set -DprocessAllModules=true -DgenerateBackupPoms=false -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
             sh 'export VERSION=$PREVIEW_VERSION'
-            sh "mvn deploy -DskipTests -DskipITs"
+//             sh "mvn deploy -DskipTests -DskipITs"
           }
         }
       }

--- a/activiti-cloud-api/activiti-cloud-api-model-shared-impl/src/main/java/org/activiti/cloud/api/model/shared/impl/CloudRuntimeEntityImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-model-shared-impl/src/main/java/org/activiti/cloud/api/model/shared/impl/CloudRuntimeEntityImpl.java
@@ -16,6 +16,8 @@
 
 package org.activiti.cloud.api.model.shared.impl;
 
+import java.util.Objects;
+
 import org.activiti.api.model.shared.model.ApplicationElement;
 import org.activiti.api.runtime.model.impl.ApplicationElementImpl;
 import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
@@ -78,5 +80,51 @@ public class CloudRuntimeEntityImpl extends ApplicationElementImpl implements Cl
 
     public void setServiceVersion(String serviceVersion) {
         this.serviceVersion = serviceVersion;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(appName, serviceFullName, serviceName, serviceType, serviceVersion);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CloudRuntimeEntityImpl other = (CloudRuntimeEntityImpl) obj;
+        return Objects.equals(appName, other.appName) &&
+               Objects.equals(serviceFullName, other.serviceFullName) &&
+               Objects.equals(serviceName, other.serviceName) &&
+               Objects.equals(serviceType, other.serviceType) &&
+               Objects.equals(serviceVersion, other.serviceVersion);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CloudRuntimeEntityImpl [appName=")
+               .append(appName)
+               .append(", serviceName=")
+               .append(serviceName)
+               .append(", serviceFullName=")
+               .append(serviceFullName)
+               .append(", serviceType=")
+               .append(serviceType)
+               .append(", serviceVersion=")
+               .append(serviceVersion)
+               .append(", toString()=")
+               .append(super.toString())
+               .append("]");
+        return builder.toString();
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationErrorImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationErrorImpl.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.api.process.model.impl;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
@@ -28,11 +29,11 @@ public class IntegrationErrorImpl extends CloudRuntimeEntityImpl implements Inte
 
     private IntegrationRequest integrationRequest;
     private IntegrationContext integrationContext;
-    
+
     private String errorMessage;
     private List<StackTraceElement> stackTraceElements;
     private String errorClassName;
-    
+
     IntegrationErrorImpl() {
     }
 
@@ -54,19 +55,72 @@ public class IntegrationErrorImpl extends CloudRuntimeEntityImpl implements Inte
     public IntegrationRequest getIntegrationRequest() {
         return integrationRequest;
     }
-    
+
     @Override
     public List<StackTraceElement> getStackTraceElements() {
         return stackTraceElements;
     }
-    
+
     @Override
     public String getErrorMessage() {
         return errorMessage;
     }
-    
+
     @Override
     public String getErrorClassName() {
         return errorClassName;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(errorClassName,
+                                               errorMessage,
+                                               integrationContext,
+                                               integrationRequest,
+                                               stackTraceElements);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        IntegrationErrorImpl other = (IntegrationErrorImpl) obj;
+        return Objects.equals(errorClassName, other.errorClassName) &&
+               Objects.equals(errorMessage, other.errorMessage) &&
+               Objects.equals(integrationContext, other.integrationContext) &&
+               Objects.equals(integrationRequest, other.integrationRequest) &&
+               Objects.equals(stackTraceElements, other.stackTraceElements);
+    }
+
+    @Override
+    public String toString() {
+        final int maxLen = 10;
+        StringBuilder builder = new StringBuilder();
+        builder.append("IntegrationErrorImpl [integrationRequest=")
+               .append(integrationRequest)
+               .append(", integrationContext=")
+               .append(integrationContext)
+               .append(", errorMessage=")
+               .append(errorMessage)
+               .append(", stackTraceElements=")
+               .append(stackTraceElements != null ? stackTraceElements.subList(0,
+                                                                               Math.min(stackTraceElements.size(),
+                                                                                        maxLen)) : null)
+               .append(", errorClassName=")
+               .append(errorClassName)
+               .append(", toString()=")
+               .append(super.toString())
+               .append("]");
+        return builder.toString();
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model;
+
+public class CloudBpmnError extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public CloudBpmnError(String errorCode) {
+      super(errorCode);
+
+      if (errorCode == null) {
+          throw new IllegalArgumentException("Error Code must not be null.");
+        }
+        if (errorCode.length() < 1) {
+          throw new IllegalArgumentException("Error Code must not be empty.");
+        }
+
+    }
+
+    public String getErrorCode() {
+      return getMessage();
+    }
+
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/EventHandlersAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/EventHandlersAutoConfiguration.java
@@ -244,20 +244,26 @@ public class EventHandlersAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BPMNActivityStartedEventHandler bpmnActivityStartedEventHandler(BPMNActivityRepository bpmnActivityRepository) {
-        return new BPMNActivityStartedEventHandler(bpmnActivityRepository);
+    public BPMNActivityStartedEventHandler bpmnActivityStartedEventHandler(BPMNActivityRepository bpmnActivityRepository,
+                                                                           EntityManager entityManager) {
+        return new BPMNActivityStartedEventHandler(bpmnActivityRepository,
+                                                   entityManager);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public BPMNActivityCompletedEventHandler bpmnActivityCompletedEventHandler(BPMNActivityRepository bpmnActivityRepository) {
-        return new BPMNActivityCompletedEventHandler(bpmnActivityRepository);
+    public BPMNActivityCompletedEventHandler bpmnActivityCompletedEventHandler(BPMNActivityRepository bpmnActivityRepository,
+                                                                               EntityManager entityManager) {
+        return new BPMNActivityCompletedEventHandler(bpmnActivityRepository,
+                                                     entityManager);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public BPMNActivityCancelledEventHandler bpmnActivityCancelledEventHandler(BPMNActivityRepository bpmnActivityRepository) {
-        return new BPMNActivityCancelledEventHandler(bpmnActivityRepository);
+    public BPMNActivityCancelledEventHandler bpmnActivityCancelledEventHandler(BPMNActivityRepository bpmnActivityRepository,
+                                                                               EntityManager entityManager) {
+        return new BPMNActivityCancelledEventHandler(bpmnActivityRepository,
+                                                     entityManager);
     }
 
     @Bean

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCancelledEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCancelledEventHandler.java
@@ -18,17 +18,24 @@ package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
 
+import javax.persistence.EntityManager;
+
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCancelledEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class BPMNActivityCancelledEventHandler extends BaseBPMNActivityEventHandler implements QueryEventHandler {
 
-    public BPMNActivityCancelledEventHandler(BPMNActivityRepository activitiyRepository) {
-        super(activitiyRepository);
+    public BPMNActivityCancelledEventHandler(BPMNActivityRepository activitiyRepository,
+                                             EntityManager entityManager) {
+        super(activitiyRepository,
+              entityManager);
+
     }
 
     @Override
@@ -39,9 +46,6 @@ public class BPMNActivityCancelledEventHandler extends BaseBPMNActivityEventHand
 
         bpmnActivityEntity.setCancelledDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(BPMNActivityStatus.CANCELLED);
-
-        persistIntoDatabase(event,
-                            bpmnActivityEntity);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCompletedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCompletedEventHandler.java
@@ -18,17 +18,23 @@ package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
 
+import javax.persistence.EntityManager;
+
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class BPMNActivityCompletedEventHandler extends BaseBPMNActivityEventHandler implements QueryEventHandler {
 
-    public BPMNActivityCompletedEventHandler(BPMNActivityRepository activitiyRepository) {
-        super(activitiyRepository);
+    public BPMNActivityCompletedEventHandler(BPMNActivityRepository activitiyRepository,
+                                             EntityManager entityManager) {
+        super(activitiyRepository,
+              entityManager);
     }
 
     @Override
@@ -40,8 +46,6 @@ public class BPMNActivityCompletedEventHandler extends BaseBPMNActivityEventHand
         bpmnActivityEntity.setCompletedDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(BPMNActivityStatus.COMPLETED);
 
-        persistIntoDatabase(event,
-                            bpmnActivityEntity);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -18,17 +18,23 @@ package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
 
+import javax.persistence.EntityManager;
+
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandler implements QueryEventHandler {
 
-    public BPMNActivityStartedEventHandler(BPMNActivityRepository activitiyRepository) {
-        super(activitiyRepository);
+    public BPMNActivityStartedEventHandler(BPMNActivityRepository activitiyRepository,
+                                           EntityManager entityManager) {
+        super(activitiyRepository,
+              entityManager);
     }
 
     @Override
@@ -40,10 +46,6 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
         // Activity can be cyclical, so we just update the status and started date anyways
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(BPMNActivityStatus.STARTED);
-
-        persistIntoDatabase(event,
-                            bpmnActivityEntity);
-
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseBPMNActivityEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseBPMNActivityEventHandler.java
@@ -16,19 +16,23 @@
 
 package org.activiti.cloud.services.query.events.handlers;
 
+import javax.persistence.EntityManager;
+
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.QueryException;
 
 public abstract class BaseBPMNActivityEventHandler  {
 
-    private final BPMNActivityRepository bpmnActivitiyRepository;
+    protected final BPMNActivityRepository bpmnActivitiyRepository;
+    protected final EntityManager entityManager;
 
-    public BaseBPMNActivityEventHandler(BPMNActivityRepository activitiyRepository) {
+    public BaseBPMNActivityEventHandler(BPMNActivityRepository activitiyRepository,
+                                        EntityManager entityManager) {
         this.bpmnActivitiyRepository = activitiyRepository;
+        this.entityManager = entityManager;
     }
 
     protected BPMNActivityEntity findOrCreateBPMNActivityEntity(CloudRuntimeEvent<?, ?> event) {
@@ -57,19 +61,11 @@ public abstract class BaseBPMNActivityEventHandler  {
             bpmnActivityEntity.setProcessDefinitionKey(activityEvent.getProcessDefinitionKey());
             bpmnActivityEntity.setProcessDefinitionVersion(activityEvent.getProcessDefinitionVersion());
             bpmnActivityEntity.setBusinessKey(activityEvent.getBusinessKey());
+
+            entityManager.persist(bpmnActivityEntity);
         }
 
         return bpmnActivityEntity;
 
-    }
-
-    protected void persistIntoDatabase(CloudRuntimeEvent<?, ?> event,
-                                       BPMNActivityEntity entity) {
-        try {
-            bpmnActivitiyRepository.save(entity);
-        } catch (Exception cause) {
-            throw new QueryException("Error handling CloudBPMNActivityStartedEvent[" + event + "]",
-                                     cause);
-        }
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseIntegrationEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseIntegrationEventHandler.java
@@ -1,5 +1,7 @@
 package org.activiti.cloud.services.query.events.handlers;
 
+import java.util.Optional;
+
 import javax.persistence.EntityManager;
 
 import org.activiti.api.process.model.IntegrationContext;
@@ -27,7 +29,7 @@ public abstract class BaseIntegrationEventHandler {
         this.entityManager = entityManager;
     }
 
-    protected IntegrationContextEntity findOrCreateIntegrationContextEntity(CloudIntegrationEvent event) {
+    protected Optional<IntegrationContextEntity> findOrCreateIntegrationContextEntity(CloudIntegrationEvent event) {
 
         IntegrationContext integrationContext = event.getEntity();
 
@@ -39,32 +41,35 @@ public abstract class BaseIntegrationEventHandler {
             BPMNActivityEntity bpmnActivityEntity = bpmnActivityRepository.findByProcessInstanceIdAndElementIdAndExecutionId(integrationContext.getProcessInstanceId(),
                                                                                                                              integrationContext.getClientId(),
                                                                                                                              integrationContext.getExecutionId());
-            logger.info("Found BPMNActivityEntity: {}", bpmnActivityEntity);
+            if (bpmnActivityEntity != null) {
+                logger.debug("Found BPMNActivityEntity: {}", bpmnActivityEntity);
 
-            entity = new IntegrationContextEntity(event.getServiceName(),
-                                                  event.getServiceFullName(),
-                                                  event.getServiceVersion(),
-                                                  event.getAppName(),
-                                                  event.getAppVersion());
-            // Let use event id to persist integration context
-            entity.setId(bpmnActivityEntity.getId());
-            entity.setClientId(integrationContext.getClientId());
-            entity.setClientName(integrationContext.getClientName());
-            entity.setClientType(integrationContext.getClientType());
-            entity.setConnectorType(integrationContext.getConnectorType());
-            entity.setProcessDefinitionId(integrationContext.getProcessDefinitionId());
-            entity.setProcessInstanceId(integrationContext.getProcessInstanceId());
-            entity.setExecutionId(integrationContext.getExecutionId());
-            entity.setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
-            entity.setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
-            entity.setBusinessKey(integrationContext.getBusinessKey());
-            entity.setBpmnActivity(bpmnActivityEntity);
+                entity = new IntegrationContextEntity(event.getServiceName(),
+                                                      event.getServiceFullName(),
+                                                      event.getServiceVersion(),
+                                                      event.getAppName(),
+                                                      event.getAppVersion());
+                // Let use event id to persist integration context
+                entity.setId(bpmnActivityEntity.getId());
+                entity.setClientId(integrationContext.getClientId());
+                entity.setClientName(integrationContext.getClientName());
+                entity.setClientType(integrationContext.getClientType());
+                entity.setConnectorType(integrationContext.getConnectorType());
+                entity.setProcessDefinitionId(integrationContext.getProcessDefinitionId());
+                entity.setProcessInstanceId(integrationContext.getProcessInstanceId());
+                entity.setExecutionId(integrationContext.getExecutionId());
+                entity.setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
+                entity.setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
+                entity.setBusinessKey(integrationContext.getBusinessKey());
+                entity.setBpmnActivity(bpmnActivityEntity);
 
-            entityManager.persist(entity);
-
+                entityManager.persist(entity);
+            } else {
+                logger.error("Cannot find BPMNActivityEntity for integrationContext: {}", integrationContext);
+            }
         }
 
-        return entity;
+        return Optional.ofNullable(entity);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
@@ -46,18 +47,20 @@ public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHa
     public void handle(CloudRuntimeEvent<?, ?> event) {
         CloudIntegrationErrorReceivedEvent integrationEvent = CloudIntegrationErrorReceivedEvent.class.cast(event);
 
-        IntegrationContextEntity entity = findOrCreateIntegrationContextEntity(integrationEvent);
+        Optional<IntegrationContextEntity> result = findOrCreateIntegrationContextEntity(integrationEvent);
 
-        entity.setErrorDate(new Date(integrationEvent.getTimestamp()));
-        entity.setStatus(IntegrationContextStatus.INTEGRATION_ERROR_RECEIVED);
-        entity.setErrorMessage(integrationEvent.getErrorMessage());
-        entity.setErrorClassName(integrationEvent.getErrorClassName());
-        entity.setStackTraceElements(integrationEvent.getStackTraceElements());
-        entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
-        entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
+        result.ifPresent(entity -> {
+            entity.setErrorDate(new Date(integrationEvent.getTimestamp()));
+            entity.setStatus(IntegrationContextStatus.INTEGRATION_ERROR_RECEIVED);
+            entity.setErrorMessage(integrationEvent.getErrorMessage());
+            entity.setErrorClassName(integrationEvent.getErrorClassName());
+            entity.setStackTraceElements(integrationEvent.getStackTraceElements());
+            entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
+            entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
 
-        BPMNActivityEntity bpmnActivityEntity = entity.getBpmnActivity();
-        bpmnActivityEntity.setStatus(BPMNActivityStatus.ERROR);
+            BPMNActivityEntity bpmnActivityEntity = entity.getBpmnActivity();
+            bpmnActivityEntity.setStatus(BPMNActivityStatus.ERROR);
+        });
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
@@ -48,11 +49,13 @@ public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandle
     public void handle(CloudRuntimeEvent<?, ?> event) {
         CloudIntegrationRequestedEvent integrationEvent = CloudIntegrationRequestedEvent.class.cast(event);
 
-        IntegrationContextEntity entity = findOrCreateIntegrationContextEntity(integrationEvent);
+        Optional<IntegrationContextEntity> result = findOrCreateIntegrationContextEntity(integrationEvent);
 
-        entity.setRequestDate(new Date(integrationEvent.getTimestamp()));
-        entity.setStatus(IntegrationContextStatus.INTEGRATION_REQUESTED);
-        entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
+        result.ifPresent(entity -> {
+            entity.setRequestDate(new Date(integrationEvent.getTimestamp()));
+            entity.setStatus(IntegrationContextStatus.INTEGRATION_REQUESTED);
+            entity.setInboundVariables(integrationEvent.getEntity().getInBoundVariables());
+        });
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationResultReceivedEventHandler.java
@@ -17,6 +17,7 @@
 package org.activiti.cloud.services.query.events.handlers;
 
 import java.util.Date;
+import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
@@ -44,11 +45,13 @@ public class IntegrationResultReceivedEventHandler extends BaseIntegrationEventH
     public void handle(CloudRuntimeEvent<?, ?> event) {
         CloudIntegrationResultReceivedEvent integrationEvent = CloudIntegrationResultReceivedEvent.class.cast(event);
 
-        IntegrationContextEntity entity = findOrCreateIntegrationContextEntity(integrationEvent);
+        Optional<IntegrationContextEntity> result = findOrCreateIntegrationContextEntity(integrationEvent);
 
-        entity.setResultDate(new Date(integrationEvent.getTimestamp()));
-        entity.setStatus(IntegrationContextStatus.INTEGRATION_RESULT_RECEIVED);
-        entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
+        result.ifPresent(entity -> {
+            entity.setResultDate(new Date(integrationEvent.getTimestamp()));
+            entity.setStatus(IntegrationContextStatus.INTEGRATION_RESULT_RECEIVED);
+            entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
+        });
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -90,7 +90,7 @@ public class ServiceTaskIntegrationErrorEventHandler {
                         ", flow node id `" + clientId +
                         "`. The integration error for the integration context `" + integrationContext.getId() + "` is {}";
 
-                LOGGER.error(message, integrationError);
+                LOGGER.info(message, integrationError);
 
                 if(CloudBpmnError.class.getName().equals(errorClassName)) {
                     if(execution.getActivityId().equals(clientId)) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -82,7 +82,7 @@ public class ServiceTaskIntegrationErrorEventHandler {
             List<Execution> executions = runtimeService.createExecutionQuery().executionId(integrationContextEntity.getExecutionId()).list();
             if (executions.size() > 0) {
                 String errorClassName = integrationError.getErrorClassName();
-                String message = "Received integration error ' + errorClassName + ' with execution id `" +
+                String message = "Received integration error '" + errorClassName + "' with execution id `" +
                         integrationContextEntity.getExecutionId() +
                         ", flow node id `" + integrationContext.getClientId() +
                         "`. The integration error for the integration context `" + integrationContext.getId() + "` is {}";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -98,8 +98,12 @@ public class ServiceTaskIntegrationErrorEventHandler {
                         cloudBpmnError.setStackTrace(integrationError.getStackTraceElements()
                                                                      .toArray(new StackTraceElement[] {}));
 
-                        managementService.executeCommand(new PropagateCloudBpmnErrorCmd(cloudBpmnError,
-                                                                                        execution));
+                        try {
+                            managementService.executeCommand(new PropagateCloudBpmnErrorCmd(cloudBpmnError,
+                                                                                            execution));
+                        } catch(Throwable cause) {
+                            LOGGER.error("Error propagating CloudBpmnError: {}", cause.getMessage());
+                        }
                     } else {
                         LOGGER.warn("Could not find matching activityId '{}' for integration error '{}' with executionId '{}'",
                                      clientId,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/CloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/CloudConnectorsAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.conf.activiti.services.connectors;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.bpmn.parser.factory.DefaultActivityBehaviorFactory;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
@@ -74,12 +75,14 @@ public class CloudConnectorsAutoConfiguration {
     public ServiceTaskIntegrationErrorEventHandler serviceTaskIntegrationErrorEventHandler(RuntimeService runtimeService,
                                                                                            IntegrationContextService integrationContextService,
                                                                                            ProcessEngineChannels processEngineChannels,
+                                                                                           ManagementService managementService,
                                                                                            RuntimeBundleProperties runtimeBundleProperties,
                                                                                            RuntimeBundleInfoAppender runtimeBundleInfoAppender,
                                                                                            IntegrationContextMessageBuilderFactory messageBuilderFactory) {
         return new ServiceTaskIntegrationErrorEventHandler(runtimeService,
                                                            integrationContextService,
                                                            processEngineChannels.auditProducer(),
+                                                           managementService,
                                                            runtimeBundleProperties,
                                                            runtimeBundleInfoAppender,
                                                            messageBuilderFactory);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandlerTest.java
@@ -41,6 +41,7 @@ import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderAppenderChain;
 import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
 import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.engine.runtime.Execution;
@@ -121,7 +122,7 @@ public class ServiceTaskIntegrationResultEventHandlerTest {
 
         given(integrationContextService.findById(ENTITY_ID))
                 .willReturn(integrationContextEntity);
-        given(executionQuery.list()).willReturn(Collections.singletonList(mock(Execution.class)));
+        given(executionQuery.list()).willReturn(Collections.singletonList(mock(ExecutionEntity.class)));
         given(executionQuery.list().get(0).getActivityId()).willReturn(CLIENT_ID);
         Map<String, Object> variables = Collections.singletonMap("var1",
                 "v");

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -5,8 +5,6 @@ import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.V
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_CANCELLED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
-import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
-import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED;
 import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED;
 import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED;
 import static org.activiti.api.process.model.events.ProcessDefinitionEvent.ProcessDefinitionEvents.PROCESS_DEPLOYED;
@@ -45,9 +43,6 @@ import java.util.stream.Stream;
 
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.model.shared.model.ApplicationElement;
-import org.activiti.api.process.model.BPMNActivity;
-import org.activiti.api.process.model.BPMNError;
-import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
@@ -58,21 +53,12 @@ import org.activiti.api.task.model.TaskCandidateGroup;
 import org.activiti.api.task.model.TaskCandidateUser;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
-import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
-import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
-import org.activiti.cloud.api.process.model.events.CloudBPMNErrorReceivedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.api.process.model.impl.CandidateGroup;
 import org.activiti.cloud.api.process.model.impl.CandidateUser;
-import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
-import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
-import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.api.task.model.events.CloudTaskCancelledEvent;
 import org.activiti.cloud.api.task.model.events.CloudTaskCandidateUserRemovedEvent;
@@ -86,7 +72,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
@@ -94,8 +79,6 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -136,15 +119,6 @@ public class AuditProducerIT {
 
     @Autowired
     private AuditConsumerStreamHandler streamHandler;
-
-    @Autowired
-    private BinderAwareChannelResolver channelResolver;
-
-    @Value("integrationResult_${spring.application.name}")
-    private String integrationResultDestination;
-
-    @Value("integrationError_${spring.application.name}")
-    private String integrationErrorDestination;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();
 
@@ -904,362 +878,6 @@ public class AuditProducerIT {
                     .contains(
                             tuple(TASK_CANCELLED, "My Task 3"),
                             tuple(TASK_CANCELLED, "My Task 4")
-                    );
-
-            assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
-                    RuntimeEvent::getProcessInstanceId)
-                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
-        });
-    }
-
-    @Test
-    public void shouldProduceIntegrationResultEventsDuringMultiInstanceCloudConnectorExecution() {
-
-        //when
-        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("miParallelCloudConnector",
-                                                                                                                Collections.singletonMap("instanceCount", 3),
-                                                                                                                null);
-
-        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
-
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
-
-
-            List<CloudBPMNActivityStartedEvent> receivedActivityStartedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ACTIVITY_STARTED && event.getEntityId()
-                                                                                      .equals("miCloudConnectorId"))
-                    .map(CloudBPMNActivityStartedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedActivityStartedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
-                    .containsExactlyInAnyOrder(
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId")
-                    );
-
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED &&
-                                        ((IntegrationContext) event.getEntity()).getClientId()
-                                                                                .equals("miCloudConnectorId"))
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationRequestedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId")
-                    );
-
-            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
-
-        });
-
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
-
-        // complete cloud connector tasks
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                       request.getEntity());
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-
-
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            List<CloudBPMNActivityCompletedEvent> receivedActivityCompletedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ACTIVITY_COMPLETED && event.getEntityId()
-                                                                                      .equals("miCloudConnectorId"))
-                    .map(CloudBPMNActivityCompletedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedActivityCompletedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
-                    .containsExactlyInAnyOrder(
-                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId")
-                    );
-
-            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED &&
-                                        ((IntegrationContext) event.getEntity()).getClientId()
-                                                                                .equals("miCloudConnectorId"))
-                    .map(CloudIntegrationResultReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationResultEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId")
-                    );
-
-            assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
-                    RuntimeEvent::getProcessInstanceId)
-                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
-        });
-    }
-
-    @Test
-    public void shouldProduceIntegrationErrorEventsDuringMultiInstanceCloudConnectorExecution() {
-
-        //when
-        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("miParallelCloudConnector",
-                                                                                                                Collections.singletonMap("instanceCount", 3),
-                                                                                                                null);
-        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
-
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
-
-
-            List<CloudBPMNActivityStartedEvent> receivedActivityStartedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ACTIVITY_STARTED && event.getEntityId()
-                                                                                      .equals("miCloudConnectorId"))
-                    .map(CloudBPMNActivityStartedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedActivityStartedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
-                    .containsExactlyInAnyOrder(
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
-                            tuple(ACTIVITY_STARTED, "miCloudConnectorId")
-                    );
-
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED &&
-                                        ((IntegrationContext) event.getEntity()).getClientId()
-                                                                                .equals("miCloudConnectorId"))
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationRequestedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId")
-                    );
-
-            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
-
-        });
-
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        Error error = new Error("IntegrationError");
-        error.fillInStackTrace();
-
-        // throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED &&
-                                        ((IntegrationContext) event.getEntity()).getClientId()
-                                                                                .equals("miCloudConnectorId"))
-                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationResultEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId"),
-                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId")
-                    );
-        });
-    }
-
-    @Test
-    public void shouldProduceIntegrationCloudBpmnErrorEventsForCloudBpmnErrorConnectorProcess() {
-
-        //when
-        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("cloudBpmnErrorCloudConnectorProcess",
-                                                                                                                null,
-                                                                                                                null);
-        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
-
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
-
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationRequestedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_REQUESTED, "performBusinessTaskCloudConnector")
-                    );
-
-            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
-
-        });
-
-        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
-
-        // when throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(errorChannel::send);
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED)
-                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationResultEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_ERROR_RECEIVED, "performBusinessTaskCloudConnector")
-                    );
-
-            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ERROR_RECEIVED)
-                    .map(CloudBPMNErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedBmpnErrorEvents)
-                    .extracting(CloudBPMNErrorReceivedEvent::getEventType,
-                                event -> ((BPMNError) event.getEntity()).getErrorCode())
-                    .containsExactlyInAnyOrder(
-                            tuple(ERROR_RECEIVED,
-                                  "CLOUD_BPMN_ERROR")
-                    );
-        });
-
-        // given reset state
-        integrationRequestedEvents.clear();
-        streamHandler.clear();
-
-        // when fix business error
-        List<CloudTask> tasks = new ArrayList<>(processInstanceRestTemplate.getTasks(startProcessEntity).getBody().getContent());
-        assertThat(tasks).hasSize(1);
-
-        taskRestTemplate.complete(tasks.get(0));
-
-        // then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
-
-
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationRequestedEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_REQUESTED, "performBusinessTaskCloudConnector")
-                    );
-
-            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
-
-        });
-
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
-
-        // complete cloud connector tasks
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                       request.getEntity());
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-
-
-        //then
-        await()
-            .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
-
-            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED)
-                    .map(CloudIntegrationResultReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
-            assertThat(receivedIntegrationResultEvents)
-                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
-                    .containsExactlyInAnyOrder(
-                            tuple(INTEGRATION_RESULT_RECEIVED, "performBusinessTaskCloudConnector")
                     );
 
             assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -37,7 +37,7 @@ import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
-import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -87,7 +87,7 @@ public class ConnectorAuditProducerIT {
     @Value("integrationError_${spring.application.name}")
     private String integrationErrorDestination;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         streamHandler.clear();
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -105,10 +105,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
@@ -151,10 +148,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             List<CloudBPMNActivityCompletedEvent> receivedActivityCompletedEvents = receivedEvents.stream()
                     .filter(event -> event.getEventType() == ACTIVITY_COMPLETED && event.getEntityId()
@@ -203,10 +197,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
@@ -261,10 +252,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
                     .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED &&
@@ -295,17 +283,12 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = getEventsByType(receivedEvents,
+                                                                                                      INTEGRATION_REQUESTED);
 
             assertThat(receivedIntegrationRequestedEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
@@ -321,16 +304,10 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED)
-                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = getEventsByType(receivedEvents,
+                                                                                                       INTEGRATION_ERROR_RECEIVED);
             assertThat(receivedIntegrationResultEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -364,19 +341,13 @@ public class ConnectorAuditProducerIT {
         // then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
 
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = getEventsByType(receivedEvents,
+                                                                                                      INTEGRATION_REQUESTED);
             assertThat(receivedIntegrationRequestedEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -392,16 +363,10 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED)
-                    .map(CloudIntegrationResultReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = getEventsByType(receivedEvents,
+                                                                                                        INTEGRATION_RESULT_RECEIVED);
             assertThat(receivedIntegrationResultEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -480,10 +445,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);;
 
             assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
                     RuntimeEvent::getProcessInstanceId)
@@ -503,18 +465,12 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = getEventsByType(receivedEvents,
+                                                                                                      INTEGRATION_REQUESTED);
             assertThat(receivedIntegrationRequestedEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -529,27 +485,18 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED)
-                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = getEventsByType(receivedEvents,
+                                                                                                       INTEGRATION_ERROR_RECEIVED);
             assertThat(receivedIntegrationResultEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
                             tuple(INTEGRATION_ERROR_RECEIVED, "performBusinessTaskCloudConnector4")
                     );
 
-            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ERROR_RECEIVED)
-                    .map(CloudBPMNErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = getEventsByType(receivedEvents,
+                                                                                        ERROR_RECEIVED);
             assertThat(receivedBmpnErrorEvents)
                     .extracting(CloudBPMNErrorReceivedEvent::getEventType,
                                 event -> ((BPMNError) event.getEntity()).getErrorCode())
@@ -572,19 +519,12 @@ public class ConnectorAuditProducerIT {
         // then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
-
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = getEventsByType(receivedEvents,
+                                                                                                      INTEGRATION_REQUESTED);
             assertThat(receivedIntegrationRequestedEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -600,16 +540,10 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED)
-                    .map(CloudIntegrationResultReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = getEventsByType(receivedEvents,
+                                                                                                        INTEGRATION_RESULT_RECEIVED);
             assertThat(receivedIntegrationResultEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -650,18 +584,12 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
-            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
-                    .map(CloudIntegrationRequestedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = getEventsByType(receivedEvents,
+                                                                                                      INTEGRATION_REQUESTED);
             assertThat(receivedIntegrationRequestedEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
@@ -676,27 +604,18 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED)
-                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = getEventsByType(receivedEvents,
+                                                                                                       INTEGRATION_ERROR_RECEIVED);
             assertThat(receivedIntegrationResultEvents)
                     .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
                     .containsExactlyInAnyOrder(
                             tuple(INTEGRATION_ERROR_RECEIVED, "performBusinessTaskCloudConnector3")
                     );
 
-            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = receivedEvents.stream()
-                    .filter(event -> event.getEventType() == ERROR_RECEIVED)
-                    .map(CloudBPMNErrorReceivedEvent.class::cast)
-                    .collect(Collectors.toList());
-
+            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = getEventsByType(receivedEvents,
+                                                                                        ERROR_RECEIVED);
             assertThat(receivedBmpnErrorEvents)
                     .extracting(CloudBPMNErrorReceivedEvent::getEventType,
                                 event -> ((BPMNError) event.getEntity()).getErrorCode())
@@ -719,15 +638,12 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-            receivedEvents = receivedEvents.stream()
-                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
-                    .collect(Collectors.toList());
+                   List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
-            assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
-                    RuntimeEvent::getProcessInstanceId)
-                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
-        });
+                   assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
+                                                         RuntimeEvent::getProcessInstanceId)
+                                             .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
+               });
     }
 
     private void sendIntegrationErrorFor(

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -445,7 +445,7 @@ public class ConnectorAuditProducerIT {
         //then
         await()
             .untilAsserted(() -> {
-            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);;
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = getProcessInstanceEvents(startProcessEntity);
 
             assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
                     RuntimeEvent::getProcessInstanceId)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -58,8 +58,8 @@ import org.springframework.test.context.TestPropertySource;
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ConnectorAuditProducerIT {
 
-    public static final String ROUTING_KEY_HEADER = "routingKey";
-    public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
+    private static final String ROUTING_KEY_HEADER = "routingKey";
+    private static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
     public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS)
                                                               .flatMap(Stream::of)
                                                               .toArray(String[]::new);
@@ -146,18 +146,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
-
-        // complete cloud connector tasks
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                       request.getEntity());
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-
+        sendIntegrationResultFor(integrationRequestedEvents);
 
         //then
         await()
@@ -328,19 +317,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
-
-        // when throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(errorChannel::send);
+        sendIntegrationErrorFor(integrationRequestedEvents);
         //then
         await()
             .untilAsserted(() -> {
@@ -410,18 +387,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
-
-        // complete cloud connector tasks
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                       request.getEntity());
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-
+        sendIntegrationResultFor(integrationRequestedEvents);
 
         //then
         await()
@@ -476,19 +442,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
-
-        // when throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(errorChannel::send);
+        sendIntegrationErrorFor(integrationRequestedEvents);
         //then
         await()
             .untilAsserted(() -> {
@@ -571,19 +525,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
-
-        // when throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(errorChannel::send);
+        sendIntegrationErrorFor(integrationRequestedEvents);
         //then
         await()
             .untilAsserted(() -> {
@@ -653,18 +595,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
-
-        // complete cloud connector tasks
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                       request.getEntity());
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(resultsChannel::send);
-
+        sendIntegrationResultFor(integrationRequestedEvents);
 
         //then
         await()
@@ -689,6 +620,22 @@ public class ConnectorAuditProducerIT {
                     RuntimeEvent::getProcessInstanceId)
                     .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
         });
+    }
+
+    private void sendIntegrationResultFor(
+        List<CloudIntegrationRequestedEvent> integrationRequestedEvents) {
+        MessageChannel resultsChannel = channelResolver
+            .resolveDestination(integrationResultDestination);
+
+        // complete cloud connector tasks
+        integrationRequestedEvents.stream()
+            .map(request -> {
+                return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
+                    request.getEntity());
+            })
+            .map(payload -> MessageBuilder.withPayload(payload)
+                .build())
+            .forEach(resultsChannel::send);
     }
 
     @Test
@@ -725,19 +672,7 @@ public class ConnectorAuditProducerIT {
 
         });
 
-        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
-
-        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
-
-        // when throw error in cloud connector
-        integrationRequestedEvents.stream()
-                                  .map(request -> {
-                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
-                                                                      error);
-                                  })
-                                  .map(payload -> MessageBuilder.withPayload(payload)
-                                                                .build())
-                                  .forEach(errorChannel::send);
+        sendIntegrationErrorFor(integrationRequestedEvents);
         //then
         await()
             .untilAsserted(() -> {
@@ -793,6 +728,23 @@ public class ConnectorAuditProducerIT {
                     RuntimeEvent::getProcessInstanceId)
                     .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
         });
+    }
+
+    private void sendIntegrationErrorFor(
+        List<CloudIntegrationRequestedEvent> integrationRequestedEvents) {
+        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
+
+        MessageChannel errorChannel = channelResolver
+            .resolveDestination(integrationErrorDestination);
+
+        integrationRequestedEvents.stream()
+            .map(request -> {
+                return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
+                    error);
+            })
+            .map(payload -> MessageBuilder.withPayload(payload)
+                .build())
+            .forEach(errorChannel::send);
     }
 
     private List<CloudRuntimeEvent<?, ?>> getProcessInstanceEvents(ResponseEntity<CloudProcessInstance> processInstanceEntity) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -1,0 +1,453 @@
+package org.activiti.cloud.starter.tests.services.audit;
+
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
+import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
+import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED;
+import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED;
+import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.activiti.api.model.shared.event.RuntimeEvent;
+import org.activiti.api.process.model.BPMNActivity;
+import org.activiti.api.process.model.BPMNError;
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBpmnError;
+import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEvent;
+import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
+import org.activiti.cloud.api.process.model.events.CloudBPMNErrorReceivedEvent;
+import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
+import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
+import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
+import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
+import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
+import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
+import org.activiti.cloud.api.task.model.CloudTask;
+import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
+import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles(ConnectorAuditProducerIT.AUDIT_PRODUCER_IT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource("classpath:application-test.properties")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
+public class ConnectorAuditProducerIT {
+
+    public static final String ROUTING_KEY_HEADER = "routingKey";
+    public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
+    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS)
+                                                              .flatMap(Stream::of)
+                                                              .toArray(String[]::new);
+
+    public static final String AUDIT_PRODUCER_IT = "AuditProducerIT";
+
+    @Value("${activiti.keycloak.test-user}")
+    protected String keycloakTestUser;
+
+    @Autowired
+    private ProcessInstanceRestTemplate processInstanceRestTemplate;
+
+    @Autowired
+    private TaskRestTemplate taskRestTemplate;
+
+    @Autowired
+    private AuditConsumerStreamHandler streamHandler;
+
+    @Autowired
+    private BinderAwareChannelResolver channelResolver;
+
+    @Value("integrationResult_${spring.application.name}")
+    private String integrationResultDestination;
+
+    @Value("integrationError_${spring.application.name}")
+    private String integrationErrorDestination;
+
+    @Before
+    public void setUp() {
+        streamHandler.clear();
+    }
+
+    @Test
+    public void shouldProduceIntegrationResultEventsDuringMultiInstanceCloudConnectorExecution() {
+
+        //when
+        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("miParallelCloudConnector",
+                                                                                                                Collections.singletonMap("instanceCount", 3),
+                                                                                                                null);
+
+        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
+
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+
+
+            List<CloudBPMNActivityStartedEvent> receivedActivityStartedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == ACTIVITY_STARTED && event.getEntityId()
+                                                                                      .equals("miCloudConnectorId"))
+                    .map(CloudBPMNActivityStartedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedActivityStartedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
+                    .containsExactlyInAnyOrder(
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId")
+                    );
+
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED &&
+                                        ((IntegrationContext) event.getEntity()).getClientId()
+                                                                                .equals("miCloudConnectorId"))
+                    .map(CloudIntegrationRequestedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationRequestedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId")
+                    );
+
+            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
+
+        });
+
+        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
+
+        // complete cloud connector tasks
+        integrationRequestedEvents.stream()
+                                  .map(request -> {
+                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
+                                                                       request.getEntity());
+                                  })
+                                  .map(payload -> MessageBuilder.withPayload(payload)
+                                                                .build())
+                                  .forEach(resultsChannel::send);
+
+
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            List<CloudBPMNActivityCompletedEvent> receivedActivityCompletedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == ACTIVITY_COMPLETED && event.getEntityId()
+                                                                                      .equals("miCloudConnectorId"))
+                    .map(CloudBPMNActivityCompletedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedActivityCompletedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
+                    .containsExactlyInAnyOrder(
+                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_COMPLETED, "miCloudConnectorId")
+                    );
+
+            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED &&
+                                        ((IntegrationContext) event.getEntity()).getClientId()
+                                                                                .equals("miCloudConnectorId"))
+                    .map(CloudIntegrationResultReceivedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationResultEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_RESULT_RECEIVED, "miCloudConnectorId")
+                    );
+
+            assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
+                    RuntimeEvent::getProcessInstanceId)
+                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
+        });
+    }
+
+    @Test
+    public void shouldProduceIntegrationErrorEventsDuringMultiInstanceCloudConnectorExecution() {
+
+        //when
+        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("miParallelCloudConnector",
+                                                                                                                Collections.singletonMap("instanceCount", 3),
+                                                                                                                null);
+        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
+
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+
+
+            List<CloudBPMNActivityStartedEvent> receivedActivityStartedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == ACTIVITY_STARTED && event.getEntityId()
+                                                                                      .equals("miCloudConnectorId"))
+                    .map(CloudBPMNActivityStartedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedActivityStartedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((BPMNActivity) event.getEntity()).getElementId())
+                    .containsExactlyInAnyOrder(
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId"),
+                            tuple(ACTIVITY_STARTED, "miCloudConnectorId")
+                    );
+
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED &&
+                                        ((IntegrationContext) event.getEntity()).getClientId()
+                                                                                .equals("miCloudConnectorId"))
+                    .map(CloudIntegrationRequestedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationRequestedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_REQUESTED, "miCloudConnectorId")
+                    );
+
+            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
+
+        });
+
+        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationErrorDestination);
+
+        Error error = new Error("IntegrationError");
+        error.fillInStackTrace();
+
+        // throw error in cloud connector
+        integrationRequestedEvents.stream()
+                                  .map(request -> {
+                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
+                                                                      error);
+                                  })
+                                  .map(payload -> MessageBuilder.withPayload(payload)
+                                                                .build())
+                                  .forEach(resultsChannel::send);
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED &&
+                                        ((IntegrationContext) event.getEntity()).getClientId()
+                                                                                .equals("miCloudConnectorId"))
+                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationResultEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId"),
+                            tuple(INTEGRATION_ERROR_RECEIVED, "miCloudConnectorId")
+                    );
+        });
+    }
+
+    @Test
+    public void shouldProduceIntegrationCloudBpmnErrorEventsForCloudBpmnErrorConnectorProcess() {
+
+        //when
+        ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("cloudBpmnErrorCloudConnectorProcess",
+                                                                                                                null,
+                                                                                                                null);
+        List<CloudIntegrationRequestedEvent> integrationRequestedEvents = new ArrayList<>();
+
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
+                    .map(CloudIntegrationRequestedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationRequestedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_REQUESTED, "performBusinessTaskCloudConnector")
+                    );
+
+            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
+
+        });
+
+        MessageChannel errorChannel = channelResolver.resolveDestination(integrationErrorDestination);
+
+        CloudBpmnError error = new CloudBpmnError("CLOUD_BPMN_ERROR");
+
+        // when throw error in cloud connector
+        integrationRequestedEvents.stream()
+                                  .map(request -> {
+                                      return new IntegrationErrorImpl(new IntegrationRequestImpl(request.getEntity()),
+                                                                      error);
+                                  })
+                                  .map(payload -> MessageBuilder.withPayload(payload)
+                                                                .build())
+                                  .forEach(errorChannel::send);
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            List<CloudIntegrationErrorReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_ERROR_RECEIVED)
+                    .map(CloudIntegrationErrorReceivedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationResultEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_ERROR_RECEIVED, "performBusinessTaskCloudConnector")
+                    );
+
+            List<CloudBPMNErrorReceivedEvent> receivedBmpnErrorEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == ERROR_RECEIVED)
+                    .map(CloudBPMNErrorReceivedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedBmpnErrorEvents)
+                    .extracting(CloudBPMNErrorReceivedEvent::getEventType,
+                                event -> ((BPMNError) event.getEntity()).getErrorCode())
+                    .containsExactlyInAnyOrder(
+                            tuple(ERROR_RECEIVED,
+                                  "CLOUD_BPMN_ERROR")
+                    );
+        });
+
+        // given reset state
+        integrationRequestedEvents.clear();
+        streamHandler.clear();
+
+        // when fix business error
+        List<CloudTask> tasks = new ArrayList<>(processInstanceRestTemplate.getTasks(startProcessEntity).getBody().getContent());
+        assertThat(tasks).hasSize(1);
+
+        taskRestTemplate.complete(tasks.get(0));
+
+        // then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+
+
+            List<CloudIntegrationRequestedEvent> receivedIntegrationRequestedEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_REQUESTED)
+                    .map(CloudIntegrationRequestedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationRequestedEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_REQUESTED, "performBusinessTaskCloudConnector")
+                    );
+
+            integrationRequestedEvents.addAll(receivedIntegrationRequestedEvents);
+
+        });
+
+        MessageChannel resultsChannel = channelResolver.resolveDestination(integrationResultDestination);
+
+        // complete cloud connector tasks
+        integrationRequestedEvents.stream()
+                                  .map(request -> {
+                                      return new IntegrationResultImpl(new IntegrationRequestImpl(request.getEntity()),
+                                                                       request.getEntity());
+                                  })
+                                  .map(payload -> MessageBuilder.withPayload(payload)
+                                                                .build())
+                                  .forEach(resultsChannel::send);
+
+
+        //then
+        await()
+            .untilAsserted(() -> {
+            List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+            receivedEvents = receivedEvents.stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
+                    .collect(Collectors.toList());
+
+            List<CloudIntegrationResultReceivedEvent> receivedIntegrationResultEvents = receivedEvents.stream()
+                    .filter(event -> event.getEventType() == INTEGRATION_RESULT_RECEIVED)
+                    .map(CloudIntegrationResultReceivedEvent.class::cast)
+                    .collect(Collectors.toList());
+
+            assertThat(receivedIntegrationResultEvents)
+                    .extracting(RuntimeEvent::getEventType, event -> ((IntegrationContext) event.getEntity()).getClientId())
+                    .containsExactlyInAnyOrder(
+                            tuple(INTEGRATION_RESULT_RECEIVED, "performBusinessTaskCloudConnector")
+                    );
+
+            assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
+                    RuntimeEvent::getProcessInstanceId)
+                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
+        });
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -37,9 +37,8 @@ import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,9 +50,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @ActiveProfiles(ConnectorAuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -21,6 +21,7 @@ import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.BPMNError;
 import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -451,7 +452,7 @@ public class ConnectorAuditProducerIT {
     }
 
     @Test
-    public void shouldProduceIntegrationCloudBpmnErrorEventsForCloudBpmnErrorEndEventProcess() {
+    public void shouldProduceIntegrationCloudBpmnErrorEventsForCloudBpmnTerminateEndEventProcess() {
 
         //when
         ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcessByKey("cloudBpmnErrorEndEventProcess",
@@ -535,7 +536,7 @@ public class ConnectorAuditProducerIT {
 
             assertThat(receivedEvents).extracting(RuntimeEvent::getEventType,
                     RuntimeEvent::getProcessInstanceId)
-                    .contains(tuple(PROCESS_COMPLETED, startProcessEntity.getBody().getId()));
+                    .contains(tuple(ProcessRuntimeEvent.ProcessEvents.PROCESS_CANCELLED, startProcessEntity.getBody().getId()));
         });
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:activiti="http://activiti.org/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1kzq71p" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta">
+  <bpmn:process id="cloudBpmnErrorCloudConnectorProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0zioauh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0zioauh" sourceRef="StartEvent_1" targetRef="performBusinessTaskCloudConnector" />
+    <bpmn:endEvent id="EndEvent_08o6dag">
+      <bpmn:incoming>SequenceFlow_18yia5b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18yia5b" sourceRef="performBusinessTaskCloudConnector" targetRef="EndEvent_08o6dag" />
+    <bpmn:sequenceFlow id="SequenceFlow_03boqs3" sourceRef="BoundaryEvent_0w05ccr" targetRef="Task_1rhcxhq" />
+    <bpmn:sequenceFlow id="SequenceFlow_1gzrhyf" sourceRef="Task_1rhcxhq" targetRef="performBusinessTaskCloudConnector" />
+    <bpmn:userTask id="Task_1rhcxhq" name="Correct Business Error" activiti:assignee="hruser">
+      <bpmn:incoming>SequenceFlow_03boqs3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1gzrhyf</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="performBusinessTaskCloudConnector" name="Perfrom Business Task" implementation="perfromBusinessTask">
+      <bpmn:incoming>SequenceFlow_0zioauh</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1gzrhyf</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18yia5b</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="BoundaryEvent_0w05ccr" attachedToRef="performBusinessTaskCloudConnector">
+      <bpmn:outgoing>SequenceFlow_03boqs3</bpmn:outgoing>
+      <bpmn:errorEventDefinition errorRef="Error_116gnbk" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_116gnbk" name="Cloud Bpmn Business Error" errorCode="CLOUD_BPMN_ERROR" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="cloudBpmnErrorCloudConnectorProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="300" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zioauh_di" bpmnElement="SequenceFlow_0zioauh">
+        <di:waypoint x="192" y="318" />
+        <di:waypoint x="303" y="318" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_08o6dag_di" bpmnElement="EndEvent_08o6dag">
+        <dc:Bounds x="502" y="300" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_18yia5b_di" bpmnElement="SequenceFlow_18yia5b">
+        <di:waypoint x="403" y="318" />
+        <di:waypoint x="502" y="318" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_03boqs3_di" bpmnElement="SequenceFlow_03boqs3">
+        <di:waypoint x="415" y="265" />
+        <di:waypoint x="447" y="229" />
+        <di:waypoint x="447" y="137" />
+        <di:waypoint x="403" y="137" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gzrhyf_di" bpmnElement="SequenceFlow_1gzrhyf">
+        <di:waypoint x="303" y="137" />
+        <di:waypoint x="257" y="137" />
+        <di:waypoint x="257" y="241" />
+        <di:waypoint x="305" y="283" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0f3upj2_di" bpmnElement="Task_1rhcxhq">
+        <dc:Bounds x="303" y="97" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1du2cks_di" bpmnElement="performBusinessTaskCloudConnector">
+        <dc:Bounds x="303" y="278" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0yo1kn3_di" bpmnElement="BoundaryEvent_0w05ccr">
+        <dc:Bounds x="385" y="260" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
@@ -32,30 +32,34 @@
     <bpmn:sequenceFlow id="SequenceFlow_18yia5b" sourceRef="performBusinessTaskCloudConnector" targetRef="EndEvent_08o6dag" />
     <bpmn:sequenceFlow id="SequenceFlow_0zioauh" sourceRef="StartEvent_1" targetRef="performBusinessTaskCloudConnector" />
   </bpmn:process>
-  <bpmn:process id="cloudBpmnErrorEndEventProcess" isExecutable="false">
+  <bpmn:process id="cloudBpmnErrorEndEventProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_0tjz9q2">
       <bpmn:outgoing>SequenceFlow_01ow8v0</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:endEvent id="EndEvent_0bv5owk">
-      <bpmn:incoming>SequenceFlow_0i7fciu</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:endEvent id="EndEvent_0k0x5is">
-      <bpmn:incoming>SequenceFlow_0eeyehk</bpmn:incoming>
-      <bpmn:errorEventDefinition id="ErrorEventDefinition_199rjt6" errorRef="Error_116gnbk" />
-    </bpmn:endEvent>
-    <bpmn:serviceTask id="ServiceTask_1bpxgc4" name="Perform Business Task" implementation="perfromBusinessTask">
+    <bpmn:serviceTask id="performBusinessTaskCloudConnector2" name="Perform Business Task" implementation="perfromBusinessTask">
       <bpmn:incoming>SequenceFlow_01ow8v0</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0i7fciu</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="BoundaryEvent_0xwjcuo" attachedToRef="ServiceTask_1bpxgc4">
+    <bpmn:boundaryEvent id="BoundaryEvent_0xwjcuo" attachedToRef="performBusinessTaskCloudConnector2">
       <bpmn:outgoing>SequenceFlow_0eeyehk</bpmn:outgoing>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_0t5wxoj" errorRef="Error_116gnbk" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0eeyehk" sourceRef="BoundaryEvent_0xwjcuo" targetRef="EndEvent_0k0x5is" />
-    <bpmn:sequenceFlow id="SequenceFlow_0i7fciu" sourceRef="ServiceTask_1bpxgc4" targetRef="EndEvent_0bv5owk" />
-    <bpmn:sequenceFlow id="SequenceFlow_01ow8v0" sourceRef="StartEvent_0tjz9q2" targetRef="ServiceTask_1bpxgc4" />
+    <bpmn:sequenceFlow id="SequenceFlow_0eeyehk" sourceRef="BoundaryEvent_0xwjcuo" targetRef="Task_03qcwv4" />
+    <bpmn:sequenceFlow id="SequenceFlow_0i7fciu" sourceRef="performBusinessTaskCloudConnector2" targetRef="EndEvent_0bv5owk" />
+    <bpmn:sequenceFlow id="SequenceFlow_01ow8v0" sourceRef="StartEvent_0tjz9q2" targetRef="performBusinessTaskCloudConnector2" />
+    <bpmn:endEvent id="EndEvent_0bv5owk">
+      <bpmn:incoming>SequenceFlow_0i7fciu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0unae7l" sourceRef="Task_03qcwv4" targetRef="EndEvent_0k0x5is" />
+    <bpmn:userTask id="Task_03qcwv4" name="Handle Business Error" activiti:assignee="hruser">
+      <bpmn:incoming>SequenceFlow_0eeyehk</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0unae7l</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_0k0x5is">
+      <bpmn:incoming>SequenceFlow_0unae7l</bpmn:incoming>
+    </bpmn:endEvent>
   </bpmn:process>
-  <bpmn:process id="cloudBpmnErrorEventSubprocessProcess" isExecutable="false">
+  <bpmn:process id="cloudBpmnErrorEventSubprocessProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_046yf6x">
       <bpmn:outgoing>SequenceFlow_1vnw95d</bpmn:outgoing>
     </bpmn:startEvent>
@@ -71,21 +75,12 @@
       <bpmn:endEvent id="EndEvent_181buds">
         <bpmn:incoming>SequenceFlow_1td99rs</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:endEvent id="EndEvent_0k7jv0t">
-        <bpmn:incoming>SequenceFlow_0lf3d23</bpmn:incoming>
-        <bpmn:errorEventDefinition id="ErrorEventDefinition_1sgdqko" errorRef="Error_116gnbk" />
-      </bpmn:endEvent>
-      <bpmn:serviceTask id="ServiceTask_1vtie9d" name="Perform Task">
+      <bpmn:serviceTask id="performBusinessTaskCloudConnector3" name="Perform Task" implementation="perfromBusinessTask">
         <bpmn:incoming>SequenceFlow_0iv3jrg</bpmn:incoming>
         <bpmn:outgoing>SequenceFlow_1td99rs</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:boundaryEvent id="BoundaryEvent_0gv9na1" attachedToRef="ServiceTask_1vtie9d">
-        <bpmn:outgoing>SequenceFlow_0lf3d23</bpmn:outgoing>
-        <bpmn:errorEventDefinition id="ErrorEventDefinition_0d0602t" errorRef="Error_116gnbk" />
-      </bpmn:boundaryEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_0lf3d23" sourceRef="BoundaryEvent_0gv9na1" targetRef="EndEvent_0k7jv0t" />
-      <bpmn:sequenceFlow id="SequenceFlow_1td99rs" sourceRef="ServiceTask_1vtie9d" targetRef="EndEvent_181buds" />
-      <bpmn:sequenceFlow id="SequenceFlow_0iv3jrg" sourceRef="StartEvent_13ynzce" targetRef="ServiceTask_1vtie9d" />
+      <bpmn:sequenceFlow id="SequenceFlow_1td99rs" sourceRef="performBusinessTaskCloudConnector3" targetRef="EndEvent_181buds" />
+      <bpmn:sequenceFlow id="SequenceFlow_0iv3jrg" sourceRef="StartEvent_13ynzce" targetRef="performBusinessTaskCloudConnector3" />
     </bpmn:subProcess>
     <bpmn:subProcess id="SubProcess_15lkmkd" triggeredByEvent="true">
       <bpmn:startEvent id="StartEvent_07pa616">
@@ -95,7 +90,7 @@
       <bpmn:endEvent id="EndEvent_0ocvrtk">
         <bpmn:incoming>SequenceFlow_0xg8t7x</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:userTask id="UserTask_17k2lmm" name="Handle Error">
+      <bpmn:userTask id="UserTask_17k2lmm" name="Handle Business Error" activiti:assignee="hruser">
         <bpmn:incoming>SequenceFlow_1wf5ejr</bpmn:incoming>
         <bpmn:outgoing>SequenceFlow_0xg8t7x</bpmn:outgoing>
       </bpmn:userTask>
@@ -105,14 +100,14 @@
     <bpmn:sequenceFlow id="SequenceFlow_1ehcmle" sourceRef="SubProcess_0kv70cv" targetRef="EndEvent_18hszu4" />
     <bpmn:sequenceFlow id="SequenceFlow_1vnw95d" sourceRef="StartEvent_046yf6x" targetRef="SubProcess_0kv70cv" />
   </bpmn:process>
-  <bpmn:process id="cloudBpmnErrorBoundarySubprocessEventProcess" isExecutable="false">
+  <bpmn:process id="cloudBpmnErrorBoundarySubprocessEventProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1dgvyhk">
       <bpmn:outgoing>SequenceFlow_0iuovd0</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:endEvent id="EndEvent_1b3pqn9">
       <bpmn:incoming>SequenceFlow_0k03hfm</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:userTask id="UserTask_1atu9zc" name="Handle Error">
+    <bpmn:userTask id="UserTask_1atu9zc" name="Correct Business Error" activiti:assignee="hruser">
       <bpmn:incoming>SequenceFlow_1c0yubl</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_005ojtd</bpmn:outgoing>
     </bpmn:userTask>
@@ -126,21 +121,12 @@
       <bpmn:startEvent id="StartEvent_160p7w1">
         <bpmn:outgoing>SequenceFlow_05td236</bpmn:outgoing>
       </bpmn:startEvent>
-      <bpmn:serviceTask id="ServiceTask_07exfbz" name="Perform Task" implementation="perfromBusinessTask">
+      <bpmn:serviceTask id="performBusinessTaskCloudConnector4" name="Perform Task" implementation="perfromBusinessTask">
         <bpmn:incoming>SequenceFlow_05td236</bpmn:incoming>
         <bpmn:outgoing>SequenceFlow_1wo85z0</bpmn:outgoing>
       </bpmn:serviceTask>
-      <bpmn:endEvent id="EndEvent_1viuu3u">
-        <bpmn:incoming>SequenceFlow_0nmfjab</bpmn:incoming>
-        <bpmn:errorEventDefinition id="ErrorEventDefinition_19gmf70" errorRef="Error_116gnbk" />
-      </bpmn:endEvent>
-      <bpmn:boundaryEvent id="BoundaryEvent_1r8yilk" attachedToRef="ServiceTask_07exfbz">
-        <bpmn:outgoing>SequenceFlow_0nmfjab</bpmn:outgoing>
-        <bpmn:errorEventDefinition id="ErrorEventDefinition_121qxtm" errorRef="Error_116gnbk" />
-      </bpmn:boundaryEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_0nmfjab" sourceRef="BoundaryEvent_1r8yilk" targetRef="EndEvent_1viuu3u" />
-      <bpmn:sequenceFlow id="SequenceFlow_05td236" sourceRef="StartEvent_160p7w1" targetRef="ServiceTask_07exfbz" />
-      <bpmn:sequenceFlow id="SequenceFlow_1wo85z0" sourceRef="ServiceTask_07exfbz" targetRef="EndEvent_1w1me8v" />
+      <bpmn:sequenceFlow id="SequenceFlow_05td236" sourceRef="StartEvent_160p7w1" targetRef="performBusinessTaskCloudConnector4" />
+      <bpmn:sequenceFlow id="SequenceFlow_1wo85z0" sourceRef="performBusinessTaskCloudConnector4" targetRef="EndEvent_1w1me8v" />
     </bpmn:subProcess>
     <bpmn:boundaryEvent id="BoundaryEvent_1hr7c7l" attachedToRef="SubProcess_0ny8j0a">
       <bpmn:outgoing>SequenceFlow_1c0yubl</bpmn:outgoing>
@@ -151,10 +137,12 @@
     <bpmn:sequenceFlow id="SequenceFlow_0k03hfm" sourceRef="SubProcess_0ny8j0a" targetRef="EndEvent_1b3pqn9" />
     <bpmn:sequenceFlow id="SequenceFlow_0iuovd0" sourceRef="StartEvent_1dgvyhk" targetRef="SubProcess_0ny8j0a" />
   </bpmn:process>
+  <bpmn:error id="Error_0u2691d" name="End error event" errorCode="END_BPMN_ERROR" />
+  <bpmn:signal id="Signal_0ywe5jt" name="END_SIGNAL" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1tv8flb">
       <bpmndi:BPMNShape id="Participant_1chz6y3_di" bpmnElement="Participant_1chz6y3" isHorizontal="true">
-        <dc:Bounds x="156" y="77" width="651" height="302" />
+        <dc:Bounds x="156" y="77" width="662" height="334" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="206" y="300" width="36" height="36" />
@@ -192,7 +180,7 @@
         <di:waypoint x="353" y="318" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Participant_0zr7vvn_di" bpmnElement="Participant_0zr7vvn" isHorizontal="true">
-        <dc:Bounds x="863" y="85" width="664" height="295" />
+        <dc:Bounds x="863" y="85" width="668" height="321" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Participant_075otk4_di" bpmnElement="Participant_075otk4" isHorizontal="true">
         <dc:Bounds x="156" y="459" width="657" height="587" />
@@ -204,12 +192,9 @@
         <dc:Bounds x="999" y="147" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0bv5owk_di" bpmnElement="EndEvent_0bv5owk">
-        <dc:Bounds x="1287" y="147" width="36" height="36" />
+        <dc:Bounds x="1355" y="147" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0k0x5is_di" bpmnElement="EndEvent_0k0x5is">
-        <dc:Bounds x="1287" y="267" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1bpxgc4_di" bpmnElement="ServiceTask_1bpxgc4">
+      <bpmndi:BPMNShape id="ServiceTask_1bpxgc4_di" bpmnElement="performBusinessTaskCloudConnector2">
         <dc:Bounds x="1109" y="125" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_046yf6x_di" bpmnElement="StartEvent_046yf6x">
@@ -244,12 +229,11 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0eeyehk_di" bpmnElement="SequenceFlow_0eeyehk">
         <di:waypoint x="1171" y="223" />
-        <di:waypoint x="1171" y="285" />
-        <di:waypoint x="1287" y="285" />
+        <di:waypoint x="1171" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0i7fciu_di" bpmnElement="SequenceFlow_0i7fciu">
         <di:waypoint x="1209" y="165" />
-        <di:waypoint x="1287" y="165" />
+        <di:waypoint x="1355" y="165" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_01ow8v0_di" bpmnElement="SequenceFlow_01ow8v0">
         <di:waypoint x="1035" y="165" />
@@ -282,16 +266,13 @@
         <di:waypoint x="1020" y="633" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_13ynzce_di" bpmnElement="StartEvent_13ynzce">
-        <dc:Bounds x="325" y="588" width="36" height="36" />
+        <dc:Bounds x="328" y="628" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_181buds_di" bpmnElement="EndEvent_181buds">
-        <dc:Bounds x="561" y="588" width="36" height="36" />
+        <dc:Bounds x="569" y="628" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0k7jv0t_di" bpmnElement="EndEvent_0k7jv0t">
-        <dc:Bounds x="561" y="695" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1vtie9d_di" bpmnElement="ServiceTask_1vtie9d">
-        <dc:Bounds x="411" y="566" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1vtie9d_di" bpmnElement="performBusinessTaskCloudConnector3">
+        <dc:Bounds x="415" y="606" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_07pa616_di" bpmnElement="StartEvent_07pa616">
         <dc:Bounds x="310" y="865" width="36" height="36" />
@@ -303,35 +284,21 @@
         <dc:Bounds x="401" y="843" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1w1me8v_di" bpmnElement="EndEvent_1w1me8v">
-        <dc:Bounds x="1293" y="575" width="36" height="36" />
+        <dc:Bounds x="1302" y="618" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_160p7w1_di" bpmnElement="StartEvent_160p7w1">
-        <dc:Bounds x="1052" y="575" width="36" height="36" />
+        <dc:Bounds x="1053" y="618" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_07exfbz_di" bpmnElement="ServiceTask_07exfbz">
-        <dc:Bounds x="1130" y="553" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_07exfbz_di" bpmnElement="performBusinessTaskCloudConnector4">
+        <dc:Bounds x="1148" y="596" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1viuu3u_di" bpmnElement="EndEvent_1viuu3u">
-        <dc:Bounds x="1293" y="695" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_0gv9na1_di" bpmnElement="BoundaryEvent_0gv9na1">
-        <dc:Bounds x="454" y="628" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BoundaryEvent_1r8yilk_di" bpmnElement="BoundaryEvent_1r8yilk">
-        <dc:Bounds x="1176" y="615" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0lf3d23_di" bpmnElement="SequenceFlow_0lf3d23">
-        <di:waypoint x="472" y="664" />
-        <di:waypoint x="472" y="713" />
-        <di:waypoint x="561" y="713" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1td99rs_di" bpmnElement="SequenceFlow_1td99rs">
-        <di:waypoint x="511" y="606" />
-        <di:waypoint x="561" y="606" />
+        <di:waypoint x="515" y="646" />
+        <di:waypoint x="569" y="646" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0iv3jrg_di" bpmnElement="SequenceFlow_0iv3jrg">
-        <di:waypoint x="361" y="606" />
-        <di:waypoint x="411" y="606" />
+        <di:waypoint x="364" y="646" />
+        <di:waypoint x="415" y="646" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0xg8t7x_di" bpmnElement="SequenceFlow_0xg8t7x">
         <di:waypoint x="501" y="883" />
@@ -341,19 +308,24 @@
         <di:waypoint x="346" y="883" />
         <di:waypoint x="401" y="883" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0nmfjab_di" bpmnElement="SequenceFlow_0nmfjab">
-        <di:waypoint x="1194" y="651" />
-        <di:waypoint x="1194" y="713" />
-        <di:waypoint x="1293" y="713" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05td236_di" bpmnElement="SequenceFlow_05td236">
-        <di:waypoint x="1088" y="593" />
-        <di:waypoint x="1130" y="593" />
+        <di:waypoint x="1089" y="636" />
+        <di:waypoint x="1148" y="636" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1wo85z0_di" bpmnElement="SequenceFlow_1wo85z0">
-        <di:waypoint x="1230" y="593" />
-        <di:waypoint x="1293" y="593" />
+        <di:waypoint x="1248" y="636" />
+        <di:waypoint x="1302" y="636" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_184b0xx_di" bpmnElement="EndEvent_0k0x5is">
+        <dc:Bounds x="1355" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0unae7l_di" bpmnElement="SequenceFlow_0unae7l">
+        <di:waypoint x="1221" y="300" />
+        <di:waypoint x="1355" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0q5e1bx_di" bpmnElement="Task_03qcwv4">
+        <dc:Bounds x="1121" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
@@ -57,6 +57,7 @@
     </bpmn:userTask>
     <bpmn:endEvent id="EndEvent_0k0x5is">
       <bpmn:incoming>SequenceFlow_0unae7l</bpmn:incoming>
+      <bpmn:terminateEventDefinition />
     </bpmn:endEvent>
   </bpmn:process>
   <bpmn:process id="cloudBpmnErrorEventSubprocessProcess" isExecutable="true">
@@ -316,15 +317,15 @@
         <di:waypoint x="1248" y="636" />
         <di:waypoint x="1302" y="636" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_184b0xx_di" bpmnElement="EndEvent_0k0x5is">
-        <dc:Bounds x="1355" y="282" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0unae7l_di" bpmnElement="SequenceFlow_0unae7l">
         <di:waypoint x="1221" y="300" />
         <di:waypoint x="1355" y="300" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_0q5e1bx_di" bpmnElement="Task_03qcwv4">
         <dc:Bounds x="1121" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0he6g0o_di" bpmnElement="EndEvent_0k0x5is">
+        <dc:Bounds x="1355" y="282" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/CloudBpmnErrorIT.bpmn
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:activiti="http://activiti.org/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1kzq71p" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta">
+  <bpmn:error id="Error_116gnbk" name="Cloud Bpmn Business Error" errorCode="CLOUD_BPMN_ERROR" />
+  <bpmn:collaboration id="Collaboration_1tv8flb">
+    <bpmn:participant id="Participant_1chz6y3" name="cloudBpmnErrorCloudConnectorProcess" processRef="cloudBpmnErrorCloudConnectorProcess" />
+    <bpmn:participant id="Participant_0zr7vvn" name="cloudBpmnErrorEndEventProcess" processRef="cloudBpmnErrorEndEventProcess" />
+    <bpmn:participant id="Participant_075otk4" name="cloudBpmnErrorEventSubprocessProcess" processRef="cloudBpmnErrorEventSubprocessProcess" />
+    <bpmn:participant id="Participant_0fnqwdo" name="cloudBpmnErrorBoundarySubprocessEventProcess" processRef="cloudBpmnErrorBoundarySubprocessEventProcess" />
+  </bpmn:collaboration>
   <bpmn:process id="cloudBpmnErrorCloudConnectorProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0zioauh</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0zioauh" sourceRef="StartEvent_1" targetRef="performBusinessTaskCloudConnector" />
     <bpmn:endEvent id="EndEvent_08o6dag">
       <bpmn:incoming>SequenceFlow_18yia5b</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_18yia5b" sourceRef="performBusinessTaskCloudConnector" targetRef="EndEvent_08o6dag" />
-    <bpmn:sequenceFlow id="SequenceFlow_03boqs3" sourceRef="BoundaryEvent_0w05ccr" targetRef="Task_1rhcxhq" />
-    <bpmn:sequenceFlow id="SequenceFlow_1gzrhyf" sourceRef="Task_1rhcxhq" targetRef="performBusinessTaskCloudConnector" />
     <bpmn:userTask id="Task_1rhcxhq" name="Correct Business Error" activiti:assignee="hruser">
       <bpmn:incoming>SequenceFlow_03boqs3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gzrhyf</bpmn:outgoing>
@@ -24,45 +27,333 @@
       <bpmn:outgoing>SequenceFlow_03boqs3</bpmn:outgoing>
       <bpmn:errorEventDefinition errorRef="Error_116gnbk" />
     </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1gzrhyf" sourceRef="Task_1rhcxhq" targetRef="performBusinessTaskCloudConnector" />
+    <bpmn:sequenceFlow id="SequenceFlow_03boqs3" sourceRef="BoundaryEvent_0w05ccr" targetRef="Task_1rhcxhq" />
+    <bpmn:sequenceFlow id="SequenceFlow_18yia5b" sourceRef="performBusinessTaskCloudConnector" targetRef="EndEvent_08o6dag" />
+    <bpmn:sequenceFlow id="SequenceFlow_0zioauh" sourceRef="StartEvent_1" targetRef="performBusinessTaskCloudConnector" />
   </bpmn:process>
-  <bpmn:error id="Error_116gnbk" name="Cloud Bpmn Business Error" errorCode="CLOUD_BPMN_ERROR" />
+  <bpmn:process id="cloudBpmnErrorEndEventProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_0tjz9q2">
+      <bpmn:outgoing>SequenceFlow_01ow8v0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0bv5owk">
+      <bpmn:incoming>SequenceFlow_0i7fciu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_0k0x5is">
+      <bpmn:incoming>SequenceFlow_0eeyehk</bpmn:incoming>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_199rjt6" errorRef="Error_116gnbk" />
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="ServiceTask_1bpxgc4" name="Perform Business Task" implementation="perfromBusinessTask">
+      <bpmn:incoming>SequenceFlow_01ow8v0</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0i7fciu</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="BoundaryEvent_0xwjcuo" attachedToRef="ServiceTask_1bpxgc4">
+      <bpmn:outgoing>SequenceFlow_0eeyehk</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0t5wxoj" errorRef="Error_116gnbk" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0eeyehk" sourceRef="BoundaryEvent_0xwjcuo" targetRef="EndEvent_0k0x5is" />
+    <bpmn:sequenceFlow id="SequenceFlow_0i7fciu" sourceRef="ServiceTask_1bpxgc4" targetRef="EndEvent_0bv5owk" />
+    <bpmn:sequenceFlow id="SequenceFlow_01ow8v0" sourceRef="StartEvent_0tjz9q2" targetRef="ServiceTask_1bpxgc4" />
+  </bpmn:process>
+  <bpmn:process id="cloudBpmnErrorEventSubprocessProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_046yf6x">
+      <bpmn:outgoing>SequenceFlow_1vnw95d</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_18hszu4">
+      <bpmn:incoming>SequenceFlow_1ehcmle</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="SubProcess_0kv70cv">
+      <bpmn:incoming>SequenceFlow_1vnw95d</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ehcmle</bpmn:outgoing>
+      <bpmn:startEvent id="StartEvent_13ynzce">
+        <bpmn:outgoing>SequenceFlow_0iv3jrg</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_181buds">
+        <bpmn:incoming>SequenceFlow_1td99rs</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:endEvent id="EndEvent_0k7jv0t">
+        <bpmn:incoming>SequenceFlow_0lf3d23</bpmn:incoming>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_1sgdqko" errorRef="Error_116gnbk" />
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="ServiceTask_1vtie9d" name="Perform Task">
+        <bpmn:incoming>SequenceFlow_0iv3jrg</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_1td99rs</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="BoundaryEvent_0gv9na1" attachedToRef="ServiceTask_1vtie9d">
+        <bpmn:outgoing>SequenceFlow_0lf3d23</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0d0602t" errorRef="Error_116gnbk" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_0lf3d23" sourceRef="BoundaryEvent_0gv9na1" targetRef="EndEvent_0k7jv0t" />
+      <bpmn:sequenceFlow id="SequenceFlow_1td99rs" sourceRef="ServiceTask_1vtie9d" targetRef="EndEvent_181buds" />
+      <bpmn:sequenceFlow id="SequenceFlow_0iv3jrg" sourceRef="StartEvent_13ynzce" targetRef="ServiceTask_1vtie9d" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SubProcess_15lkmkd" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_07pa616">
+        <bpmn:outgoing>SequenceFlow_1wf5ejr</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0cjxwcz" errorRef="Error_116gnbk" />
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_0ocvrtk">
+        <bpmn:incoming>SequenceFlow_0xg8t7x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:userTask id="UserTask_17k2lmm" name="Handle Error">
+        <bpmn:incoming>SequenceFlow_1wf5ejr</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_0xg8t7x</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="SequenceFlow_0xg8t7x" sourceRef="UserTask_17k2lmm" targetRef="EndEvent_0ocvrtk" />
+      <bpmn:sequenceFlow id="SequenceFlow_1wf5ejr" sourceRef="StartEvent_07pa616" targetRef="UserTask_17k2lmm" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="SequenceFlow_1ehcmle" sourceRef="SubProcess_0kv70cv" targetRef="EndEvent_18hszu4" />
+    <bpmn:sequenceFlow id="SequenceFlow_1vnw95d" sourceRef="StartEvent_046yf6x" targetRef="SubProcess_0kv70cv" />
+  </bpmn:process>
+  <bpmn:process id="cloudBpmnErrorBoundarySubprocessEventProcess" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1dgvyhk">
+      <bpmn:outgoing>SequenceFlow_0iuovd0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1b3pqn9">
+      <bpmn:incoming>SequenceFlow_0k03hfm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="UserTask_1atu9zc" name="Handle Error">
+      <bpmn:incoming>SequenceFlow_1c0yubl</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_005ojtd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:subProcess id="SubProcess_0ny8j0a">
+      <bpmn:incoming>SequenceFlow_005ojtd</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0iuovd0</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0k03hfm</bpmn:outgoing>
+      <bpmn:endEvent id="EndEvent_1w1me8v">
+        <bpmn:incoming>SequenceFlow_1wo85z0</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_160p7w1">
+        <bpmn:outgoing>SequenceFlow_05td236</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="ServiceTask_07exfbz" name="Perform Task" implementation="perfromBusinessTask">
+        <bpmn:incoming>SequenceFlow_05td236</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_1wo85z0</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="EndEvent_1viuu3u">
+        <bpmn:incoming>SequenceFlow_0nmfjab</bpmn:incoming>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_19gmf70" errorRef="Error_116gnbk" />
+      </bpmn:endEvent>
+      <bpmn:boundaryEvent id="BoundaryEvent_1r8yilk" attachedToRef="ServiceTask_07exfbz">
+        <bpmn:outgoing>SequenceFlow_0nmfjab</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_121qxtm" errorRef="Error_116gnbk" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_0nmfjab" sourceRef="BoundaryEvent_1r8yilk" targetRef="EndEvent_1viuu3u" />
+      <bpmn:sequenceFlow id="SequenceFlow_05td236" sourceRef="StartEvent_160p7w1" targetRef="ServiceTask_07exfbz" />
+      <bpmn:sequenceFlow id="SequenceFlow_1wo85z0" sourceRef="ServiceTask_07exfbz" targetRef="EndEvent_1w1me8v" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_1hr7c7l" attachedToRef="SubProcess_0ny8j0a">
+      <bpmn:outgoing>SequenceFlow_1c0yubl</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0oq5exf" errorRef="Error_116gnbk" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_005ojtd" sourceRef="UserTask_1atu9zc" targetRef="SubProcess_0ny8j0a" />
+    <bpmn:sequenceFlow id="SequenceFlow_1c0yubl" sourceRef="BoundaryEvent_1hr7c7l" targetRef="UserTask_1atu9zc" />
+    <bpmn:sequenceFlow id="SequenceFlow_0k03hfm" sourceRef="SubProcess_0ny8j0a" targetRef="EndEvent_1b3pqn9" />
+    <bpmn:sequenceFlow id="SequenceFlow_0iuovd0" sourceRef="StartEvent_1dgvyhk" targetRef="SubProcess_0ny8j0a" />
+  </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="cloudBpmnErrorCloudConnectorProcess">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1tv8flb">
+      <bpmndi:BPMNShape id="Participant_1chz6y3_di" bpmnElement="Participant_1chz6y3" isHorizontal="true">
+        <dc:Bounds x="156" y="77" width="651" height="302" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="156" y="300" width="36" height="36" />
+        <dc:Bounds x="206" y="300" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zioauh_di" bpmnElement="SequenceFlow_0zioauh">
-        <di:waypoint x="192" y="318" />
-        <di:waypoint x="303" y="318" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_08o6dag_di" bpmnElement="EndEvent_08o6dag">
-        <dc:Bounds x="502" y="300" width="36" height="36" />
+        <dc:Bounds x="552" y="300" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_18yia5b_di" bpmnElement="SequenceFlow_18yia5b">
-        <di:waypoint x="403" y="318" />
-        <di:waypoint x="502" y="318" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_03boqs3_di" bpmnElement="SequenceFlow_03boqs3">
-        <di:waypoint x="415" y="265" />
-        <di:waypoint x="447" y="229" />
-        <di:waypoint x="447" y="137" />
-        <di:waypoint x="403" y="137" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1gzrhyf_di" bpmnElement="SequenceFlow_1gzrhyf">
-        <di:waypoint x="303" y="137" />
-        <di:waypoint x="257" y="137" />
-        <di:waypoint x="257" y="241" />
-        <di:waypoint x="305" y="283" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_0f3upj2_di" bpmnElement="Task_1rhcxhq">
-        <dc:Bounds x="303" y="97" width="100" height="80" />
+        <dc:Bounds x="353" y="97" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1du2cks_di" bpmnElement="performBusinessTaskCloudConnector">
-        <dc:Bounds x="303" y="278" width="100" height="80" />
+        <dc:Bounds x="353" y="278" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BoundaryEvent_0yo1kn3_di" bpmnElement="BoundaryEvent_0w05ccr">
-        <dc:Bounds x="385" y="260" width="36" height="36" />
+        <dc:Bounds x="435" y="260" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gzrhyf_di" bpmnElement="SequenceFlow_1gzrhyf">
+        <di:waypoint x="353" y="137" />
+        <di:waypoint x="307" y="137" />
+        <di:waypoint x="307" y="241" />
+        <di:waypoint x="355" y="283" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_03boqs3_di" bpmnElement="SequenceFlow_03boqs3">
+        <di:waypoint x="465" y="265" />
+        <di:waypoint x="497" y="229" />
+        <di:waypoint x="497" y="137" />
+        <di:waypoint x="453" y="137" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18yia5b_di" bpmnElement="SequenceFlow_18yia5b">
+        <di:waypoint x="453" y="318" />
+        <di:waypoint x="552" y="318" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zioauh_di" bpmnElement="SequenceFlow_0zioauh">
+        <di:waypoint x="242" y="318" />
+        <di:waypoint x="353" y="318" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0zr7vvn_di" bpmnElement="Participant_0zr7vvn" isHorizontal="true">
+        <dc:Bounds x="863" y="85" width="664" height="295" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_075otk4_di" bpmnElement="Participant_075otk4" isHorizontal="true">
+        <dc:Bounds x="156" y="459" width="657" height="587" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0fnqwdo_di" bpmnElement="Participant_0fnqwdo" isHorizontal="true">
+        <dc:Bounds x="863" y="459" width="666" height="583" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0tjz9q2_di" bpmnElement="StartEvent_0tjz9q2">
+        <dc:Bounds x="999" y="147" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0bv5owk_di" bpmnElement="EndEvent_0bv5owk">
+        <dc:Bounds x="1287" y="147" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0k0x5is_di" bpmnElement="EndEvent_0k0x5is">
+        <dc:Bounds x="1287" y="267" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1bpxgc4_di" bpmnElement="ServiceTask_1bpxgc4">
+        <dc:Bounds x="1109" y="125" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_046yf6x_di" bpmnElement="StartEvent_046yf6x">
+        <dc:Bounds x="206" y="624" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_18hszu4_di" bpmnElement="EndEvent_18hszu4">
+        <dc:Bounds x="705" y="624" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_0kv70cv_di" bpmnElement="SubProcess_0kv70cv" isExpanded="true">
+        <dc:Bounds x="289" y="510" width="356" height="264" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_15lkmkd_di" bpmnElement="SubProcess_15lkmkd" isExpanded="true">
+        <dc:Bounds x="277" y="801" width="371" height="182" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_0ny8j0a_di" bpmnElement="SubProcess_0ny8j0a" isExpanded="true">
+        <dc:Bounds x="1020" y="492" width="344" height="279" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1dgvyhk_di" bpmnElement="StartEvent_1dgvyhk">
+        <dc:Bounds x="931" y="615" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1b3pqn9_di" bpmnElement="EndEvent_1b3pqn9">
+        <dc:Bounds x="1439" y="615" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1atu9zc_di" bpmnElement="UserTask_1atu9zc">
+        <dc:Bounds x="1156" y="836" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0xwjcuo_di" bpmnElement="BoundaryEvent_0xwjcuo">
+        <dc:Bounds x="1153" y="187" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1hr7c7l_di" bpmnElement="BoundaryEvent_1hr7c7l">
+        <dc:Bounds x="1300" y="754" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0eeyehk_di" bpmnElement="SequenceFlow_0eeyehk">
+        <di:waypoint x="1171" y="223" />
+        <di:waypoint x="1171" y="285" />
+        <di:waypoint x="1287" y="285" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0i7fciu_di" bpmnElement="SequenceFlow_0i7fciu">
+        <di:waypoint x="1209" y="165" />
+        <di:waypoint x="1287" y="165" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_01ow8v0_di" bpmnElement="SequenceFlow_01ow8v0">
+        <di:waypoint x="1035" y="165" />
+        <di:waypoint x="1109" y="165" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ehcmle_di" bpmnElement="SequenceFlow_1ehcmle">
+        <di:waypoint x="645" y="642" />
+        <di:waypoint x="705" y="642" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1vnw95d_di" bpmnElement="SequenceFlow_1vnw95d">
+        <di:waypoint x="242" y="642" />
+        <di:waypoint x="289" y="642" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_005ojtd_di" bpmnElement="SequenceFlow_005ojtd">
+        <di:waypoint x="1156" y="876" />
+        <di:waypoint x="1099" y="876" />
+        <di:waypoint x="1099" y="772" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1c0yubl_di" bpmnElement="SequenceFlow_1c0yubl">
+        <di:waypoint x="1318" y="790" />
+        <di:waypoint x="1318" y="876" />
+        <di:waypoint x="1256" y="876" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k03hfm_di" bpmnElement="SequenceFlow_0k03hfm">
+        <di:waypoint x="1364" y="633" />
+        <di:waypoint x="1439" y="633" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0iuovd0_di" bpmnElement="SequenceFlow_0iuovd0">
+        <di:waypoint x="967" y="633" />
+        <di:waypoint x="1020" y="633" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_13ynzce_di" bpmnElement="StartEvent_13ynzce">
+        <dc:Bounds x="325" y="588" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_181buds_di" bpmnElement="EndEvent_181buds">
+        <dc:Bounds x="561" y="588" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0k7jv0t_di" bpmnElement="EndEvent_0k7jv0t">
+        <dc:Bounds x="561" y="695" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1vtie9d_di" bpmnElement="ServiceTask_1vtie9d">
+        <dc:Bounds x="411" y="566" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_07pa616_di" bpmnElement="StartEvent_07pa616">
+        <dc:Bounds x="310" y="865" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0ocvrtk_di" bpmnElement="EndEvent_0ocvrtk">
+        <dc:Bounds x="562" y="865" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_17k2lmm_di" bpmnElement="UserTask_17k2lmm">
+        <dc:Bounds x="401" y="843" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1w1me8v_di" bpmnElement="EndEvent_1w1me8v">
+        <dc:Bounds x="1293" y="575" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_160p7w1_di" bpmnElement="StartEvent_160p7w1">
+        <dc:Bounds x="1052" y="575" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_07exfbz_di" bpmnElement="ServiceTask_07exfbz">
+        <dc:Bounds x="1130" y="553" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1viuu3u_di" bpmnElement="EndEvent_1viuu3u">
+        <dc:Bounds x="1293" y="695" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0gv9na1_di" bpmnElement="BoundaryEvent_0gv9na1">
+        <dc:Bounds x="454" y="628" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1r8yilk_di" bpmnElement="BoundaryEvent_1r8yilk">
+        <dc:Bounds x="1176" y="615" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lf3d23_di" bpmnElement="SequenceFlow_0lf3d23">
+        <di:waypoint x="472" y="664" />
+        <di:waypoint x="472" y="713" />
+        <di:waypoint x="561" y="713" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1td99rs_di" bpmnElement="SequenceFlow_1td99rs">
+        <di:waypoint x="511" y="606" />
+        <di:waypoint x="561" y="606" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0iv3jrg_di" bpmnElement="SequenceFlow_0iv3jrg">
+        <di:waypoint x="361" y="606" />
+        <di:waypoint x="411" y="606" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xg8t7x_di" bpmnElement="SequenceFlow_0xg8t7x">
+        <di:waypoint x="501" y="883" />
+        <di:waypoint x="562" y="883" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wf5ejr_di" bpmnElement="SequenceFlow_1wf5ejr">
+        <di:waypoint x="346" y="883" />
+        <di:waypoint x="401" y="883" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0nmfjab_di" bpmnElement="SequenceFlow_0nmfjab">
+        <di:waypoint x="1194" y="651" />
+        <di:waypoint x="1194" y="713" />
+        <di:waypoint x="1293" y="713" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_05td236_di" bpmnElement="SequenceFlow_05td236">
+        <di:waypoint x="1088" y="593" />
+        <di:waypoint x="1130" y="593" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wo85z0_di" bpmnElement="SequenceFlow_1wo85z0">
+        <di:waypoint x="1230" y="593" />
+        <di:waypoint x="1293" y="593" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
This PR adds Api and implementation support for propagating business errors from cloud counectors using CloudBpmnError exception.

![image](https://user-images.githubusercontent.com/20428629/78331952-f0b2ee80-753b-11ea-839b-93a12939dae2.png)

The implemented error infrastructure will allow to use error propagation mechanism to trigger Bpmn errors from cloud connectors as follows:

1. Provide special exception class in Cloud Api, i.e. CloudBpmnError, to designate as base class for throwing business exceptions from Cloud Connectors.
2. Recognize in Connector Error Handler that the exception is an instance of CloudBpmnError.
3. Propagate CloudBpmnError via CloudIntegrationBpmnErrorEvent message to Rb
4. Receive and handle CloudIntegrationBpmnErrorEvent in Rb by mapping CloudBpmnError to Java runtime exception instance
5. Provide Api to throw BpmnError from inside execution context to trigger existing BpmnError handling logic in Activiti Engine.
6. Capture BpmnError application event as part of the execution and wrap it in CloudBpmnErrorEvent message
7. Send CloudBpmnErrorEvent mesage to Audit and Query
8. Receive and save CloudBpmnErrorEvent in Audit database
9. Receive and save CloudBpmnErrorEvent in Query database

Test Coverage:

- [x] Basic Bpmn Error Handling 

![image](https://user-images.githubusercontent.com/20428629/78577782-71dfdf00-77e3-11ea-939b-961a9fdfadee.png)

- [x] Catch Bpmn End Error event and terminate process

![image](https://user-images.githubusercontent.com/20428629/78926627-3f87e900-7a52-11ea-9768-f1f48c3620ef.png)

- [x] Catch Bpmn Error Subprocess Event 
![image](https://user-images.githubusercontent.com/20428629/78926815-9b527200-7a52-11ea-8e36-3bbf61437fac.png)

- [x] Catch Bpmn Error Boundary Event

![image](https://user-images.githubusercontent.com/20428629/78926838-a4dbda00-7a52-11ea-8217-d07bd5e0b55b.png)

Part of https://github.com/Activiti/Activiti/issues/2712