### PR TITLE
fix(AAE-1978): Start a process and declare variable type at the same time #3246

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/ProcessVariableValue.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/ProcessVariableValue.java
@@ -1,0 +1,103 @@
+package org.activiti.cloud.services.api.model;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ProcessVariableValue implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private String type;
+    private String value;
+
+    ProcessVariableValue() { }
+
+    public ProcessVariableValue(String type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+
+    public String getType() {
+        return type;
+    }
+
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ProcessVariableValue other = (ProcessVariableValue) obj;
+        return Objects.equals(type, other.type) && Objects.equals(value, other.value);
+    }
+
+    public Map<String, String> toMap() {
+        Map<String, String> result = new LinkedHashMap<>(2);
+
+        result.put("type", type);
+        result.put("value", value);
+
+        return result;
+    }
+
+    public String toJson() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\"type\":\"")
+               .append(type)
+               .append("\",\"value\":")
+               .append(Optional.ofNullable(value)
+                               .map(this::escape)
+                               .orElse("null"))
+               .append("}");
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toJson();
+    }
+
+    private String escape( String value )
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append( "\"" );
+        for( char c : value.toCharArray() )
+        {
+            if( c == '\'' )
+                builder.append( "\\'" );
+            else if ( c == '\"' )
+                builder.append( "\\\"" );
+            else if( c == '\r' )
+                builder.append( "\\r" );
+            else if( c == '\n' )
+                builder.append( "\\n" );
+            else if( c == '\t' )
+                builder.append( "\\t" );
+            else if( c < 32 || c >= 127 )
+                builder.append( String.format( "\\u%04x", (int)c ) );
+            else
+                builder.append( c );
+        }
+        builder.append( "\"" );
+        return builder.toString();
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
@@ -12,6 +12,10 @@
   <dependencies>
     <dependency>
       <groupId>org.activiti</groupId>
+      <artifactId>activiti-common-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti</groupId>
       <artifactId>activiti-spring-identity</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableDateConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableDateConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.core;
