### PR TITLE
Fix IntegrationRequestSender

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/IntegrationRequestSenderTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/IntegrationRequestSenderTest.java
@@ -219,7 +219,7 @@ public class IntegrationRequestSenderTest {
         given(eventsProperties.isIntegrationAuditEventsEnabled()).willReturn(true);
 
         //when
-        integrationRequestSender.sendIntegrationRequest(integrationRequest);
+        integrationRequestSender.sendAuditEvent(integrationRequest);
 
         //then
         verify(auditProducer).send(auditMessageArgumentCaptor.capture());


### PR DESCRIPTION
- the integration request itself is sent after the activiti transaction has been committed because the connector channel is not transacted, so sending it before commit could result in sending an integration request for a rolled back transaction
- the audit event related to integration request is included in the Activiti transaction because the audit channel is transacted, so the message will only be available to consumers if the the Activiti transaction has been successfully committed

Ref  Activiti/Activiti#1801