### PR TITLE
fix(AAE-2166); command context close listener transacted producer

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
@@ -26,8 +26,10 @@ import org.activiti.engine.impl.context.ExecutionContext;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandContextCloseListener;
 import org.springframework.messaging.Message;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+@Transactional
 public class MessageProducerCommandContextCloseListener implements CommandContextCloseListener {
 
     public static final String PROCESS_ENGINE_EVENTS = "processEngineEvents";
@@ -35,7 +37,7 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
     private final ProcessEngineChannels producer;
     private final MessageBuilderChainFactory<ExecutionContext> messageBuilderChainFactory;
     private final RuntimeBundleInfoAppender runtimeBundleInfoAppender;
-    
+
     public MessageProducerCommandContextCloseListener(ProcessEngineChannels producer,
             MessageBuilderChainFactory<ExecutionContext> messageBuilderChainFactory,
             RuntimeBundleInfoAppender runtimeBundleInfoAppender ) {
@@ -50,14 +52,14 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
         this.messageBuilderChainFactory = messageBuilderChainFactory;
         this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
     }
-    
+
     @Override
     public void closed(CommandContext commandContext) {
         List<CloudRuntimeEvent<?, ?>> events = commandContext.getGenericAttribute(PROCESS_ENGINE_EVENTS);
-        
+
         if (events != null && !events.isEmpty()) {
 
-            // Add runtime bundle context attributes to every event 
+            // Add runtime bundle context attributes to every event
             CloudRuntimeEvent<?, ?>[] payload = events.stream()
                                                       .filter(CloudRuntimeEventImpl.class::isInstance)
                                                       .map(CloudRuntimeEventImpl.class::cast)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -6,3 +6,6 @@ spring.activiti.async-executor.default-timer-job-acquire-wait-time-in-millis=500
 
 #ensures the consumer (query, audit) will receive the message even if it starts after the message has been sent
 spring.cloud.stream.bindings.auditProducer.producer.required-groups=${ACT_QUERY_CONSUMER_GROUP:query},${ACT_AUDIT_CONSUMER_GROUP:audit}
+#ensures that producer participates in the Spring transactions 
+spring.cloud.stream.rabbit.bindings.auditProducer.producer.transacted=${ACT_AUDIT_PRODUCER_TRANSACTED:true}
+spring.cloud.stream.kafka.binder.transaction.transactionIdPrefix=tx-

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -6,6 +6,6 @@ spring.activiti.async-executor.default-timer-job-acquire-wait-time-in-millis=500
 
 #ensures the consumer (query, audit) will receive the message even if it starts after the message has been sent
 spring.cloud.stream.bindings.auditProducer.producer.required-groups=${ACT_QUERY_CONSUMER_GROUP:query},${ACT_AUDIT_CONSUMER_GROUP:audit}
-#ensures that producer participates in the Spring transactions 
+#ensures that producer participates in the Spring transactions
 spring.cloud.stream.rabbit.bindings.auditProducer.producer.transacted=${ACT_AUDIT_PRODUCER_TRANSACTED:true}
-spring.cloud.stream.kafka.binder.transaction.transactionIdPrefix=tx-
+spring.cloud.stream.kafka.binder.transaction.transactionIdPrefix=${ACT_AUDIT_PRODUCER_TRANSACTION_ID_PREFIX:tx-}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -59,7 +59,7 @@ public class MessageProducerCommandContextCloseListenerIT {
     }
 
     @Test
-    public void testMessageProducerCommandContextCloseListenerNeverClosed() {
+    public void shouldNot_callCloseListener_when_exceptionOccursOnActivitiTransaction() {
         // given
         String processDefinitionKey = "rollbackProcess";
 
@@ -80,7 +80,7 @@ public class MessageProducerCommandContextCloseListenerIT {
     }
 
     @Test
-    public void testMessageProducerCommandContextCloseListenerNeverSend() throws InterruptedException {
+    public void should_rollbackSentMessages_when_exceptionOccursAfterSent() throws InterruptedException {
         // given
         String processDefinitionKey = "SimpleProcess";
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -61,18 +61,18 @@ public class MessageProducerCommandContextCloseListenerIT {
     @Test
     public void testMessageProducerCommandContextCloseListenerNeverClosed() {
         // given
-        String processDefintionKey = "SimpleProcess";
+        String processDefinitionKey = "rollbackProcess";
 
         // when
         Throwable thrown = catchThrowable(() -> {
             runtimeService.createProcessInstanceBuilder()
-                          .processDefinitionKey("rollbackProcess")
+                          .processDefinitionKey(processDefinitionKey)
                           .start();
         });
 
         // then
         ProcessInstance result = runtimeService.createProcessInstanceQuery()
-                                               .processDefinitionKey(processDefintionKey)
+                                               .processDefinitionKey(processDefinitionKey)
                                                .singleResult();
         assertThat(result).isNull();
         assertThat(thrown).isInstanceOf(ActivitiException.class);
@@ -82,7 +82,7 @@ public class MessageProducerCommandContextCloseListenerIT {
     @Test
     public void testMessageProducerCommandContextCloseListenerNeverSend() throws InterruptedException {
         // given
-        String processDefintionKey = "SimpleProcess";
+        String processDefinitionKey = "SimpleProcess";
 
         doAnswer(new Answer<Void>() {
             @Override
@@ -102,13 +102,13 @@ public class MessageProducerCommandContextCloseListenerIT {
         // when
         Throwable thrown = catchThrowable(() -> {
             runtimeService.createProcessInstanceBuilder()
-                          .processDefinitionKey(processDefintionKey)
+                          .processDefinitionKey(processDefinitionKey)
                           .start();
         });
 
         // then
         ProcessInstance result = runtimeService.createProcessInstanceQuery()
-                                               .processDefinitionKey(processDefintionKey)
+                                               .processDefinitionKey(processDefinitionKey)
                                                .singleResult();
         assertThat(result).isNull();
         assertThat(thrown).isInstanceOf(MessageDeliveryException.class);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -1,0 +1,120 @@
+package org.activiti.cloud.starter.tests.services.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener;
+import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+                properties = {"spring.activiti.asyncExecutorActivate=true"})
+@TestPropertySource("classpath:application-test.properties")
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
+                      initializers = {RabbitMQContainerApplicationInitializer.class,
+                                      KeycloakContainerApplicationInitializer.class}
+)
+@DirtiesContext
+public class MessageProducerCommandContextCloseListenerIT {
+
+    @Autowired
+    private RuntimeService runtimeService;
+
+    @SpyBean
+    private MessageProducerCommandContextCloseListener subject;
+
+    @Autowired
+    private AuditConsumerStreamHandler streamHandler;
+
+    @BeforeEach
+    public void setUp() {
+        streamHandler.clear();
+    }
+
+    @Test
+    public void contextLoads() {
+        //
+    }
+
+    @Test
+    public void testMessageProducerCommandContextCloseListenerNeverClosed() {
+        // given
+        String processDefintionKey = "SimpleProcess";
+
+        // when
+        Throwable thrown = catchThrowable(() -> {
+            runtimeService.createProcessInstanceBuilder()
+                          .processDefinitionKey("rollbackProcess")
+                          .start();
+        });
+
+        // then
+        ProcessInstance result = runtimeService.createProcessInstanceQuery()
+                                               .processDefinitionKey(processDefintionKey)
+                                               .singleResult();
+        assertThat(result).isNull();
+        assertThat(thrown).isInstanceOf(ActivitiException.class);
+        verify(subject, never()).closed(any(CommandContext.class));
+    }
+
+    @Test
+    public void testMessageProducerCommandContextCloseListenerNeverSend() throws InterruptedException {
+        // given
+        String processDefintionKey = "SimpleProcess";
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                CommandContext commandContext = invocation.getArgument(0);
+
+                doCallRealMethod().when(subject)
+                                  .closed(any(CommandContext.class));
+
+                subject.closed(commandContext);
+
+                throw new MessageDeliveryException("Test exception");
+            }
+        }).when(subject)
+          .closed(any(CommandContext.class));
+
+        // when
+        Throwable thrown = catchThrowable(() -> {
+            runtimeService.createProcessInstanceBuilder()
+                          .processDefinitionKey(processDefintionKey)
+                          .start();
+        });
+
+        // then
+        ProcessInstance result = runtimeService.createProcessInstanceQuery()
+                                               .processDefinitionKey(processDefintionKey)
+                                               .singleResult();
+        assertThat(result).isNull();
+        assertThat(thrown).isInstanceOf(MessageDeliveryException.class);
+
+        // let's wait
+        Thread.sleep(2000);
+        assertThat(streamHandler.getAllReceivedEvents()).isEmpty();
+    }
+}


### PR DESCRIPTION
I have investigated the issue with CommandContextCloseListener.closed being called inside transaction. By design, the close method is called at the end of Activiti engine transaction when CommandContext is successfully closed and no rollback has happened. However, 

As part of the code review, I have looked into whether the transmission of the message on the producer side is linked to the spring transaction or whether we need to enable a Spring Cloud Stream feature. The problem I discovered is that there could be a potential problem with publishing messages without having producer channel participating in the Spring transaction, which will result in events published even if Activiti transaction is rolled back. 

Spring Cloud Stream Rabbit binder implementation has transaction synchronization configuration with Spring PlatformTransactionManager for producer output channels

To enable transactional support, the producer output stream in rabbit binder configuration needs to be declared as transacted: spring.cloud.stream.rabbit.bindings.output.producer.transacted=true

After that, the MessageProducerCommandContextCloseListener.closed(CommandContext commandContext) method should be annotated with @Transactional to join Activiti transaction when sending events.

If Activiti successfully commits its transaction, the producer binder will also execute commit on transacted channel to publish messages.

In the event Activiti database transaction is rolled back, the producer binder will rollback any messages waiting for commit in the output stream Rabbit channel.

If there is infrastructure problem and messages cannot be sent, producer send() method will return false and raise ActivitiException to signal Activiti closing manager to rollback database transaction.

