### PR TITLE
AAE-2382 persist start date in process started event

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessStartedEventHandler.java
@@ -16,9 +16,6 @@
 
 package org.activiti.cloud.services.query.events.handlers;
 
-import java.util.Date;
-import java.util.Optional;
-
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
@@ -28,6 +25,9 @@ import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.QueryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Optional;
 
 public class ProcessStartedEventHandler implements QueryEventHandler {
 
@@ -53,6 +53,7 @@ public class ProcessStartedEventHandler implements QueryEventHandler {
             //instance name is not available in ProcessCreatedEvent, so we need to updated it here
             processInstanceEntity.setName(startedEvent.getEntity().getName());
             processInstanceEntity.setLastModified(new Date(startedEvent.getTimestamp()));
+            processInstanceEntity.setStartDate(startedEvent.getEntity().getStartDate());
             processInstanceRepository.save(processInstanceEntity);
         }
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/ProcessStartedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/ProcessStartedEventHandlerTest.java
@@ -68,6 +68,7 @@ public class ProcessStartedEventHandlerTest {
         verify(processInstanceRepository).save(currentProcessInstanceEntity);
         verify(currentProcessInstanceEntity).setStatus(ProcessInstance.ProcessInstanceStatus.RUNNING);
         verify(currentProcessInstanceEntity).setName(event.getEntity().getName());
+        verify(currentProcessInstanceEntity).setStartDate(event.getEntity().getStartDate());
     }
 
     @Test


### PR DESCRIPTION
The start date in process_instances table is always null.

After a debug session I noticed that when we consume a process creation (ProcessCreatedEventHandler) we try to persist the startDate but this is null. After in the start process event (ProcessStartedEventHandler) the date is valorized, but it is ignored.

Going to the root cause of the problem, the event PROCESS_CREATED event in RB is produced without the startDate because the startTime is null in org.activiti.engine.runtime.ProcessInstance, the source event entity.

IMHO a fix could be to persist the start date in ProcessStartedEventHandler.