### PR TITLE
fix(version): update graphql-jpa-query to 0.4.7

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -14,7 +14,7 @@
   <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.4.6</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.4.7</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR updates graphql-jpa-query to 0.4.7 with the following bug fixes:

* fix(GH-232):  SimpleDateFormat is not threadsafe (#261) [cecb286](https://github.com/introproventures/graphql-jpa-query/commit/cecb286ecd3ef805c56e04f95fae28c239c50fc6)