### PR TITLE
Serialize BigDecimals as String

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
@@ -45,6 +45,15 @@ public class VariableEventContainedBuilder {
         return this;
     }
 
+    public <T> VariableEventContainedBuilder aCreatedVariable(String name, T value) {
+        aCreatedVariable(name, value, resolveType(value));
+        return this;
+    }
+
+    private <T> String resolveType(T value) {
+        return value.getClass().getSimpleName().toLowerCase();
+    }
+
     public <T> VariableEventContainedBuilder anUpdatedVariable(String name,
                                                                T value,
                                                                String type) {


### PR DESCRIPTION
This will ensure that BigDecimals are serialized as String and not as a number, meaning that double quotes will be added around the value. Serializing it as a number it's problematic because, by default, it will be deserialized back to Java as double and it will lose precision. For instance, `1.00` (scale 2) will become `1.0` (scale 1) that are considered as different values in BigDecimal. By adding the quotes, it will be deserialized as String, but it will not lose the information about the scale, so it can be easily converted back to BigDecimal.