### PR TITLE
fix(Connector): apply filter only for runtime errors generated by integration requests

### DIFF
--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/ErrorChannelServiceActivator.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/ErrorChannelServiceActivator.java
@@ -1,6 +1,6 @@
 package org.activiti.cloud.connectors.starter.channels;
 
-import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.messaging.support.ErrorMessage;
 
 public class ErrorChannelServiceActivator {
@@ -13,7 +13,7 @@ public class ErrorChannelServiceActivator {
         this.integrationErrorHandler = integrationErrorSender;
     }
 
-    @ServiceActivator(inputChannel = ERROR_CHANNEL)
+    @StreamListener(ERROR_CHANNEL)
     public void handleError(ErrorMessage errorMessage) {
         integrationErrorHandler.handleErrorMessage(errorMessage);
     }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImpl.java
@@ -1,7 +1,7 @@
 package org.activiti.cloud.connectors.starter.channels;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
-
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -11,8 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class IntegrationErrorHandlerImpl implements IntegrationErrorHandler {
     private static final String INTEGRATION_CONTEXT_ID = "integrationContextId";
@@ -49,14 +47,14 @@ public class IntegrationErrorHandlerImpl implements IntegrationErrorHandler {
         }
     }
 
-    protected boolean isIntegrationRequest(Message<?> message) {
+    private boolean isIntegrationRequest(Message<?> message) {
         return Optional.ofNullable(message)
                        .map(Message::getHeaders)
                        .map(headers -> headers.get(INTEGRATION_CONTEXT_ID))
                        .isPresent();
     }
 
-    protected void sendIntegrationError(ErrorMessage errorMessage) {
+    private void sendIntegrationError(ErrorMessage errorMessage) {
         byte[] data = (byte[]) errorMessage.getOriginalMessage()
                                            .getPayload();
         try {

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationRequestErrorChannelListener.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationRequestErrorChannelListener.java
@@ -3,13 +3,13 @@ package org.activiti.cloud.connectors.starter.channels;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.messaging.support.ErrorMessage;
 
-public class ErrorChannelServiceActivator {
+public class IntegrationRequestErrorChannelListener {
 
     private static final String ERROR_CHANNEL = "errorChannel";
 
     private final IntegrationErrorHandler integrationErrorHandler;
 
-    public ErrorChannelServiceActivator(IntegrationErrorHandler integrationErrorSender) {
+    public IntegrationRequestErrorChannelListener(IntegrationErrorHandler integrationErrorSender) {
         this.integrationErrorHandler = integrationErrorSender;
     }
 

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/configuration/ActivitiCloudConnectorAutoConfiguration.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/configuration/ActivitiCloudConnectorAutoConfiguration.java
@@ -1,6 +1,6 @@
 package org.activiti.cloud.connectors.starter.configuration;
 
-import org.activiti.cloud.connectors.starter.channels.ErrorChannelServiceActivator;
+import org.activiti.cloud.connectors.starter.channels.IntegrationRequestErrorChannelListener;
 import org.activiti.cloud.connectors.starter.channels.IntegrationErrorChannelResolver;
 import org.activiti.cloud.connectors.starter.channels.IntegrationErrorChannelResolverImpl;
 import org.activiti.cloud.connectors.starter.channels.IntegrationErrorDestinationBuilder;
@@ -50,8 +50,8 @@ public class ActivitiCloudConnectorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ErrorChannelServiceActivator errorChannelServiceActivator(IntegrationErrorHandler integrationErrorHandler) {
-        return new ErrorChannelServiceActivator(integrationErrorHandler);
+    public IntegrationRequestErrorChannelListener integrationRequestErrorChannelListener(IntegrationErrorHandler integrationErrorHandler) {
+        return new IntegrationRequestErrorChannelListener(integrationErrorHandler);
     }
 
     @Bean

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImplTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorHandlerImplTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.connectors.starter.channels;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class IntegrationErrorHandlerImplTest {
+
+    private static final String INTEGRATION_CONTEXT_ID = "integrationContextId";
+
+    private IntegrationErrorHandlerImpl integrationErrorHandler;
+
+    @Mock
+    private IntegrationErrorSender integrationErrorSender;
+
+    @Mock
+    private ConnectorProperties connectorProperties;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        integrationErrorHandler = new IntegrationErrorHandlerImpl(integrationErrorSender,
+            connectorProperties, new ObjectMapper());
+    }
+
+
+    @Test
+    public void handleErrorMessage_should_notThrowExceptionWhenOriginalMessageIsNotIntegrationRequest() {
+        //given
+        ErrorMessage errorMessage = new ErrorMessage(new MessagingException(
+            MessageBuilder
+                .withPayload("This is not an integration request".getBytes())
+                .setHeader(INTEGRATION_CONTEXT_ID, UUID.randomUUID().toString())
+                .build()));
+
+        //when
+        integrationErrorHandler.handleErrorMessage(errorMessage);
+
+        //then
+        Mockito.verifyNoInteractions(integrationErrorSender);
+    }
+}

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -86,13 +86,13 @@ public class ActivitiCloudConnectorServiceIT {
         integrationRequest.setServiceVersion("1");
         integrationRequest.setAppVersion("1");
 
-        Message<? extends IntegrationRequest> message = MessageBuilder.withPayload(integrationRequest)
+        Message<IntegrationRequest> message = MessageBuilder.<IntegrationRequest>withPayload(integrationRequest)
                 .setHeader("type",
                            "Mock")
                 .build();
         integrationEventsProducer.send(message);
 
-        message = MessageBuilder.withPayload((IntegrationRequest)integrationRequest)
+        message = MessageBuilder.<IntegrationRequest>withPayload(integrationRequest)
                 .setHeader("type",
                            "MockProcessRuntime")
                 .build();

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -27,8 +27,8 @@ import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,6 +43,8 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles(ConnectorsITStreamHandlers.CONNECTOR_IT)
 public class ActivitiCloudConnectorServiceIT {
+
+    private static final String INTEGRATION_CONTEXT_ID = "integrationContextId";
 
     @Autowired
     private MessageChannel integrationEventsProducer;
@@ -84,7 +86,7 @@ public class ActivitiCloudConnectorServiceIT {
         integrationRequest.setServiceVersion("1");
         integrationRequest.setAppVersion("1");
 
-        Message<IntegrationRequest> message = MessageBuilder.withPayload((IntegrationRequest)integrationRequest)
+        Message<? extends IntegrationRequest> message = MessageBuilder.withPayload(integrationRequest)
                 .setHeader("type",
                            "Mock")
                 .build();
@@ -110,7 +112,8 @@ public class ActivitiCloudConnectorServiceIT {
 
         IntegrationRequest integrationRequest = mockIntegrationRequest();
 
-        Message<IntegrationRequest> message = MessageBuilder.withPayload((IntegrationRequest) integrationRequest)
+        Message<IntegrationRequest> message = MessageBuilder.withPayload(integrationRequest)
+                                                            .setHeader(INTEGRATION_CONTEXT_ID, UUID.randomUUID().toString())
                                                             .setHeader("type",
                                                                        "RuntimeException")
                                                             .build();
@@ -134,7 +137,8 @@ public class ActivitiCloudConnectorServiceIT {
 
         IntegrationRequest integrationRequest = mockIntegrationRequest();
 
-        Message<IntegrationRequest> message = MessageBuilder.withPayload((IntegrationRequest) integrationRequest)
+        Message<IntegrationRequest> message = MessageBuilder.withPayload(integrationRequest)
+                                                            .setHeader(INTEGRATION_CONTEXT_ID, UUID.randomUUID().toString())
                                                             .setHeader("type",
                                                                        "Error")
                                                             .build();


### PR DESCRIPTION
This PR fixes IntegrationErrorHandlerImpl in the Cloud Connector Starter to apply filter only for runtime errors generated by integration requests. It will try to use `integrationContextId` header as marker in the original IntegrationRequest message order to filter out any other error messages that may be generated from other services that use Spring Cloud Stream.