### PR TITLE
Activiti/Activiti#3307 enable reusable containers

### DIFF
--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
@@ -99,8 +99,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>rabbitmq</artifactId>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-containers</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -15,19 +15,15 @@
  */
 package org.activiti.cloud.connectors.starter.test.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.ClassRule;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,28 +34,15 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.test.context.ContextConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles(ConnectorsITStreamHandlers.CONNECTOR_IT)
-@Testcontainers
+@ContextConfiguration(initializers = RabbitMQContainerApplicationInitializer.class)
 public class ActivitiCloudConnectorServiceIT {
-
-
-    @Container
-    private static RabbitMQContainer rabbitMQContainer = new RabbitMQContainer("rabbitmq:management");
-
-    @BeforeAll
-    public static void beforeAll() {
-
-        System.setProperty("spring.rabbitmq.host", rabbitMQContainer.getContainerIpAddress());
-        System.setProperty("spring.rabbitmq.port", String.valueOf(rabbitMQContainer.getAmqpPort()));
-
-    }
-
 
     private static final String INTEGRATION_CONTEXT_ID = "integrationContextId";
 

--- a/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/PostgresApplicationInitializer.java
+++ b/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/PostgresApplicationInitializer.java
@@ -18,18 +18,21 @@ package org.activiti.cloud.starter.messages.test.jdbc;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresApplicationInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    private PostgreSQLContainer container = new PostgreSQLContainer("postgres:10");
+    private PostgreSQLContainer container = (PostgreSQLContainer) new PostgreSQLContainer("postgres:10")
+        .withReuse(false);
 
     @Override
     public void initialize(ConfigurableApplicationContext context) {
 
         container.start();
 
-        TestPropertyValues.of("spring.datasource.url=" + container.getJdbcUrl(),
+        TestPropertyValues.of(
+            "spring.datasource.url=" + container.getJdbcUrl(),
             "spring.datasource.username=" + container.getUsername(),
             "spring.datasource.password=" + container.getPassword()
         ).applyTo(context.getEnvironment());

--- a/activiti-cloud-messages-service/starters/mongodb/src/test/java/org/activiti/cloud/starter/messages/test/mongodb/MongodbApplicationInitializer.java
+++ b/activiti-cloud-messages-service/starters/mongodb/src/test/java/org/activiti/cloud/starter/messages/test/mongodb/MongodbApplicationInitializer.java
@@ -22,7 +22,8 @@ import org.testcontainers.containers.MongoDBContainer;
 
 public class MongodbApplicationInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    private static MongoDBContainer container = new MongoDBContainer();
+    private static MongoDBContainer container = new MongoDBContainer()
+        .withReuse(false);
 
     @Override
     public void initialize(ConfigurableApplicationContext context) {

--- a/activiti-cloud-messages-service/starters/redis/src/test/java/org/activiti/cloud/starter/messages/test/redis/RedisApplicationInitializer.java
+++ b/activiti-cloud-messages-service/starters/redis/src/test/java/org/activiti/cloud/starter/messages/test/redis/RedisApplicationInitializer.java
@@ -24,6 +24,7 @@ public class RedisApplicationInitializer implements ApplicationContextInitialize
 
 
     private static GenericContainer container = new GenericContainer("redis")
+        .withReuse(false)
         .withExposedPorts(6379);
 
     @Override

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -23,11 +23,10 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class KeycloakContainerApplicationInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    private static GenericContainer keycloakContainer = new GenericContainer(
-        "activiti/activiti-keycloak")
+    private static GenericContainer keycloakContainer = new GenericContainer("activiti/activiti-keycloak")
         .withExposedPorts(8180)
-        .waitingFor(Wait.defaultWaitStrategy());
-
+        .waitingFor(Wait.defaultWaitStrategy())
+        .withReuse(true);
 
     @Override
     public void initialize(ConfigurableApplicationContext context) {

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/RabbitMQContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/RabbitMQContainerApplicationInitializer.java
@@ -27,9 +27,8 @@ import org.testcontainers.lifecycle.Startables;
 public class RabbitMQContainerApplicationInitializer implements
     ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-
-    private static RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(
-        "rabbitmq:management");
+    private static RabbitMQContainer rabbitMQContainer = new RabbitMQContainer("rabbitmq:management")
+        .withReuse(true);
 
     @Override
     public void initialize(ConfigurableApplicationContext context) {
@@ -40,7 +39,7 @@ public class RabbitMQContainerApplicationInitializer implements
 
         TestPropertyValues.of(
             "spring.rabbitmq.host=" + rabbitMQContainer.getContainerIpAddress(),
-            "spring.rabbitmq.port=" + String.valueOf(rabbitMQContainer.getAmqpPort())
+            "spring.rabbitmq.port=" + rabbitMQContainer.getAmqpPort()
         ).applyTo(context.getEnvironment());
 
     }


### PR DESCRIPTION
configure container with reuse flag

remember to setup your local machine enabling reuse of containers in `.testcontainers.properties` file in your home dir

```
testcontainers.reuse.enable=true
```