+
+import java.util.Date;
+
+import org.activiti.common.util.DateFormatterProvider;
+
+public class ProcessVariableDateConverter implements SpringProcessVariableValueConverter<Date> {
+
+    private final DateFormatterProvider provider;
+
+    public ProcessVariableDateConverter(DateFormatterProvider provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    public Date convert(String source) {
+        return provider.parse(source);
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableDateConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableDateConverter.java
@@ -20,7 +20,7 @@ import java.util.Date;
 
 import org.activiti.common.util.DateFormatterProvider;
 
-public class ProcessVariableDateConverter implements SpringProcessVariableValueConverter<Date> {
+public class ProcessVariableDateConverter implements ProcessVariableValueSpringConverter<Date> {
 
     private final DateFormatterProvider provider;
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
@@ -25,10 +25,6 @@ public class ProcessVariableJsonNodeConverter implements ProcessVariableValueSpr
 
     private final ObjectMapper objectMapper;
 
-    public ProcessVariableJsonNodeConverter() {
-        this.objectMapper = new ObjectMapper();
-    }
-
     public ProcessVariableJsonNodeConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.core;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ProcessVariableJsonNodeConverter implements SpringProcessVariableValueConverter<JsonNode> {
+
+    private final ObjectMapper objectMapper;
+
+    public ProcessVariableJsonNodeConverter() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public ProcessVariableJsonNodeConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public JsonNode convert(String source) {
+
+        try {
+            return objectMapper.readTree(source);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableJsonNodeConverter.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class ProcessVariableJsonNodeConverter implements SpringProcessVariableValueConverter<JsonNode> {
+public class ProcessVariableJsonNodeConverter implements ProcessVariableValueSpringConverter<JsonNode> {
 
     private final ObjectMapper objectMapper;
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueConverter.java
@@ -16,23 +16,20 @@
 
 package org.activiti.cloud.services.core;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.activiti.cloud.services.api.model.ProcessVariableValue;
 import org.activiti.engine.ActivitiException;
-import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.util.Assert;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 public class ProcessVariableValueConverter  {
 
-    protected static Map<String, Class<?>> typeRegistry = new HashMap<>();
+    private static Map<String, Class<?>> typeRegistry = new HashMap<>();
 
     static {
         typeRegistry.put("string", String.class);
@@ -45,13 +42,9 @@ public class ProcessVariableValueConverter  {
         typeRegistry.put("localdate", LocalDate.class);
         typeRegistry.put("bigdecimal", BigDecimal.class);
         typeRegistry.put("json", JsonNode.class);
-    };
+    }
 
     private final ConversionService conversionService;
-
-    public ProcessVariableValueConverter() {
-        this(ApplicationConversionService.getSharedInstance());
-    }
 
     public ProcessVariableValueConverter(ConversionService conversionService) {
         Assert.notNull(conversionService, "ConversionService must not be null");
@@ -65,8 +58,7 @@ public class ProcessVariableValueConverter  {
 
         try {
             return (T) type.cast(this.conversionService.convert(value, type));
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             throw new ActivitiException("VariableValue conversion error", ex);
         }
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.core;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.activiti.cloud.services.api.model.ProcessVariableValue;
+import org.activiti.engine.ActivitiException;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ProcessVariableValueConverter  {
+
+    protected static Map<String, Class<?>> typeRegistry = new HashMap<>();
+
+    static {
+        typeRegistry.put("string", String.class);
+        typeRegistry.put("long", Long.class);
+        typeRegistry.put("int", Integer.class);
+        typeRegistry.put("integer", Integer.class);
+        typeRegistry.put("boolean", Boolean.class);
+        typeRegistry.put("double", Double.class);
+        typeRegistry.put("date", Date.class);
+        typeRegistry.put("localdate", LocalDate.class);
+        typeRegistry.put("bigdecimal", BigDecimal.class);
+        typeRegistry.put("json", JsonNode.class);
+    };
+
+    private final ConversionService conversionService;
+
+    public ProcessVariableValueConverter() {
+        this(ApplicationConversionService.getSharedInstance());
+    }
+
+    public ProcessVariableValueConverter(ConversionService conversionService) {
+        Assert.notNull(conversionService, "ConversionService must not be null");
+        this.conversionService = conversionService;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T convert(ProcessVariableValue variableValue) {
+        Class<?> type = typeRegistry.getOrDefault(variableValue.getType().toLowerCase(), Object.class);
+        Object value = variableValue.getValue();
+
+        try {
+            return (T) type.cast(this.conversionService.convert(value, type));
+        }
+        catch (Exception ex) {
+            throw new ActivitiException("VariableValue conversion error", ex);
+        }
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueSpringConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariableValueSpringConverter.java
@@ -2,6 +2,6 @@ package org.activiti.cloud.services.core;
 
 import org.springframework.core.convert.converter.Converter;
 
-public interface SpringProcessVariableValueConverter<T> extends Converter<String, T>  {
+public interface ProcessVariableValueSpringConverter<T> extends Converter<String, T>  {
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.core;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.StartProcessPayload;
+import org.activiti.cloud.services.api.model.ProcessVariableValue;
+import org.springframework.util.Assert;
+
+public class ProcessVariablesPayloadConverter {
+
+    private final ProcessVariableValueConverter variableValueConverter;
+
+    public ProcessVariablesPayloadConverter(ProcessVariableValueConverter variableValueConverter) {
+        Assert.notNull(variableValueConverter, "VariableValueConverter must not be null");
+
+        this.variableValueConverter = variableValueConverter;
+    }
+
+    public StartProcessPayload convert(StartProcessPayload from) {
+        return ProcessPayloadBuilder.start()
+                                    .withBusinessKey(from.getBusinessKey())
+                                    .withName(from.getName())
+                                    .withProcessDefinitionId(from.getProcessDefinitionId())
+                                    .withProcessDefinitionKey(from.getProcessDefinitionKey())
+                                    .withVariables(mapVariableValues(from.getVariables()))
+                                    .build();
+
+    }
+
+    private Map<String, Object> mapVariableValues(Map<String, Object> input) {
+        return input.entrySet()
+                    .stream()
+                    .map(this::parseValue)
+                    .collect(LinkedHashMap::new, (m,v)->m.put(v.getKey(), v.getValue()), HashMap::putAll);
+    }
+
+    private Map.Entry<String, Object> parseValue(Map.Entry<String, Object> entry) {
+        Object entryValue = entry.getValue();
+
+        try {
+            if(Map.class.isInstance(entryValue)) {
+                Map<String, String> valuesMap = Map.class.cast(entryValue);
+
+                if(valuesMap.containsKey("type") && valuesMap.containsKey("value")) {
+                    String type = (String) valuesMap.get("type");
+                    String value = (String) valuesMap.get("value");
+
+                    entryValue = variableValueConverter.convert(new ProcessVariableValue(type, value));
+                }
+
+            } else if (ProcessVariableValue.class.isInstance(entryValue)) {
+                entryValue = variableValueConverter.convert(ProcessVariableValue.class.cast(entryValue));
+            }
+        } catch (Exception ignored) { }
+
+        return new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), entryValue);
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
@@ -17,9 +17,11 @@
 package org.activiti.cloud.services.core;
 
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
@@ -37,12 +39,19 @@ public class ProcessVariablesPayloadConverter {
     }
 
     public StartProcessPayload convert(StartProcessPayload from) {
+        if(from == null) {
+            return null;
+        }
+
+        Map<String, Object> variables = Optional.ofNullable(from.getVariables())
+                                                .orElseGet(Collections::emptyMap);
+
         return ProcessPayloadBuilder.start()
                                     .withBusinessKey(from.getBusinessKey())
                                     .withName(from.getName())
                                     .withProcessDefinitionId(from.getProcessDefinitionId())
                                     .withProcessDefinitionKey(from.getProcessDefinitionKey())
-                                    .withVariables(mapVariableValues(from.getVariables()))
+                                    .withVariables(mapVariableValues(variables))
                                     .build();
 
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverter.java
@@ -66,7 +66,7 @@ public class ProcessVariablesPayloadConverter {
                     .stream()
                     .map(this::parseValue)
                     .collect(LinkedHashMap::new,
-                             (m,v)->m.put(v.getKey(), v.getValue()),
+                             (m,v) -> m.put(v.getKey(), v.getValue()),
                              HashMap::putAll);
     }
 
@@ -74,12 +74,12 @@ public class ProcessVariablesPayloadConverter {
         Object entryValue = entry.getValue();
 
         try {
-            if(Map.class.isInstance(entryValue)) {
+            if (Map.class.isInstance(entryValue)) {
                 Map<String, String> valuesMap = Map.class.cast(entryValue);
 
-                if(valuesMap.containsKey("type") && valuesMap.containsKey("value")) {
-                    String type = (String) valuesMap.get("type");
-                    String value = (String) valuesMap.get("value");
+                if (valuesMap.containsKey("type") && valuesMap.containsKey("value")) {
+                    String type = valuesMap.get("type");
+                    String value = valuesMap.get("value");
 
                     entryValue = variableValueConverter.convert(new ProcessVariableValue(type, value));
                 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/SpringProcessVariableValueConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/SpringProcessVariableValueConverter.java
@@ -1,0 +1,7 @@
+package org.activiti.cloud.services.core;
+
+import org.springframework.core.convert.converter.Converter;
+
+public interface SpringProcessVariableValueConverter<T> extends Converter<String, T>  {
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -16,11 +16,12 @@
 
 package org.activiti.cloud.services.core.conf;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-
 import org.activiti.api.model.shared.Payload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
@@ -28,8 +29,8 @@ import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.ProcessVariableDateConverter;
 import org.activiti.cloud.services.core.ProcessVariableJsonNodeConverter;
 import org.activiti.cloud.services.core.ProcessVariableValueConverter;
-import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
 import org.activiti.cloud.services.core.ProcessVariableValueSpringConverter;
+import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
 import org.activiti.cloud.services.core.commands.ClaimTaskCmdExecutor;
 import org.activiti.cloud.services.core.commands.CommandEndpoint;
 import org.activiti.cloud.services.core.commands.CommandExecutor;
@@ -60,8 +61,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
 import org.springframework.format.support.FormattingConversionService;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 @Configuration
 @PropertySource("classpath:config/command-endpoint-channels.properties")
@@ -198,8 +197,9 @@ public class ServicesCoreAutoConfiguration {
     }
 
     @Bean
-    public ProcessVariableValueSpringConverter<JsonNode> processVariableJsonNodeConverter() {
-        return new ProcessVariableJsonNodeConverter();
+    public ProcessVariableValueSpringConverter<JsonNode> processVariableJsonNodeConverter(
+        ObjectMapper objectMapper) {
+        return new ProcessVariableJsonNodeConverter(objectMapper);
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.activiti.cloud.services.core.ProcessVariableDateConverter;
 import org.activiti.cloud.services.core.ProcessVariableJsonNodeConverter;
 import org.activiti.cloud.services.core.ProcessVariableValueConverter;
 import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
-import org.activiti.cloud.services.core.SpringProcessVariableValueConverter;
+import org.activiti.cloud.services.core.ProcessVariableValueSpringConverter;
 import org.activiti.cloud.services.core.commands.ClaimTaskCmdExecutor;
 import org.activiti.cloud.services.core.commands.CommandEndpoint;
 import org.activiti.cloud.services.core.commands.CommandExecutor;
@@ -193,18 +193,18 @@ public class ServicesCoreAutoConfiguration {
     }
 
     @Bean
-    public SpringProcessVariableValueConverter<Date> processVariableDateConverter(DateFormatterProvider dateFormatterProvider) {
+    public ProcessVariableValueSpringConverter<Date> processVariableDateConverter(DateFormatterProvider dateFormatterProvider) {
         return new ProcessVariableDateConverter(dateFormatterProvider);
     }
 
     @Bean
-    public SpringProcessVariableValueConverter<JsonNode> processVariableJsonNodeConverter() {
+    public ProcessVariableValueSpringConverter<JsonNode> processVariableJsonNodeConverter() {
         return new ProcessVariableJsonNodeConverter();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public ProcessVariableValueConverter processVariableValueConverter(List<SpringProcessVariableValueConverter<?>> converters,
+    public ProcessVariableValueConverter processVariableValueConverter(List<ProcessVariableValueSpringConverter<?>> converters,
                                                                        DateFormatterProvider dateFormatterProvider) {
         FormattingConversionService conversionService = new ApplicationConversionService();
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -16,12 +16,20 @@
 
 package org.activiti.cloud.services.core.conf;
 
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import org.activiti.api.model.shared.Payload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
+import org.activiti.cloud.services.core.ProcessVariableDateConverter;
+import org.activiti.cloud.services.core.ProcessVariableJsonNodeConverter;
+import org.activiti.cloud.services.core.ProcessVariableValueConverter;
+import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
+import org.activiti.cloud.services.core.SpringProcessVariableValueConverter;
 import org.activiti.cloud.services.core.commands.ClaimTaskCmdExecutor;
 import org.activiti.cloud.services.core.commands.CommandEndpoint;
 import org.activiti.cloud.services.core.commands.CommandExecutor;
@@ -42,12 +50,18 @@ import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.core.pageable.sort.ProcessDefinitionSortApplier;
 import org.activiti.cloud.services.core.pageable.sort.ProcessInstanceSortApplier;
 import org.activiti.cloud.services.core.pageable.sort.TaskSortApplier;
+import org.activiti.common.util.DateFormatterProvider;
 import org.activiti.image.ProcessDiagramGenerator;
 import org.activiti.image.impl.DefaultProcessDiagramGenerator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
+import org.springframework.format.support.FormattingConversionService;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 @Configuration
 @PropertySource("classpath:config/command-endpoint-channels.properties")
@@ -57,13 +71,13 @@ public class ServicesCoreAutoConfiguration {
     public SpringPageConverter pageConverter(){
         return new SpringPageConverter();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ClaimTaskCmdExecutor claimTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime) {
         return new ClaimTaskCmdExecutor(taskAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CompleteTaskCmdExecutor completeTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime) {
@@ -75,31 +89,31 @@ public class ServicesCoreAutoConfiguration {
     public CreateTaskVariableCmdExecutor createTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime) {
         return new CreateTaskVariableCmdExecutor(taskAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ReleaseTaskCmdExecutor releaseTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime) {
         return new ReleaseTaskCmdExecutor(taskAdminRuntime);
-    }    
+    }
 
     @Bean
     @ConditionalOnMissingBean
     public UpdateTaskVariableCmdExecutor updateTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime) {
         return new UpdateTaskVariableCmdExecutor(taskAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public RemoveProcessVariablesCmdExecutor removeProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new RemoveProcessVariablesCmdExecutor(processAdminRuntime);
-    }    
+    }
 
     @Bean
     @ConditionalOnMissingBean
     public ResumeProcessInstanceCmdExecutor resumeProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new ResumeProcessInstanceCmdExecutor(processAdminRuntime);
-    }  
-    
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public SetProcessVariablesCmdExecutor setProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
@@ -111,7 +125,7 @@ public class ServicesCoreAutoConfiguration {
     public SignalCmdExecutor signalCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new SignalCmdExecutor(processAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public StartProcessInstanceCmdExecutor startProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
@@ -122,7 +136,7 @@ public class ServicesCoreAutoConfiguration {
     @ConditionalOnMissingBean
     public SuspendProcessInstanceCmdExecutor suspendProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new SuspendProcessInstanceCmdExecutor(processAdminRuntime);
-    }    
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -135,49 +149,78 @@ public class ServicesCoreAutoConfiguration {
     public ReceiveMessageCmdExecutor receiveMessageCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new ReceiveMessageCmdExecutor(processAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public DeleteProcessInstanceCmdExecutor deleteProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new DeleteProcessInstanceCmdExecutor(processAdminRuntime);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public <T extends Payload> CommandEndpoint<T> commandEndpoint(Set<CommandExecutor<T>> cmdExecutors) {
         return new CommandEndpoint<T>(cmdExecutors);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ProcessDefinitionSortApplier processDefinitionSortApplier() {
         return new ProcessDefinitionSortApplier();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ProcessInstanceSortApplier processInstanceSortApplier() {
         return new ProcessInstanceSortApplier();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public TaskSortApplier taskSortApplier() {
         return new TaskSortApplier();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ProcessDiagramGenerator processDiagramGenerator() {
         return new DefaultProcessDiagramGenerator();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ProcessDiagramGeneratorWrapper processDiagramGeneratorWrapper(ProcessDiagramGenerator processDiagramGenerator) {
         return new ProcessDiagramGeneratorWrapper(processDiagramGenerator);
-        
     }
-    
 
+    @Bean
+    public SpringProcessVariableValueConverter<Date> processVariableDateConverter(DateFormatterProvider dateFormatterProvider) {
+        return new ProcessVariableDateConverter(dateFormatterProvider);
+    }
+
+    @Bean
+    public SpringProcessVariableValueConverter<JsonNode> processVariableJsonNodeConverter() {
+        return new ProcessVariableJsonNodeConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessVariableValueConverter processVariableValueConverter(List<SpringProcessVariableValueConverter<?>> converters,
+                                                                       DateFormatterProvider dateFormatterProvider) {
+        FormattingConversionService conversionService = new ApplicationConversionService();
+
+        converters.forEach(conversionService::addConverter);
+
+        DateTimeFormatterRegistrar registrar = new DateTimeFormatterRegistrar();
+        registrar.setDateFormatter(DateTimeFormatter.ofPattern(dateFormatterProvider.getDateFormatPattern()));
+        registrar.setDateTimeFormatter(DateTimeFormatter.ofPattern(dateFormatterProvider.getDateFormatPattern()));
+        registrar.registerFormatters(conversionService);
+
+        return new ProcessVariableValueConverter(conversionService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessVariablesPayloadConverter processVariablesPayloadConverter(ProcessVariableValueConverter variableValueConverter) {
+        return new ProcessVariablesPayloadConverter(variableValueConverter);
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariableValueConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariableValueConverterTest.java
@@ -1,0 +1,162 @@
+package org.activiti.cloud.services.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import org.activiti.cloud.services.api.model.ProcessVariableValue;
+import org.activiti.cloud.services.core.utils.TestProcessEngineConfiguration;
+import org.activiti.common.util.DateFormatterProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = TestProcessEngineConfiguration.class)
+@TestPropertySource("classpath:test-application.properties")
+public class ProcessVariableValueConverterTest {
+
+    private static final String DATE_1970_01_01T01_01_01_001Z = "1970-01-01T01:01:01.001Z";
+
+    @Autowired
+    private ProcessVariableValueConverter variableValueConverter;
+
+    @Autowired
+    private DateFormatterProvider dateFormatterProvider;
+
+    @Test
+    public void testProcessVariableValueConverterNullValue() {
+        // when
+        String nullValue = variableValueConverter.convert(new ProcessVariableValue("String", null));
+
+        // then
+        assertThat(nullValue).isNull();
+    }
+
+    @Test
+    public void testProcessVariableValueConverterStringValue() {
+        // when
+        String stringValue = variableValueConverter.convert(new ProcessVariableValue("string", "name"));
+
+        // then
+        assertThat(stringValue).isEqualTo("name");
+    }
+
+    @Test
+    public void testProcessVariableValueConverterIntValue() {
+        // when
+        Integer intValue = variableValueConverter.convert(new ProcessVariableValue("int", "10"));
+
+        // then
+        assertThat(intValue).isEqualTo(10);
+    }
+
+    @Test
+    public void testProcessVariableValueConverterLongValue() {
+        // when
+        Long longValue = variableValueConverter.convert(new ProcessVariableValue("long", "10"));
+
+        // then
+        assertThat(longValue).isEqualTo(10L);
+    }
+
+    @Test
+    public void testProcessVariableValueConverterBooleanValue() {
+        // when
+        Boolean booleanValue = variableValueConverter.convert(new ProcessVariableValue("boolean", "true"));
+
+        // then
+        assertThat(booleanValue).isEqualTo(true);
+    }
+
+    @Test
+    public void testProcessVariableValueConverterDoubleValue() {
+        // when
+        Double doubleValue = variableValueConverter.convert(new ProcessVariableValue("double", "10.00"));
+
+        // then
+        assertThat(doubleValue).isEqualTo(10.00);
+    }
+
+    @Test
+    public void testProcessVariableValueConverterlocalDateValue() {
+        // when
+        String nullValue = variableValueConverter.convert(new ProcessVariableValue("String", null));
+        String stringValue = variableValueConverter.convert(new ProcessVariableValue("string", "name"));
+        Integer intValue = variableValueConverter.convert(new ProcessVariableValue("int", "10"));
+        Long longValue = variableValueConverter.convert(new ProcessVariableValue("long", "10"));
+        Boolean booleanValue = variableValueConverter.convert(new ProcessVariableValue("boolean", "true"));
+        Double doubleValue = variableValueConverter.convert(new ProcessVariableValue("double", "10.00"));
+        LocalDate localDateValue = variableValueConverter.convert(new ProcessVariableValue("LocalDate", "2020-04-20"));
+        Date dateValue = variableValueConverter.convert(new ProcessVariableValue("Date", DATE_1970_01_01T01_01_01_001Z));
+        BigDecimal bigDecimalValue = variableValueConverter.convert(new ProcessVariableValue("BigDecimal", "10.00"));
+        JsonNode jsonNodeValue = variableValueConverter.convert(new ProcessVariableValue("JsonNode", "{}"));
+        Map<String, Object> mapValue = variableValueConverter.convert(new ProcessVariableValue("Map", "{}"));
+
+        // then
+        assertThat(nullValue).isNull();
+        assertThat(stringValue).isEqualTo("name");
+        assertThat(intValue).isEqualTo(10);
+        assertThat(longValue).isEqualTo(10L);
+        assertThat(booleanValue).isEqualTo(true);
+        assertThat(doubleValue).isEqualTo(10.00);
+        assertThat(localDateValue).isEqualTo(LocalDate.of(2020, 4, 20));
+        assertThat(dateValue).isEqualTo(dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z));
+        assertThat(bigDecimalValue).isEqualTo(BigDecimal.valueOf(1000, 2));
+        assertThat(jsonNodeValue).isEqualTo(JsonNodeFactory.instance.objectNode());
+        assertThat(mapValue).isEqualTo(Collections.emptyMap());
+    }
+
+
+    @Test
+    public void testProcessVariableValueConverterLocalDateValue() {
+        // when
+        LocalDate localDateValue = variableValueConverter.convert(new ProcessVariableValue("LocalDate", "2020-04-20"));
+
+        // then
+        assertThat(localDateValue).isEqualTo(LocalDate.of(2020, 4, 20));
+    }
+
+    @Test
+    public void testProcessVariableValueConverterDateValue() {
+        // when
+        Date dateValue = variableValueConverter.convert(new ProcessVariableValue("Date", DATE_1970_01_01T01_01_01_001Z));
+
+        // then
+        assertThat(dateValue).isEqualTo(dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z));
+    }
+
+    @Test
+    public void testProcessVariableValueConverterBigDecimalValue() {
+        // when
+        BigDecimal bigDecimalValue = variableValueConverter.convert(new ProcessVariableValue("BigDecimal", "10.00"));
+
+        // then
+        assertThat(bigDecimalValue).isEqualTo(BigDecimal.valueOf(1000, 2));
+    }
+
+    @Test
+    public void testProcessVariableValueConverterJsonNodeValue() {
+        // when
+        JsonNode jsonNodeValue = variableValueConverter.convert(new ProcessVariableValue("JsonNode", "{}"));
+
+        // then
+        assertThat(jsonNodeValue).isEqualTo(JsonNodeFactory.instance.objectNode());
+    }
+
+    @Test
+    public void testProcessVariableValueConverterMapValue() {
+        // when
+        Map<String, Object> mapValue = variableValueConverter.convert(new ProcessVariableValue("Map", "{}"));
+
+        // then
+        assertThat(mapValue).isEqualTo(Collections.emptyMap());
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariableValueConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariableValueConverterTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.Date;
-import java.util.Map;
 
 import org.activiti.cloud.services.api.model.ProcessVariableValue;
 import org.activiti.cloud.services.core.utils.TestProcessEngineConfiguration;
@@ -86,36 +84,6 @@ public class ProcessVariableValueConverterTest {
     }
 
     @Test
-    public void testProcessVariableValueConverterlocalDateValue() {
-        // when
-        String nullValue = variableValueConverter.convert(new ProcessVariableValue("String", null));
-        String stringValue = variableValueConverter.convert(new ProcessVariableValue("string", "name"));
-        Integer intValue = variableValueConverter.convert(new ProcessVariableValue("int", "10"));
-        Long longValue = variableValueConverter.convert(new ProcessVariableValue("long", "10"));
-        Boolean booleanValue = variableValueConverter.convert(new ProcessVariableValue("boolean", "true"));
-        Double doubleValue = variableValueConverter.convert(new ProcessVariableValue("double", "10.00"));
-        LocalDate localDateValue = variableValueConverter.convert(new ProcessVariableValue("LocalDate", "2020-04-20"));
-        Date dateValue = variableValueConverter.convert(new ProcessVariableValue("Date", DATE_1970_01_01T01_01_01_001Z));
-        BigDecimal bigDecimalValue = variableValueConverter.convert(new ProcessVariableValue("BigDecimal", "10.00"));
-        JsonNode jsonNodeValue = variableValueConverter.convert(new ProcessVariableValue("JsonNode", "{}"));
-        Map<String, Object> mapValue = variableValueConverter.convert(new ProcessVariableValue("Map", "{}"));
-
-        // then
-        assertThat(nullValue).isNull();
-        assertThat(stringValue).isEqualTo("name");
-        assertThat(intValue).isEqualTo(10);
-        assertThat(longValue).isEqualTo(10L);
-        assertThat(booleanValue).isEqualTo(true);
-        assertThat(doubleValue).isEqualTo(10.00);
-        assertThat(localDateValue).isEqualTo(LocalDate.of(2020, 4, 20));
-        assertThat(dateValue).isEqualTo(dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z));
-        assertThat(bigDecimalValue).isEqualTo(BigDecimal.valueOf(1000, 2));
-        assertThat(jsonNodeValue).isEqualTo(JsonNodeFactory.instance.objectNode());
-        assertThat(mapValue).isEqualTo(Collections.emptyMap());
-    }
-
-
-    @Test
     public void testProcessVariableValueConverterLocalDateValue() {
         // when
         LocalDate localDateValue = variableValueConverter.convert(new ProcessVariableValue("LocalDate", "2020-04-20"));
@@ -145,18 +113,10 @@ public class ProcessVariableValueConverterTest {
     @Test
     public void testProcessVariableValueConverterJsonNodeValue() {
         // when
-        JsonNode jsonNodeValue = variableValueConverter.convert(new ProcessVariableValue("JsonNode", "{}"));
+        JsonNode jsonNodeValue = variableValueConverter.convert(new ProcessVariableValue("json", "{}"));
 
         // then
         assertThat(jsonNodeValue).isEqualTo(JsonNodeFactory.instance.objectNode());
     }
 
-    @Test
-    public void testProcessVariableValueConverterMapValue() {
-        // when
-        Map<String, Object> mapValue = variableValueConverter.convert(new ProcessVariableValue("Map", "{}"));
-
-        // then
-        assertThat(mapValue).isEqualTo(Collections.emptyMap());
-    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,12 +46,11 @@ public class ProcessVariablesPayloadConverterTest {
         input.put("longValue", new ProcessVariableValue("long", "10").toMap());
         input.put("booleanValue", new ProcessVariableValue("boolean", "true").toMap());
         input.put("doubleValue", new ProcessVariableValue("double", "10.00").toMap());
-        input.put("localDateValue", new ProcessVariableValue("LocalDate", "2020-04-20").toMap());
-        input.put("dateValue", new ProcessVariableValue("Date", DATE_1970_01_01T01_01_01_001Z).toMap());
+        input.put("localDateValue", new ProcessVariableValue("localdate", "2020-04-20").toMap());
+        input.put("dateValue", new ProcessVariableValue("date", DATE_1970_01_01T01_01_01_001Z).toMap());
         input.put("bigDecimalValue", new ProcessVariableValue("BigDecimal", "10.00").toMap());
-        input.put("jsonNodeValue", new ProcessVariableValue("JsonNode", "{}").toMap());
-        input.put("jsonNodeValue2", new ProcessVariableValue("JsonNode", "{}"));
-        input.put("mapValue", new ProcessVariableValue("Map", "{}").toMap());
+        input.put("jsonNodeValue", new ProcessVariableValue("json", "{}").toMap());
+        input.put("jsonNodeValue2", new ProcessVariableValue("json", "{}"));
 
         // when
         StartProcessPayload result = subject.convert(ProcessPayloadBuilder.start()
@@ -73,8 +71,7 @@ public class ProcessVariablesPayloadConverterTest {
                           .containsEntry("dateValue", dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z))
                           .containsEntry("bigDecimalValue", BigDecimal.valueOf(1000, 2))
                           .containsEntry("jsonNodeValue", JsonNodeFactory.instance.objectNode())
-                          .containsEntry("jsonNodeValue2", JsonNodeFactory.instance.objectNode())
-                          .containsEntry("mapValue", Collections.emptyMap());
+                          .containsEntry("jsonNodeValue2", JsonNodeFactory.instance.objectNode());
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessVariablesPayloadConverterTest.java
@@ -1,0 +1,80 @@
+package org.activiti.cloud.services.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.StartProcessPayload;
+import org.activiti.cloud.services.api.model.ProcessVariableValue;
+import org.activiti.cloud.services.core.utils.TestProcessEngineConfiguration;
+import org.activiti.common.util.DateFormatterProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = TestProcessEngineConfiguration.class)
+@TestPropertySource("classpath:test-application.properties")
+public class ProcessVariablesPayloadConverterTest {
+
+    private static final String DATE_1970_01_01T01_01_01_001Z = "1970-01-01T01:01:01.001Z";
+
+    @Autowired
+    private ProcessVariablesPayloadConverter subject;
+
+    @Autowired
+    private DateFormatterProvider dateFormatterProvider;
+
+    @Test
+    public void testProcessVariablesPayloadConverter() {
+        // given
+        Map<String, Object> input = new HashMap<>();
+
+        input.put("int", 123);
+        input.put("string", "123");
+        input.put("bool", true);
+        input.put("nullValue", new ProcessVariableValue("String", null).toMap());
+        input.put("stringValue", new ProcessVariableValue("string", "name").toMap());
+        input.put("quoteValue", new ProcessVariableValue("string", "\"").toMap());
+        input.put("intValue", new ProcessVariableValue("int", "10").toMap());
+        input.put("longValue", new ProcessVariableValue("long", "10").toMap());
+        input.put("booleanValue", new ProcessVariableValue("boolean", "true").toMap());
+        input.put("doubleValue", new ProcessVariableValue("double", "10.00").toMap());
+        input.put("localDateValue", new ProcessVariableValue("LocalDate", "2020-04-20").toMap());
+        input.put("dateValue", new ProcessVariableValue("Date", DATE_1970_01_01T01_01_01_001Z).toMap());
+        input.put("bigDecimalValue", new ProcessVariableValue("BigDecimal", "10.00").toMap());
+        input.put("jsonNodeValue", new ProcessVariableValue("JsonNode", "{}").toMap());
+        input.put("jsonNodeValue2", new ProcessVariableValue("JsonNode", "{}"));
+        input.put("mapValue", new ProcessVariableValue("Map", "{}").toMap());
+
+        // when
+        StartProcessPayload result = subject.convert(ProcessPayloadBuilder.start()
+                                                                          .withVariables(input)
+                                                                          .build());
+        // then
+        assertThat(result.getVariables()).containsEntry("int", 123)
+                          .containsEntry("string", "123")
+                          .containsEntry("bool", true)
+                          .containsEntry("nullValue", null)
+                          .containsEntry("stringValue", "name")
+                          .containsEntry("quoteValue", "\"")
+                          .containsEntry("intValue", 10)
+                          .containsEntry("longValue", 10L)
+                          .containsEntry("booleanValue", true)
+                          .containsEntry("doubleValue", 10.00)
+                          .containsEntry("localDateValue", LocalDate.of(2020, 4, 20))
+                          .containsEntry("dateValue", dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z))
+                          .containsEntry("bigDecimalValue", BigDecimal.valueOf(1000, 2))
+                          .containsEntry("jsonNodeValue", JsonNodeFactory.instance.objectNode())
+                          .containsEntry("jsonNodeValue2", JsonNodeFactory.instance.objectNode())
+                          .containsEntry("mapValue", Collections.emptyMap());
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -25,6 +25,7 @@ import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.rest.api.ProcessInstanceAdminController;
 import org.activiti.cloud.services.rest.assemblers.ProcessInstanceResourceAssembler;
@@ -48,14 +49,18 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
 
     private final SpringPageConverter pageConverter;
 
+    private final ProcessVariablesPayloadConverter variablesPayloadConverter;
+
     public ProcessInstanceAdminControllerImpl(ProcessInstanceResourceAssembler resourceAssembler,
                                               AlfrescoPagedResourcesAssembler<ProcessInstance> pagedResourcesAssembler,
                                               ProcessAdminRuntime processAdminRuntime,
-                                              SpringPageConverter pageConverter) {
+                                              SpringPageConverter pageConverter,
+                                              ProcessVariablesPayloadConverter variablesPayloadConverter) {
         this.resourceAssembler = resourceAssembler;
         this.pagedResourcesAssembler = pagedResourcesAssembler;
         this.processAdminRuntime = processAdminRuntime;
         this.pageConverter = pageConverter;
+        this.variablesPayloadConverter = variablesPayloadConverter;
     }
 
     @Override
@@ -65,10 +70,12 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
                                                   pageConverter.toSpringPage(pageable, processInstancePage),
                                                   resourceAssembler);
     }
-   
+
     @Override
     public Resource<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload startProcessPayload) {
-        return resourceAssembler.toResource(processAdminRuntime.start(startProcessPayload));
+        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+
+        return resourceAssembler.toResource(processAdminRuntime.start(convertedStartProcessPayload));
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -121,6 +121,8 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
 
     @Override
     public Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload) {
+        startMessagePayload = variablesPayloadConverter.convert(startMessagePayload);
+
         ProcessInstance processInstance = processAdminRuntime.start(startMessagePayload);
 
         return resourceAssembler.toResource(processInstance);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -32,6 +32,7 @@ import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
+import org.activiti.cloud.services.core.ProcessVariablesPayloadConverter;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.rest.api.ProcessInstanceController;
 import org.activiti.cloud.services.rest.assemblers.ProcessInstanceResourceAssembler;
@@ -61,19 +62,23 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     private final SpringPageConverter pageConverter;
 
+    private final ProcessVariablesPayloadConverter variablesPayloadConverter;
+
     @Autowired
     public ProcessInstanceControllerImpl(RepositoryService repositoryService,
                                          ProcessDiagramGeneratorWrapper processDiagramGenerator,
                                          ProcessInstanceResourceAssembler resourceAssembler,
                                          AlfrescoPagedResourcesAssembler<ProcessInstance> pagedResourcesAssembler,
                                          ProcessRuntime processRuntime,
-                                         SpringPageConverter pageConverter) {
+                                         SpringPageConverter pageConverter,
+                                         ProcessVariablesPayloadConverter variablesPayloadConverter) {
         this.repositoryService = repositoryService;
         this.processDiagramGenerator = processDiagramGenerator;
         this.resourceAssembler = resourceAssembler;
         this.pagedResourcesAssembler = pagedResourcesAssembler;
         this.processRuntime = processRuntime;
         this.pageConverter = pageConverter;
+        this.variablesPayloadConverter = variablesPayloadConverter;
     }
 
     @Override
@@ -86,7 +91,9 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload startProcessPayload) {
-        return resourceAssembler.toResource(processRuntime.start(startProcessPayload));
+        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+
+        return resourceAssembler.toResource(processRuntime.start(convertedStartProcessPayload));
     }
 
     @Override
@@ -96,7 +103,9 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> createProcessInstance(@RequestBody StartProcessPayload startProcessPayload) {
-        return resourceAssembler.toResource(processRuntime.create(startProcessPayload));
+        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+
+        return resourceAssembler.toResource(processRuntime.create(convertedStartProcessPayload));
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -91,9 +91,9 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload startProcessPayload) {
-        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+        startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
 
-        return resourceAssembler.toResource(processRuntime.start(convertedStartProcessPayload));
+        return resourceAssembler.toResource(processRuntime.start(startProcessPayload));
     }
 
     @Override
@@ -103,9 +103,9 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> createProcessInstance(@RequestBody StartProcessPayload startProcessPayload) {
-        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+        startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
 
-        return resourceAssembler.toResource(processRuntime.create(convertedStartProcessPayload));
+        return resourceAssembler.toResource(processRuntime.create(startProcessPayload));
     }
 
     @Override
@@ -119,11 +119,10 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
         BpmnModel bpmnModel = repositoryService.getBpmnModel(processInstance.getProcessDefinitionId());
         return new String(processDiagramGenerator.generateDiagram(bpmnModel,
-                processRuntime
-                        .processInstanceMeta(processInstance.getId())
-                        .getActiveActivitiesIds(),
-                emptyList()),
-                StandardCharsets.UTF_8);
+                                                                  processRuntime.processInstanceMeta(processInstance.getId())
+                                                                                .getActiveActivitiesIds(),
+                                                                  emptyList()),
+                          StandardCharsets.UTF_8);
     }
 
     @Override
@@ -172,6 +171,8 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> sendStartMessage(@RequestBody StartMessagePayload startMessagePayload) {
+        startMessagePayload = variablesPayloadConverter.convert(startMessagePayload);
+
         ProcessInstance processInstance = processRuntime.start(startMessagePayload);
 
         return resourceAssembler.toResource(processInstance);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/MessageRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/MessageRestTemplate.java
@@ -45,11 +45,19 @@ public class MessageRestTemplate {
                                          });
     }
 
+    public ResponseEntity<CloudProcessInstance> adminMessage(StartMessagePayload payload) {
+        return testRestTemplate.exchange(ProcessInstanceRestTemplate.PROCESS_INSTANCES_ADMIN_RELATIVE_URL + "/message",
+                                         HttpMethod.POST,
+                                         new HttpEntity<>(payload),
+                                         new ParameterizedTypeReference<CloudProcessInstance>() {
+                                         });
+    }
+
     public ResponseEntity<Void> message(ReceiveMessagePayload payload) {
         return testRestTemplate.exchange(PROCESS_INSTANCES_RELATIVE_URL + "/message",
                                          HttpMethod.PUT,
                                          new HttpEntity<>(payload),
                                          new ParameterizedTypeReference<Void>() {
                                          });
-    }     
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -16,9 +16,12 @@
 
 package org.activiti.cloud.starter.tests.helper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.RemoveProcessVariablesPayload;
@@ -29,7 +32,6 @@ import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
-import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.util.IoUtil;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -45,14 +47,12 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @TestComponent
 public class ProcessInstanceRestTemplate {
 
     public static final String PROCESS_INSTANCES_RELATIVE_URL = "/v1/process-instances/";
 
-    private static final String PROCESS_INSTANCES_ADMIN_RELATIVE_URL = "/admin/v1/process-instances/";
+    public static final String PROCESS_INSTANCES_ADMIN_RELATIVE_URL = "/admin/v1/process-instances/";
 
     private TestRestTemplate testRestTemplate;
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -72,8 +73,22 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 @DirtiesContext
 @ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class ProcessVariablesIT {
+    private static final String LONG = "long";
+    private static final String INTEGER = "integer";
+    private static final String JSON = "json";
+    private static final String STRING = "string";
+    private static final String DOUBLE = "double";
+    private static final String BOOLEAN = "boolean";
+    private static final String INT = "int";
+    private static final String BIG_DECIMAL_VARIABLE = "bigDecimalVariable";
+    private static final String DATE_VARIABLE = "dateVariable";
+    private static final String BOOLEAN_VARIABLE = "booleanVariable";
+    private static final String DOUBLE_VARIABLE = "doubleVariable";
+    private static final String LONG_VARIABLE = "longVariable";
+    private static final String INT_VARIABLE = "intVariable";
+    private static final String STRING_VARIABLE = "stringVariable";
+    private static final String JSON_VARIABLE = "jsonVariable";
     private static final String START_MESSAGE = "startMessage";
-
     private static final String DATE_1970_01_01T01_01_01_001Z = "1970-01-01T01:01:01.001Z";
 
     @Autowired
@@ -499,11 +514,11 @@ public class ProcessVariablesIT {
                     .extracting(CloudVariableInstance::getName,
                             CloudVariableInstance::getType)
                     .containsOnly(tuple("variableInt",
-                            "integer"),
+                            INTEGER),
                             tuple("variableStr",
-                                    "string"),
+                                    STRING),
                             tuple("variableBool",
-                                    "boolean"),
+                                    BOOLEAN),
                             tuple("variableDateTime",
                                     "date"),
                             tuple("variableDate",
@@ -576,13 +591,13 @@ public class ProcessVariablesIT {
                             CloudVariableInstance::getType,
                             CloudVariableInstance::getValue)
                     .contains(tuple("variableInt",
-                            "integer",
+                            INTEGER,
                             2),
                             tuple("variableStr",
-                                    "string",
+                                    STRING,
                                     "new value"),
                             tuple("variableBool",
-                                    "boolean",
+                                    BOOLEAN,
                                     false),
                             tuple("variableDateTime",
                                     "date",
@@ -645,9 +660,10 @@ public class ProcessVariablesIT {
         // given
         StartProcessPayload startProcessPayload = testStartProcessPayload();
 
+
         // when
-        CloudProcessInstance processInstance = processInstanceRestTemplate.startProcess(startProcessPayload)
-                                                                          .getBody();
+        ResponseEntity<CloudProcessInstance> processInstanceResponseEntity = processInstanceRestTemplate.startProcess(startProcessPayload);
+        CloudProcessInstance processInstance = processInstanceResponseEntity.getBody();
 
         // then
         List<VariableInstance> variableInstances = processRuntime.variables(ProcessPayloadBuilder.variables()
@@ -739,27 +755,29 @@ public class ProcessVariablesIT {
     private Map<String, Object> testProcessVariableValues() {
         Map<String, Object> variables = new LinkedHashMap<>();
 
-        ProcessVariableValue jsonValue = new ProcessVariableValue("json", "{}");
-        Map<String, String> stringValue = new ProcessVariableValue("string", "name").toMap();
-        Map<String, String> intValue = new ProcessVariableValue("integer", "10").toMap();
-        Map<String, String> longValue = new ProcessVariableValue("long", "10").toMap();
-        Map<String, String> booleanValue = new ProcessVariableValue("boolean", "true").toMap();
-        Map<String, String> doubleValue = new ProcessVariableValue("double", "10.00").toMap();
+        ProcessVariableValue jsonValue = new ProcessVariableValue(JSON, "{}");
+        Map<String, String> stringValue = new ProcessVariableValue(STRING, "name").toMap();
+        Map<String, String> intValue = new ProcessVariableValue(INTEGER, "10").toMap();
+        Map<String, String> longValue = new ProcessVariableValue(LONG, "10").toMap();
+        Map<String, String> booleanValue = new ProcessVariableValue(BOOLEAN, "true").toMap();
+        Map<String, String> doubleValue = new ProcessVariableValue(DOUBLE, "10.00").toMap();
         Map<String, String> dateValue = new ProcessVariableValue("date", DATE_1970_01_01T01_01_01_001Z).toMap();
-        Map<String, String> bigDecimalValue = new ProcessVariableValue("BigDecimal", "10.00").toMap();
+        Map<String, String> bigDecimalValue = new ProcessVariableValue("bigdecimal", "10.00").toMap();
 
-        variables.put("jsonValue", jsonValue);
-        variables.put("stringValue", stringValue);
-        variables.put("intValue", intValue);
-        variables.put("longValue", longValue);
-        variables.put("doubleValue", doubleValue);
-        variables.put("booleanValue", booleanValue);
-        variables.put("dateValue", dateValue);
-        variables.put("bigDecimalValue", bigDecimalValue);
-        variables.put("int", 10);
-        variables.put("boolean", true);
-        variables.put("double", 10.00);
-        variables.put("string", "name");
+        variables.put(JSON_VARIABLE, jsonValue);
+        variables.put(STRING_VARIABLE, stringValue);
+        variables.put(INT_VARIABLE, intValue);
+        variables.put(LONG_VARIABLE, longValue);
+        variables.put(DOUBLE_VARIABLE, doubleValue);
+        variables.put(BOOLEAN_VARIABLE, booleanValue);
+        variables.put(DATE_VARIABLE, dateValue);
+        variables.put(BIG_DECIMAL_VARIABLE, bigDecimalValue);
+        variables.put(INT, 10);
+        variables.put(INTEGER, 10);
+        variables.put(BOOLEAN, true);
+        variables.put(DOUBLE, 10.00);
+        variables.put(STRING, "name");
+        variables.put(JSON, Collections.singletonMap("key", "data"));
 
         return variables;
     }
@@ -767,19 +785,20 @@ public class ProcessVariablesIT {
     private void asserStartProcessPayloadVariablesAreConverted(List<VariableInstance> variableInstances) {
         assertThat(variableInstances).isNotNull()
                                      .extracting("name", "value")
-                                     .contains(tuple("jsonValue", JsonNodeFactory.instance.objectNode()),
-                                               tuple("stringValue", "name"),
-                                               tuple("intValue", 10),
-                                               tuple("longValue", 10L),
-                                               tuple("doubleValue", 10.00),
-                                               tuple("booleanValue", true),
-                                               tuple("dateValue",
-                                                     dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z)),
-                                               tuple("bigDecimalValue", BigDecimal.valueOf(1000, 2)),
-                                               tuple("int", 10),
-                                               tuple("double", 10.00),
-                                               tuple("boolean", true),
-                                               tuple("string", "name")
+                                     .contains(tuple(JSON_VARIABLE, JsonNodeFactory.instance.objectNode()),
+                                               tuple(STRING_VARIABLE, "name"),
+                                               tuple(INT_VARIABLE, 10),
+                                               tuple(LONG_VARIABLE, 10L),
+                                               tuple(DOUBLE_VARIABLE, 10.00),
+                                               tuple(BOOLEAN_VARIABLE, true),
+                                               tuple(DATE_VARIABLE, dateFormatterProvider.parse(DATE_1970_01_01T01_01_01_001Z)),
+                                               tuple(BIG_DECIMAL_VARIABLE, BigDecimal.valueOf(1000, 2)),
+                                               tuple(INT, 10),
+                                               tuple(INTEGER, 10),
+                                               tuple(DOUBLE, 10.00),
+                                               tuple(BOOLEAN, true),
+                                               tuple(STRING, "name"),
+                                               tuple(JSON, Collections.singletonMap("key", "data"))
                                      );
 
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -669,7 +669,7 @@ public class ProcessVariablesIT {
         List<VariableInstance> variableInstances = processRuntime.variables(ProcessPayloadBuilder.variables()
                                                                                                  .withProcessInstance(processInstance)
                                                                                                  .build());
-        asserStartProcessPayloadVariablesAreConverted(variableInstances);
+        assertStartProcessPayloadVariablesAreConverted(variableInstances);
 
         // cleanup
         processRuntime.delete(ProcessPayloadBuilder.delete(processInstance.getId()));
@@ -690,7 +690,7 @@ public class ProcessVariablesIT {
         List<VariableInstance> variableInstances = processRuntime.variables(ProcessPayloadBuilder.variables()
                                                                                                  .withProcessInstance(processInstance)
                                                                                                  .build());
-        asserStartProcessPayloadVariablesAreConverted(variableInstances);
+        assertStartProcessPayloadVariablesAreConverted(variableInstances);
 
         // cleanup
         processRuntime.delete(ProcessPayloadBuilder.delete(processInstance.getId()));
@@ -711,7 +711,7 @@ public class ProcessVariablesIT {
         List<VariableInstance> variableInstances = processRuntime.variables(ProcessPayloadBuilder.variables()
                                                                                                  .withProcessInstance(processInstance)
                                                                                                  .build());
-        asserStartProcessPayloadVariablesAreConverted(variableInstances);
+        assertStartProcessPayloadVariablesAreConverted(variableInstances);
 
         // cleanup
         processRuntime.delete(ProcessPayloadBuilder.delete(processInstance.getId()));
@@ -732,7 +732,7 @@ public class ProcessVariablesIT {
         List<VariableInstance> variableInstances = processRuntime.variables(ProcessPayloadBuilder.variables()
                                                                                                  .withProcessInstance(processInstance)
                                                                                                  .build());
-        asserStartProcessPayloadVariablesAreConverted(variableInstances);
+        assertStartProcessPayloadVariablesAreConverted(variableInstances);
 
         // cleanup
         processRuntime.delete(ProcessPayloadBuilder.delete(processInstance.getId()));
@@ -782,7 +782,7 @@ public class ProcessVariablesIT {
         return variables;
     }
 
-    private void asserStartProcessPayloadVariablesAreConverted(List<VariableInstance> variableInstances) {
+    private void assertStartProcessPayloadVariablesAreConverted(List<VariableInstance> variableInstances) {
         assertThat(variableInstances).isNotNull()
                                      .extracting("name", "value")
                                      .contains(tuple(JSON_VARIABLE, JsonNodeFactory.instance.objectNode()),

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/access-control.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/access-control.properties
@@ -13,7 +13,7 @@ activiti.security.policies[1].serviceName=test-app
 activiti.security.policies[2].name=MyPolicy for HR User
 activiti.security.policies[2].users=hruser
 activiti.security.policies[2].access=WRITE
-activiti.security.policies[2].keys=process_pool1,ProcessWithVariables,SimpleProcess,ProcessWithVariables2,ProcessWithBoundarySignal,SubProcess,ParentProcess,ProcessWithExtensionVariables
+activiti.security.policies[2].keys=process_pool1,ProcessWithVariables,SimpleProcess,ProcessWithVariables2,ProcessWithBoundarySignal,SubProcess,ParentProcess,ProcessWithExtensionVariables,shouldDeliverMessagesViaRestApi
 activiti.security.policies[2].serviceName=test-app
 
 activiti.security.policies[3].name=MyPolicy for HR Admin

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MessageIT.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MessageIT.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="Definitions_098ju69" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta">
-  <bpmn:process id="shouldDeliverMessagesViaRestApi" isExecutable="true">
+  <bpmn:process id="shouldDeliverMessagesViaRestApi" name="shouldDeliverMessagesViaRestApi" isExecutable="true">
     <bpmn:endEvent id="EndEvent_1yxwnmm">
       <bpmn:incoming>SequenceFlow_1vsdq0e</bpmn:incoming>
     </bpmn:endEvent>


### PR DESCRIPTION
This PR adds support for explicit variable types in StartProcessPayload variables key/value map. This enables backward compatibility with side-by-side implicit variable types from Json data format, i.e.

The implicit variables key/value map:
```
{
   "id":"06ea0c12-fd69-4a9d-8aa2-c8d5fb8dca2c",
   "processDefinitionId":null,
   "processDefinitionKey":"SingleTaskProcess",
   "name":null,
   "businessKey":null,
   "variables":{
      "dateVariable": "1970-01-01T01:01:01.001Z",
      "stringVariable":"name",
      "intVariable":10
      "booleanVariable":true,
      "doubleVariable":10.0,
      "jsonVariable": {   }
   }
}
```

The explicit variables key/value map with variables type and value container map:
```
{
   "id":"06ea0c12-fd69-4a9d-8aa2-c8d5fb8dca2c",
   "processDefinitionId":null,
   "processDefinitionKey":"SingleTaskProcess",
   "name":null,
   "businessKey":null,
   "variables":{
      "dateVariable":{
         "type":"date",
         "value":"1970-01-01T01:01:01.001Z"
      },
      "stringVariable":{
         "type":"string",
         "value":"name"
      },
      "bigDecimalVariable":{
         "type":"bigdecimal",
         "value":"10.00"
      },
      "longVariable":{
         "type":"long",
         "value":"10"
      },
      "intVariable":{
         "type":"integer",
         "value":"10"
      },
      "booleanVariable":{
         "type":"boolean",
         "value":"true"
      },
      "doubleVariable": {
         "type":"double",
         "value":"10.00"
      }
      "jsonVariable": {
         "type":"json",
         "value":"{}"
      }
   }
}
```

Test coverage includes support for the following types:

- [x] date
- [x] string
- [x] bigdecimal
- [x] long
- [x] integer / int
- [x] boolean
- [x] double
- [x] json

Depends on https://github.com/Activiti/Activiti/pull/3246