### PR TITLE
make test pass locally

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
@@ -29,12 +29,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext
 public class AuditSwaggerIT {
 
     @Autowired

--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -229,7 +229,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
           <configuration>
-            <argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+            <argLine>@{argLine} -Xmx1024m</argLine>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
@@ -29,12 +29,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext
 public class ModelingSwaggerIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -29,12 +29,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext
 public class QuerySwaggerIT {
 
     @Autowired
@@ -51,7 +53,6 @@ public class QuerySwaggerIT {
             .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntriesResponseContent"))))
             .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Query :: Starter :: Query ReST API"));
-
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -73,7 +73,7 @@ import java.util.Map;
 @ActiveProfiles(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @Import({CommandEndPointITStreamHandler.class,
         ProcessInstanceRestTemplate.class,
         TaskRestTemplate.class})
@@ -152,7 +152,7 @@ public class CommandEndpointIT {
         Task task = tasks.iterator().next();
 
         setProcessVariables(processInstanceId);
-        
+
         claimTask(task);
 
         releaseTask(task);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 public class EngineConfigurationIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -53,7 +53,7 @@ import java.util.Iterator;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 public class ProcessDefinitionIT {
 
     @Autowired
@@ -261,7 +261,7 @@ public class ProcessDefinitionIT {
 
     private <T> T executeRequest(String url,
                                   HttpMethod method,
-                                  String contentType, 
+                                  String contentType,
                                   Class<T> javaType) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", contentType);
@@ -272,7 +272,7 @@ public class ProcessDefinitionIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         return response.getBody();
     }
-    
+
     private String executeRequest(String url,
                                   HttpMethod method,
                                   String contentType) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -97,8 +97,8 @@ import java.util.concurrent.TimeUnit;
         "spring.activiti.asyncExecutorActivate=true",
         "spring.activiti.cloud.rb.job-executor.message-job-consumer.max-attempts=4" // customized
 })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, 
+@DirtiesContext
+@ContextConfiguration(classes = {RuntimeITConfiguration.class,
                                 JobExecutorIT.JobExecutorITProcessEngineConfigurer.class})
 public class JobExecutorIT {
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);
@@ -113,7 +113,7 @@ public class JobExecutorIT {
 
     @Autowired
     private RuntimeService runtimeService;
-    
+
     @Autowired
     private ManagementService managementService;
 
@@ -125,15 +125,15 @@ public class JobExecutorIT {
 
     @Autowired
     private MessageBasedJobManager messageBasedJobManager;
-    
+
     @Autowired
     private RuntimeBundleProperties runtimeBundleProperties;
-    
+
     @SpyBean
     private JobMessageProducer jobMessageProducer;
-    
+
     private ProcessEngineConfiguration processEngineConfiguration;
-    
+
     @Autowired
     private MessageHandler jobMessageHandler;
 
@@ -142,20 +142,20 @@ public class JobExecutorIT {
 
     @Captor
     private ArgumentCaptor<Message<String>> messageArgumentCaptor;
-    
+
     @Autowired
     private ConfigurableApplicationContext applicationContext;
 
     @Autowired
     private PlatformTransactionManager transactionManager;
-    
+
     @MockBean(name = "spyAsyncExecutorJobs")
     private SubscribableChannel spyJobMessageChannel;
-    
+
     @TestConfiguration
     @Profile(JOB_EXECUTOR_IT)
     static class JobExecutorITProcessEngineConfigurer implements ProcessEngineConfigurationConfigurer {
-        
+
         @Override
         public void configure(SpringProcessEngineConfiguration processEngineConfiguration) {
             processEngineConfiguration.setAsyncExecutorDefaultTimerJobAcquireWaitTime(500);
@@ -173,14 +173,14 @@ public class JobExecutorIT {
             };
         }
     }
-    
+
     @Before
     public void setUp() {
         reset(jobMessageHandler);
 
         processEngineConfiguration = ProcessEngines.getProcessEngine("default").getProcessEngineConfiguration();
     }
-    
+
     @After
     public void tearDown() {
         processEngineConfiguration.getClock().reset();
@@ -197,24 +197,24 @@ public class JobExecutorIT {
         assertThat(jobMessageHandler).as("should register JobMessageHandler bean")
                                      .isInstanceOf(JobMessageHandler.class);
     }
-    
+
     @Test
     public void shouldRegisterMessageBasedJobManagerBean() {
         assertThat(messageBasedJobManager).as("should register MessageBasedJobManager bean")
                                           .isInstanceOf(MessageBasedJobManager.class);
-        
+
         assertThat(messageBasedJobManager.getDestination()).as("should configure rb scoped destination")
                                                            .startsWith(runtimeBundleProperties.getServiceName());
     }
-    
+
     @Test
     public void testAsyncJobs() throws InterruptedException {
         int jobCount = 100;
         CountDownLatch jobsCompleted = new CountDownLatch(jobCount);
-        
-        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobsCompleted), 
+
+        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobsCompleted),
                                         ActivitiEventType.JOB_EXECUTION_SUCCESS );
-        
+
         String processDefinitionId = repositoryService.createProcessDefinitionQuery()
                                                       .processDefinitionKey(ASYNC_TASK)
                                                       .singleResult()
@@ -230,21 +230,21 @@ public class JobExecutorIT {
                 .untilAsserted(() -> {
                     assertThat(runtimeService.createExecutionQuery()
                                              .processDefinitionKey(ASYNC_TASK).count()).isEqualTo(0);
-                    
+
                     assertThat(managementService.createJobQuery()
                                .processDefinitionId(processDefinitionId)
-                               .count()).isEqualTo(0); 
+                               .count()).isEqualTo(0);
                 });
 
         assertThat(jobsCompleted.await(1, TimeUnit.MINUTES)).as("should complete all jobs")
                                                             .isTrue();
         // message is sent
-        verify(jobMessageProducer, times(jobCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer, times(jobCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                                 ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler, times(jobCount)).handleMessage(ArgumentMatchers.<Message<?>>any());
     }
-    
+
     @Test
     public void testCatchingTimerEvent() throws Exception {
         CountDownLatch jobsCompleted = new CountDownLatch(1);
@@ -253,7 +253,7 @@ public class JobExecutorIT {
         CountDownLatch eventPublished = new CountDownLatch(1);
 
         applicationContext.addApplicationListener(new CountDownLatchApplicationEventListener<JobMessageSentEvent>(eventPublished));
-        
+
         // Set the clock fixed
         Date startTime = new Date();
 
@@ -271,7 +271,7 @@ public class JobExecutorIT {
 
         // then
         assertThat(pi).isNotNull();
-        
+
         await("the timer job should be created")
             .untilAsserted(() -> {
                 assertThat(managementService.createTimerJobQuery()
@@ -285,14 +285,14 @@ public class JobExecutorIT {
         // timer event has been scheduled
         assertThat(timerScheduled.await(1, TimeUnit.MINUTES)).as("should schedule timer")
                                                              .isTrue();
-        
+
         // then
         await("the process instance should complete and no more jobs should exist")
            .untilAsserted(() -> {
                assertThat(runtimeService.createProcessInstanceQuery()
                                         .processDefinitionKey(pi.getProcessDefinitionKey())
                                         .count()).isEqualTo(0);
-               
+
                assertThat(managementService.createTimerJobQuery()
                                            .processInstanceId(pi.getId())
                                            .count()).isEqualTo(0);
@@ -309,7 +309,7 @@ public class JobExecutorIT {
         assertThat(eventPublished.await(1, TimeUnit.SECONDS)).as("should publish application event")
                                                              .isTrue();
         // message is sent
-        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler).handleMessage(ArgumentMatchers.<Message<?>>any());
@@ -321,10 +321,10 @@ public class JobExecutorIT {
         RetryFailingDelegate.shallThrow = true;
         int retryCount = 5;
         CountDownLatch jobRetries = new CountDownLatch(retryCount);
-        
-        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobRetries), 
+
+        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobRetries),
                                         ActivitiEventType.JOB_EXECUTION_FAILURE );
-        
+
         String processDefinitionId = repositoryService.createProcessDefinitionQuery()
                                                       .processDefinitionKey(FAILED_JOB_RETRY)
                                                       .singleResult()
@@ -336,37 +336,37 @@ public class JobExecutorIT {
         // then
         assertThat(jobRetries.await(1, TimeUnit.MINUTES)).as("should retry failed jobs 5 times every 1 sec")
                                                          .isTrue();
-        
+
         await("the async executions should exists with job exception")
             .untilAsserted(() -> {
                 assertThat(runtimeService.createExecutionQuery()
                                          .processDefinitionId(processDefinitionId)
                                          .activityId("failingJobTask")
                                          .count()).isEqualTo(1);
-                
+
                 assertThat(managementService.createDeadLetterJobQuery()
                                             .processDefinitionId(processDefinitionId)
                                             .withException()
-                                            .count()).isEqualTo(1); 
+                                            .count()).isEqualTo(1);
             });
-        
+
         // message is sent
-        verify(jobMessageProducer, times(retryCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer, times(retryCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                                   ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler, times(retryCount)).handleMessage(ArgumentMatchers.<Message<?>>any());
     }
-    
+
     @Test
     public void testTimerJobsFailRetry() throws InterruptedException {
         //given
         RetryFailingDelegate.shallThrow = true;
-        int retryCount = 3; 
+        int retryCount = 3;
         CountDownLatch jobRetries = new CountDownLatch(retryCount);
-        
-        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobRetries), 
+
+        runtimeService.addEventListener(new CountDownLatchActvitiEventListener(jobRetries),
                                         ActivitiEventType.JOB_EXECUTION_FAILURE );
-        
+
         String processDefinitionId = repositoryService.createProcessDefinitionQuery()
                                                       .processDefinitionKey(FAILED_TIMER_JOB_RETRY)
                                                       .singleResult()
@@ -378,35 +378,35 @@ public class JobExecutorIT {
         // then
         assertThat(jobRetries.await(1, TimeUnit.MINUTES)).as("should retry failed jobs 2 times every 1 sec")
                                                          .isTrue();
-        
+
         await("the async executions should exists with job exception")
             .untilAsserted(() -> {
                 assertThat(runtimeService.createExecutionQuery()
                                          .processDefinitionId(processDefinitionId)
                                          .activityId("timerCatchEvent")
                                          .count()).isEqualTo(1);
-                
+
                 assertThat(managementService.createDeadLetterJobQuery()
                                             .processDefinitionId(processDefinitionId)
                                             .withException()
-                                            .count()).isEqualTo(1); 
+                                            .count()).isEqualTo(1);
             });
-        
+
         // timer job message is sent with 2 retries
-        verify(jobMessageProducer, times(retryCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer, times(retryCount)).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                                   ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler, times(retryCount)).handleMessage(ArgumentMatchers.<Message<?>>any());
-    }    
+    }
     @Test
     public void testStartTimeEvent() throws InterruptedException {
         // given
         CountDownLatch jobCompleted = new CountDownLatch(1);
         CountDownLatch timerFired = new CountDownLatch(1);
         CountDownLatch eventPublished = new CountDownLatch(1);
-        
+
         applicationContext.addApplicationListener(new CountDownLatchApplicationEventListener<JobMessageSentEvent>(eventPublished));
-        
+
         // Set the clock fixed
         Date startTime = new Date();
 
@@ -427,7 +427,7 @@ public class JobExecutorIT {
                                            .singleResult();
         // then
         assertThat(pi).isNull();
-        
+
         await("the timer job should be created")
             .untilAsserted(() -> {
                 assertThat(managementService.createTimerJobQuery()
@@ -444,7 +444,7 @@ public class JobExecutorIT {
                assertThat(runtimeService.createProcessInstanceQuery()
                                         .processDefinitionId(processDefinitionId)
                                         .count()).isEqualTo(1);
-               
+
                assertThat(managementService.createTimerJobQuery()
                                            .processDefinitionId(processDefinitionId)
                                            .count()).isEqualTo(0);
@@ -457,18 +457,18 @@ public class JobExecutorIT {
         // job event has been completed
         assertThat(jobCompleted.await(1, TimeUnit.MINUTES)).as("should complete job")
                                                            .isTrue();
-        
+
         // job event has been published
         assertThat(eventPublished.await(1, TimeUnit.SECONDS)).as("should publish application event")
                                                              .isTrue();
-        
+
         // message is sent
-        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler).handleMessage(ArgumentMatchers.<Message<?>>any());
     }
-    
+
     @Test
     public void testBoundaryTimerEvent() throws Exception {
         CountDownLatch jobsCompleted = new CountDownLatch(1);
@@ -492,7 +492,7 @@ public class JobExecutorIT {
 
         // then
         assertThat(pi).isNotNull();
-        
+
         await("the timer job should be created")
             .untilAsserted(() -> {
                 assertThat(managementService.createTimerJobQuery()
@@ -506,14 +506,14 @@ public class JobExecutorIT {
         // timer event has been scheduled
         assertThat(timerScheduled.await(1, TimeUnit.MINUTES)).as("should schedule timer")
                                                              .isTrue();
-        
+
         // then
         await("the process instance should complete and no more timer jobs should exist")
            .untilAsserted(() -> {
                assertThat(runtimeService.createProcessInstanceQuery()
                                         .processDefinitionKey(pi.getProcessDefinitionKey())
                                         .count()).isEqualTo(0);
-               
+
                assertThat(managementService.createTimerJobQuery()
                                            .processInstanceId(pi.getId())
                                            .count()).isEqualTo(0);
@@ -527,23 +527,23 @@ public class JobExecutorIT {
         assertThat(jobsCompleted.await(1, TimeUnit.MINUTES)).as("should complete job")
                                                             .isTrue();
         // message is sent
-        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()), 
+        verify(jobMessageProducer).sendMessage(ArgumentMatchers.eq(messageBasedJobManager.getDestination()),
                                                ArgumentMatchers.<Job>any());
         // message handler is invoked
         verify(jobMessageHandler).handleMessage(ArgumentMatchers.<Message<?>>any());
     }
-    
+
     @Test
     public void shouldPublishJobMessageFailedEvent() throws InterruptedException {
         // given
         CountDownLatch eventPublished = new CountDownLatch(1);
         String destination = "spyAsyncExecutorJobs";
-        
+
         applicationContext.addApplicationListener(new CountDownLatchApplicationEventListener<JobMessageFailedEvent>(eventPublished));
-        
+
         doReturn(false).when(spyJobMessageChannel)
                        .send(ArgumentMatchers.<Message<?>>any());
-        
+
         // when
         new TransactionTemplate(transactionManager).execute(new TransactionCallbackWithoutResult() {
 
@@ -553,17 +553,17 @@ public class JobExecutorIT {
             }
 
         });
-        
+
         // then
         assertThat(eventPublished.await(1, TimeUnit.SECONDS)).as("should publish JobMessageFailedEvent")
                                                              .isTrue();
     }
-    
+
     @Test
     public void shouldFailIfNoActiveTransactionSynchronization() {
         // when
         Throwable throwable = catchThrowable(
-                () -> jobMessageProducer.sendMessage(ArgumentMatchers.anyString(), 
+                () -> jobMessageProducer.sendMessage(ArgumentMatchers.anyString(),
                                                      ArgumentMatchers.any(Job.class))
         );
 
@@ -573,18 +573,18 @@ public class JobExecutorIT {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("requires active transaction synchronization");
     }
-    
+
     @Test
     public void shouldPublishJobMessageSentEvent() throws InterruptedException {
         // given
         CountDownLatch eventPublished = new CountDownLatch(1);
         String destination = "spyAsyncExecutorJobs";
-        
+
         applicationContext.addApplicationListener(new CountDownLatchApplicationEventListener<JobMessageSentEvent>(eventPublished));
-        
+
         doReturn(true).when(spyJobMessageChannel)
                        .send(ArgumentMatchers.<Message<?>>any());
-        
+
         // when
         new TransactionTemplate(transactionManager).execute(new TransactionCallbackWithoutResult() {
 
@@ -594,18 +594,18 @@ public class JobExecutorIT {
             }
 
         });
-        
+
         // then
         assertThat(eventPublished.await(1, TimeUnit.SECONDS)).as("should publish JobMessageSentEvent")
                                                              .isTrue();
-    }    
+    }
 
     @Test
     public void shouldBuildJobMessage() throws InterruptedException {
         // given
         String destination = "spyAsyncExecutorJobs";
         String jobId = "jobId";
-        
+
         TestJobEntity job = new TestJobEntity(jobId).withDueDate(new Date())
                                                     .withExecutionId("executionId")
                                                     .withJobHandlerType("jobHandlerType")
@@ -619,7 +619,7 @@ public class JobExecutorIT {
                                                     ;
         doReturn(true).when(spyJobMessageChannel)
                        .send(ArgumentMatchers.<Message<?>>any());
-        
+
         // when
         new TransactionTemplate(transactionManager).execute(new TransactionCallbackWithoutResult() {
 
@@ -629,12 +629,12 @@ public class JobExecutorIT {
             }
 
         });
-        
+
         // then
         verify(spyJobMessageChannel).send(messageArgumentCaptor.capture());
-        
+
         Message<String> message = messageArgumentCaptor.getValue();
-                
+
         assertThat(message.getPayload()).as("should build job id as payload")
                                         .isEqualTo(jobId);
 
@@ -642,7 +642,7 @@ public class JobExecutorIT {
                                         .containsEntry("routingKey", destination)
                                         .containsEntry("messagePayloadType", String.class.getName())
                                         ;
-        
+
         assertThat(message.getHeaders()).as("should build runtime bundle properties as headers")
                                         .containsEntry(RuntimeBundleInfoMessageHeaders.APP_NAME, properties.getAppName())
                                         .containsEntry(RuntimeBundleInfoMessageHeaders.SERVICE_NAME, properties.getServiceName())
@@ -661,12 +661,12 @@ public class JobExecutorIT {
                                         .containsEntry(JobMessageHeaders.JOB_HANDLER_CONFIGURATION, job.getJobHandlerConfiguration())
                                         .containsEntry(JobMessageHeaders.JOB_RETRIES, job.getRetries())
                                         ;
-        
+
     }
-    
-    
+
+
     abstract class AbstractActvitiEventListener implements ActivitiEventListener {
-        
+
         @Override
         public boolean isFailOnException() {
             return false;
@@ -674,37 +674,37 @@ public class JobExecutorIT {
     }
 
     class CountDownLatchActvitiEventListener extends AbstractActvitiEventListener {
-        
+
         private final CountDownLatch countDownLatch;
-           
+
         public CountDownLatchActvitiEventListener(CountDownLatch countDownLatch) {
             this.countDownLatch = countDownLatch;
         }
-        
+
         @Override
         public void onEvent(ActivitiEvent arg0) {
             logger.info("Received Activiti Event: {}", arg0);
-            
+
             countDownLatch.countDown();
         }
     }
-    
+
     class CountDownLatchApplicationEventListener<E extends ApplicationEvent> implements ApplicationListener<E> {
-        
+
         private final CountDownLatch countDownLatch;
-           
+
         public CountDownLatchApplicationEventListener(CountDownLatch countDownLatch) {
             this.countDownLatch = countDownLatch;
         }
-        
+
         @Override
         public void onApplicationEvent(E event) {
             logger.info("Received Activiti Event: {}", event);
-            
+
             countDownLatch.countDown();
         }
     }
-    
+
     static class TestJobEntity extends JobEntityImpl {
         private static final long serialVersionUID = 1L;
 
@@ -712,28 +712,28 @@ public class JobExecutorIT {
             super();
             setId(jobId);
         }
-        
+
         public TestJobEntity withExecutionId(String executionId) {
             setExecutionId(executionId);
-            
+
             return this;
         }
 
         public TestJobEntity withDueDate(Date dueDate) {
             setDuedate(dueDate);
-            
+
             return this;
         }
 
         public TestJobEntity withJobType(String jobType) {
             setJobType(jobType);
-            
+
             return this;
         }
 
         public TestJobEntity withJobHandlerType(String jobHandlerType) {
             setJobHandlerType(jobHandlerType);
-            
+
             return this;
         }
 
@@ -744,35 +744,35 @@ public class JobExecutorIT {
 
         public TestJobEntity withProcessDefinitionId(String processDefinitionId) {
             setProcessDefinitionId(processDefinitionId);
-            
+
             return this;
         }
 
         public TestJobEntity withProcessInstanceId(String processInstanceId) {
             setProcessInstanceId(processInstanceId);
-            
+
             return this;
         }
 
         public TestJobEntity withTenantId(String tenantId) {
             setTenantId(tenantId);
-            
+
             return this;
         }
-        
+
         public TestJobEntity withRetries(int retries) {
             setRetries(retries);
-            
+
             return this;
         }
 
         public TestJobEntity withExceptionMessage(String exceptionMessage) {
             setExceptionMessage(exceptionMessage);
-            
+
             return this;
         }
     }
-    
+
     public static class RetryFailingDelegate implements JavaDelegate {
 
         public static final String EXCEPTION_MESSAGE = "Expected exception.";
@@ -793,5 +793,5 @@ public class JobExecutorIT {
             throw new ActivitiException(EXCEPTION_MESSAGE);
           }
         }
-      }    
+      }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class MQServiceTaskIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class MessageIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -61,7 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class ProcessInstanceIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -61,7 +61,7 @@ import java.util.TimeZone;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class ProcessVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -60,7 +60,7 @@ import java.util.Map;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class SignalIT {
 
@@ -95,15 +95,15 @@ public class SignalIT {
         //when
         runtimeService.startProcessInstanceByKey("broadcastSignalCatchEventProcess");
         runtimeService.startProcessInstanceByKey("broadcastSignalEventProcess");
-        
+
         await("Broadcast Signals").untilAsserted(() -> {
             List<org.activiti.engine.runtime.ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("broadcastSignalCatchEventProcess").list();
-            assertThat(processInstances).isEmpty();    
-            
+            assertThat(processInstances).isEmpty();
+
             processInstances = runtimeService.createProcessInstanceQuery().processDefinitionKey("broadcastSignalEventProcess").list();
-            assertThat(processInstances).isEmpty();    
+            assertThat(processInstances).isEmpty();
         });
-       
+
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -55,7 +55,7 @@ import java.util.Map;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class TaskVariablesIT {
 
@@ -67,17 +67,17 @@ public class TaskVariablesIT {
 
     @Autowired
     private TaskRestTemplate taskRestTemplate;
-    
+
     @Autowired
     private KeycloakTokenProducer keycloakSecurityContextClientRequestInterceptor;
-    
+
     @Autowired
     private  VariablesUtil variablesUtil;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";
-    
+
     @Before
     public void setUp() {
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("hruser");
@@ -100,9 +100,9 @@ public class TaskVariablesIT {
         ResponseEntity<PagedResources<CloudTask>> tasks = processInstanceRestTemplate.getTasks(startResponse);
 
         String taskId = tasks.getBody().getContent().iterator().next().getId();
-      
+
         taskRestTemplate.claim(taskId);
-        
+
         taskRestTemplate.createVariable(taskId, "var2", "test2");
 
         //when
@@ -124,8 +124,8 @@ public class TaskVariablesIT {
 
         // give
         taskRestTemplate.updateVariable(taskId, "var2", "test2-update" );
-        
-        
+
+
         taskRestTemplate.createVariable(taskId, "var3", "test3" );
 
 
@@ -137,7 +137,7 @@ public class TaskVariablesIT {
         assertThat(variablesContainEntry("var2","test2-update",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var1","test1",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var3","test3",variablesResponse.getBody().getContent())).isTrue();
-        
+
         //given
         taskRestTemplate.updateVariable(taskId, "var3", "test3-update");
 
@@ -152,7 +152,7 @@ public class TaskVariablesIT {
 
 
     }
-    
+
     @Test
     public void adminShouldSetGetUpdateTaskVariables() {
         //given
@@ -164,7 +164,7 @@ public class TaskVariablesIT {
         ResponseEntity<PagedResources<CloudTask>> tasks = processInstanceRestTemplate.getTasks(startResponse);
 
         String taskId = tasks.getBody().getContent().iterator().next().getId();
-        
+
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("testadmin");
         taskRestTemplate.adminCreateVariable(taskId, "var2", "test2");
 
@@ -176,7 +176,7 @@ public class TaskVariablesIT {
         assertThat(variablesContainEntry("var2","test2",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var1","test1",variablesResponse.getBody().getContent())).isTrue();
 
-    
+
         //given
         taskRestTemplate.adminUpdateVariable(taskId, "var2","test2-update");
         taskRestTemplate.adminCreateVariable(taskId, "var3","test3");
@@ -189,7 +189,7 @@ public class TaskVariablesIT {
         assertThat(variablesContainEntry("var2","test2-update",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var1","test1",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var3","test3",variablesResponse.getBody().getContent())).isTrue();
-        
+
         //given
         taskRestTemplate.adminUpdateVariable(taskId, "var3", "test3-update");
 
@@ -202,20 +202,20 @@ public class TaskVariablesIT {
         assertThat(variablesContainEntry("var1","test1",variablesResponse.getBody().getContent())).isTrue();
         assertThat(variablesContainEntry("var3","test3-update",variablesResponse.getBody().getContent())).isTrue();
     }
-    
+
     @Test
     public void should_Change_Date_When_CreateUpdateTaskVariables() throws Exception{
         //given
         Date date = new Date();
-  
+
         ResponseEntity<CloudProcessInstance> startResponse = processInstanceRestTemplate.startProcess(processDefinitionIds.get(SIMPLE_PROCESS),
                                                                                                       null);
         ResponseEntity<PagedResources<CloudTask>> tasks = processInstanceRestTemplate.getTasks(startResponse);
 
         String taskId = tasks.getBody().getContent().iterator().next().getId();
-      
+
         taskRestTemplate.claim(taskId);
-        
+
         taskRestTemplate.createVariable(taskId, "variableDateTime", variablesUtil.getDateTimeFormattedString(date));
         taskRestTemplate.createVariable(taskId, "variableDate", variablesUtil.getDateFormattedString(date));
 
@@ -234,23 +234,23 @@ public class TaskVariablesIT {
 
         // when
         variablesResponse = taskRestTemplate.getVariables(taskId);
-        
-        processInstanceRestTemplate.delete(startResponse); 
+
+        processInstanceRestTemplate.delete(startResponse);
     }
-    
+
     @Test
     public void admin_Should_Change_Date_When_CreateUpdateTaskVariables() throws Exception{
         //given
         Date date = new Date();
-  
+
         ResponseEntity<CloudProcessInstance> startResponse = processInstanceRestTemplate.startProcess(processDefinitionIds.get(SIMPLE_PROCESS),
                                                                                                       null);
         ResponseEntity<PagedResources<CloudTask>> tasks = processInstanceRestTemplate.getTasks(startResponse);
 
         String taskId = tasks.getBody().getContent().iterator().next().getId();
-        
+
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("testadmin");
-        
+
         taskRestTemplate.adminCreateVariable(taskId, "variableDateTime", variablesUtil.getDateTimeFormattedString(date));
         taskRestTemplate.adminCreateVariable(taskId, "variableDate", variablesUtil.getDateFormattedString(date));
 
@@ -269,10 +269,10 @@ public class TaskVariablesIT {
 
         // when
         variablesResponse = taskRestTemplate.adminGetVariables(taskId);
-        
-        processInstanceRestTemplate.delete(startResponse); 
+
+        processInstanceRestTemplate.delete(startResponse);
     }
-    
+
     private boolean variablesContainEntry(String key, Object value, Collection<CloudVariableInstance> variableCollection){
         Iterator<CloudVariableInstance> iterator = variableCollection.iterator();
         while(iterator.hasNext()){
@@ -283,7 +283,7 @@ public class TaskVariablesIT {
                     assertThat("String").isEqualTo(variable.getValue().getClass().getSimpleName());
                 } else {
                     assertThat(type).isEqualToIgnoringCase(variable.getValue().getClass().getSimpleName());
-                }                
+                }
                 return true;
             }
         }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -63,7 +63,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class TasksIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -103,7 +103,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class AuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -64,7 +64,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -69,7 +69,7 @@ import java.util.*;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -68,7 +68,7 @@ import java.util.Map;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -58,15 +58,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class MessageAuditProducerIT {
     private static final String CATCH_MESSAGE = "catchMessage";
-    
+
 
     @Autowired
     private MessageRestTemplate messageRestTemplate;
-    
+
     @Autowired
     private ProcessInstanceRestTemplate processInstanceRestTemplate;
 
@@ -81,13 +81,13 @@ public class MessageAuditProducerIT {
     @Test
     public void shouldAuditBPMNEventsMessagesAreProduced() {
         //when
-        ResponseEntity<CloudProcessInstance> startResponse = 
+        ResponseEntity<CloudProcessInstance> startResponse =
                 messageRestTemplate.message(start("auditStartMessage").withBusinessKey("businessId")
                                                                       .withVariable("correlationKey", "correlationId")
                                                                       .build());
 
         assertThat(startResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-        
+
         assertThat(messageRestTemplate.message(receive("auditEventSubprocessMessage").withCorrelationKey("correlationId")
                                                                                      .build())
                                                                                      .getStatusCode())
@@ -104,7 +104,7 @@ public class MessageAuditProducerIT {
                                                                                        .build())
                                                                                        .getStatusCode())
                                                                                        .isEqualTo(HttpStatus.OK);
-        
+
         // then
         CloudProcessInstance processInstance = startResponse.getBody();
 
@@ -131,13 +131,13 @@ public class MessageAuditProducerIT {
                     )
                     .containsExactly(
                             tuple(MESSAGE_RECEIVED,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "startMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditStartMessage",
                                   null,
@@ -145,13 +145,13 @@ public class MessageAuditProducerIT {
                                   Collections.singletonMap("correlationKey", "correlationId")
                             ),
                             tuple(MESSAGE_WAITING,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "startMessageEventSubprocessEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditEventSubprocessMessage",
                                   "correlationId",
@@ -159,13 +159,13 @@ public class MessageAuditProducerIT {
                                   null
                             ),
                             tuple(MESSAGE_SENT,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "intermediateThrowMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditIntermediateThrowMessage",
                                   "correlationId",
@@ -173,13 +173,13 @@ public class MessageAuditProducerIT {
                                   Collections.singletonMap("correlationKey", "correlationId")
                             ),
                             tuple(MESSAGE_WAITING,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "boundaryMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditBoundaryMessage",
                                   "correlationId",
@@ -187,27 +187,27 @@ public class MessageAuditProducerIT {
                                   null
                             ),
                             tuple(MESSAGE_RECEIVED,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "startMessageEventSubprocessEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditEventSubprocessMessage",
                                   "correlationId",
                                   processInstance.getBusinessKey(),
                                   null
-                            ),                             
+                            ),
                             tuple(MESSAGE_RECEIVED,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "boundaryMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditBoundaryMessage",
                                   "correlationId",
@@ -215,13 +215,13 @@ public class MessageAuditProducerIT {
                                   Collections.singletonMap("customerKey", "customerId")
                             ),
                             tuple(MESSAGE_WAITING,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "intermediateCatchMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditInteremdiateCatchMessage",
                                   "customerId",
@@ -229,13 +229,13 @@ public class MessageAuditProducerIT {
                                   null
                             ),
                             tuple(MESSAGE_RECEIVED,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "intermediateCatchMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditInteremdiateCatchMessage",
                                   "customerId",
@@ -243,13 +243,13 @@ public class MessageAuditProducerIT {
                                   Collections.singletonMap("invoiceKey", "invoiceId")
                             ),
                             tuple(MESSAGE_SENT,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
                                   "throwEndMessageEvent",
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "auditThrowEndMessage",
                                   "invoiceId",
@@ -263,7 +263,7 @@ public class MessageAuditProducerIT {
         });
 
     }
-    
+
     @Test
     public void should_produceCloudMessageSubscriptionCancelledEvent_when_processIsDeleted() {
         //when
@@ -276,9 +276,9 @@ public class MessageAuditProducerIT {
                                                                                    .build());
 
         assertThat(startProcessEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        
+
         CloudProcessInstance processInstance = startProcessEntity.getBody();
-        
+
 
         await("Audit BPMNMessage Events").untilAsserted(() -> {
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(RUNTIME_BUNDLE_INFO_HEADERS);
@@ -301,12 +301,12 @@ public class MessageAuditProducerIT {
                     )
                     .contains(
                             tuple(MESSAGE_WAITING,
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   processInstance.getProcessDefinitionKey(),
                                   1, // version
                                   processInstance.getBusinessKey(),
-                                  processInstance.getProcessDefinitionId(), 
+                                  processInstance.getProcessDefinitionId(),
                                   processInstance.getId(),
                                   "testMessage",
                                   "foo",
@@ -314,8 +314,8 @@ public class MessageAuditProducerIT {
                     );
 
             });
-        
-        
+
+
             ResponseEntity<CloudProcessInstance> deleteProcessEntity = processInstanceRestTemplate.delete(startProcessEntity);
             assertThat(deleteProcessEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 
@@ -323,7 +323,7 @@ public class MessageAuditProducerIT {
                 assertThat(streamHandler.getReceivedHeaders()).containsKeys(RUNTIME_BUNDLE_INFO_HEADERS);
                 assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
                 List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-    
+
                 assertThat(receivedEvents)
                         .filteredOn(CloudMessageSubscriptionCancelledEvent.class::isInstance)
                         .extracting(CloudRuntimeEvent::getEventType,
@@ -340,27 +340,27 @@ public class MessageAuditProducerIT {
                         )
                         .contains(
                                 tuple(MessageSubscriptionEvent.MessageSubscriptionEvents.MESSAGE_SUBSCRIPTION_CANCELLED,
-                                      processInstance.getProcessDefinitionId(), 
+                                      processInstance.getProcessDefinitionId(),
                                       processInstance.getId(),
                                       processInstance.getProcessDefinitionKey(),
                                       1, // version
                                       processInstance.getBusinessKey(),
-                                      processInstance.getProcessDefinitionId(), 
+                                      processInstance.getProcessDefinitionId(),
                                       processInstance.getId(),
                                       "testMessage",
                                       "foo",
                                       processInstance.getBusinessKey())
                         );
-    
+
             });
-        
+
     }
-    
-    
+
+
     private BPMNMessage bpmnMessage(CloudRuntimeEvent<?,?> event) {
         return CloudBPMNMessageEvent.class.cast(event).getEntity();
     }
-    
+
     private MessageSubscription messageSubscription(CloudRuntimeEvent<?,?> event) {
         return CloudMessageSubscriptionCancelledEvent.class.cast(event).getEntity();
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -49,7 +49,7 @@ import java.util.List;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 
@@ -78,7 +78,7 @@ public class ParallelGatewayAuditProducerIT {
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
-      
+
             assertThat(receivedEvents)
                     .extracting(CloudRuntimeEvent::getEventType,
                                 CloudRuntimeEvent::getProcessInstanceId,
@@ -153,11 +153,11 @@ public class ParallelGatewayAuditProducerIT {
                                     processInstanceId,
                                     processInstanceId)
                     );
-            
-            
+
+
             assertThat(receivedEvents)
             .filteredOn(event -> (event.getEventType().equals(ACTIVITY_STARTED) ||
-                                  event.getEventType().equals(ACTIVITY_COMPLETED)) && 
+                                  event.getEventType().equals(ACTIVITY_COMPLETED)) &&
                                  ((BPMNActivity) event.getEntity()).getActivityType().equals("parallelGateway"))
             .extracting(CloudRuntimeEvent::getEventType,
                         event -> ((BPMNActivity) event.getEntity()).getActivityType(),
@@ -168,14 +168,14 @@ public class ParallelGatewayAuditProducerIT {
                       tuple(ACTIVITY_COMPLETED,
                             "parallelGateway",
                             processInstanceId)
-                      
+
             );
-           
+
 
         });
-        
-        
-       
+
+
+
 
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class SignalAuditProducerIT {
 
@@ -69,7 +69,7 @@ public class SignalAuditProducerIT {
 
     @Autowired
     private ProcessInstanceRestTemplate processInstanceRestTemplate;
-    
+
     @Autowired
     private RuntimeService runtimeService;
 
@@ -127,7 +127,7 @@ public class SignalAuditProducerIT {
                                                                                 .singleResult()
                                                                                 .getId())
                                                       .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1"));
-            
+
             List<CloudBPMNSignalReceivedEvent> signalReceivedEvents = receivedEvents
                     .stream()
                     .filter(CloudBPMNSignalReceivedEvent.class::isInstance)
@@ -151,8 +151,8 @@ public class SignalAuditProducerIT {
                             tuple(SIGNAL_RECEIVED,
                                   processWithSignalStart.getId(),
                                   startedBySignalProcessInstanceId,
-                                  processWithSignalStart.getKey(), 
-                                  processWithSignalStart.getVersion(), 
+                                  processWithSignalStart.getKey(),
+                                  processWithSignalStart.getVersion(),
                                   processWithSignalStart.getId(),
                                   startedBySignalProcessInstanceId,
                                   "theStart",
@@ -209,7 +209,7 @@ public class SignalAuditProducerIT {
                                                           .map(CloudRuntimeEvent::getProcessInstanceId)
                                                           .findFirst()
                                                           .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1"));
-            
+
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 
             assertThat(receivedEvents)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -31,12 +31,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext
 public class RuntimeBundleSwaggerIT {
 
     @Autowired
@@ -57,7 +59,6 @@ public class RuntimeBundleSwaggerIT {
             .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
             .andExpect(jsonPath("$.definitions[\"SaveTaskPayload\"].properties").value(hasKey("payloadType")))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Starter :: Runtime Bundle ReST API"));
-
     }
 
 }


### PR DESCRIPTION
Launching the tests locally with `mvn clean install` breaks since Activiti/Activiti#3186 due to a dependency on execution ordering even if it works fine on Travis CI.

To reproduce without executing all, just launch two tests in the starter of runtime-bundle:
```
cd activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle
mvn clean install -Dit.test=JobExecutorIT,RuntimeBundleSwaggerIT 
```

