### PR TITLE
Add integration test to cover result collection on cloud connectors

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
-import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
@@ -45,8 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -274,31 +274,51 @@ public class MQServiceTaskIT {
     }
 
     @Test
-    public void should_supportResultCollectionOnMultiInstance() {
+    public void multiInstance_should_collectSpecifiedVariable_when_dataItemIsSet() {
         //given
         ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate
             .startProcess(ProcessPayloadBuilder
                 .start()
-                .withProcessDefinitionKey("process-with-multi-instance-result-collection")
+                .withProcessDefinitionKey("multi-instance-service-task-result-collection-data-item")
             .build());
 
-        //when
         await().untilAsserted(() -> {
-        ResponseEntity<CollectionModel<CloudVariableInstance>> variablesResponse = processInstanceRestTemplate
-            .getVariables(processInstance);
+            //when
+            ResponseEntity<CollectionModel<CloudVariableInstance>> variablesResponse = processInstanceRestTemplate
+                .getVariables(processInstance);
 
-        //then
+            //then
             Collection<CloudVariableInstance> variables = variablesResponse.getBody().getContent();
             assertThat(variables)
-                .extracting(VariableInstance::getName)
-                .contains("meals");
-            VariableInstance meals = variables
-                .stream()
-                .filter(variableInstance -> "meals".equals(variableInstance.getName()))
-                .findFirst()
-                .orElse(null);
-            List<String> mealValues = meals.getValue();
-            assertThat(mealValues).containsExactlyInAnyOrder("pizza", "pasta");
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
+                .contains(
+                    tuple("meals",
+                        asList("pizza", "pasta")));
+        });
+    }
+
+    @Test
+    public void multiInstance_should_collectAllVariables_when_noDataItem() {
+        //given
+        ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate
+            .startProcess(ProcessPayloadBuilder
+                .start()
+                .withProcessDefinitionKey("multi-instance-service-task-result-collection-all")
+            .build());
+
+        await().untilAsserted(() -> {
+            //when
+            ResponseEntity<CollectionModel<CloudVariableInstance>> variablesResponse = processInstanceRestTemplate
+                .getVariables(processInstance);
+
+            //then
+            Collection<CloudVariableInstance> variables = variablesResponse.getBody().getContent();
+            assertThat(variables)
+                .extracting(VariableInstance::getName, VariableInstance::getValue)
+                .contains(tuple("miResult",
+                    asList(
+                        Map.of("meal", "pizza", "size", "small"),
+                        Map.of("meal", "pasta", "size", "medium"))));
         });
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -65,6 +65,7 @@ public class ServiceTaskConsumerHandler {
 
     private final AtomicInteger currentMealIndex = new AtomicInteger(0);
     private List<String> meals = Arrays.asList("pizza", "pasta");
+    private List<String> sizes = Arrays.asList("small", "medium");
 
     @Autowired
     public ServiceTaskConsumerHandler(BinderAwareChannelResolver resolver,
@@ -239,6 +240,7 @@ public class ServiceTaskConsumerHandler {
         IntegrationContext integrationContext = integrationRequest.getIntegrationContext();
         int remainder = currentMealIndex.getAndIncrement() % meals.size();
         integrationContext.addOutBoundVariable("meal", meals.get(remainder));
+        integrationContext.addOutBoundVariable("size", sizes.get(remainder));
 
         sendIntegrationResult(integrationRequest, integrationContext);
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-all-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-all-extensions.json
@@ -1,8 +1,8 @@
 {
-  "id":"process-with-multi-instance-result-collection-model",
-  "name":"process-with-multi-instance-result-collection",
+  "id":"multi-instance-service-task-result-collection-all-model",
+  "name":"multi-instance-service-task-result-collection-all",
   "extensions": {
-    "process-with-multi-instance-result-collection": {
+    "multi-instance-service-task-result-collection-all": {
       "properties": {
         "age-id": {
           "id": "age-id",

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-all.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-all.bpmn20.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="processDefinitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="processDefinitions">
+
+    <process id="multi-instance-service-task-result-collection-all">
+
+        <startEvent id="start"/>
+
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask"/>
+
+        <serviceTask id="serviceTask" implementation="mealsConnector" >
+          <multiInstanceLoopCharacteristics isSequential="true">
+            <loopCardinality>2</loopCardinality>
+            <loopDataOutputRef>miResult</loopDataOutputRef>
+          </multiInstanceLoopCharacteristics>
+        </serviceTask>
+
+        <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="userTask"/>
+
+        <userTask id="userTask" name="My user task" activiti:candidateGroups="hr"/>
+
+        <sequenceFlow id="flow3" sourceRef="userTask" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+    </process>
+
+</definitions>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-data-item-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-data-item-extensions.json
@@ -1,0 +1,30 @@
+{
+  "id":"multi-instance-service-task-result-collection-data-item-model",
+  "name":"multi-instance-service-task-result-collection-data-item",
+  "extensions": {
+    "multi-instance-service-task-result-collection-data-item": {
+      "properties": {
+        "age-id": {
+          "id": "age-id",
+          "name": "age",
+          "type": "integer",
+          "value": 20
+        },
+        "name-id": {
+          "id": "name-id",
+          "name": "name",
+          "type": "string",
+          "value": "inName"
+        }
+      },
+      "mappings": {
+        "serviceTask": {
+          "inputs": {
+          },
+          "outputs": {
+          }
+        }
+      }
+    }
+  }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-data-item.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-service-task-result-collection-data-item.bpmn20.xml
@@ -4,7 +4,7 @@
              xmlns:activiti="http://activiti.org/bpmn"
              targetNamespace="processDefinitions">
 
-    <process id="process-with-multi-instance-result-collection">
+    <process id="multi-instance-service-task-result-collection-data-item">
 
         <startEvent id="start"/>
 


### PR DESCRIPTION
- when both `loopDataOutputRef` and `outputDataItem` are set in the xml file, only the value of will be collected in `loopDataOutputRef`. The result will be a list of values. I.e.
```
          <multiInstanceLoopCharacteristics isSequential="false">
            <loopCardinality>2</loopCardinality>
            <loopDataOutputRef>meals</loopDataOutputRef>
            <outputDataItem name="meal"/>
          </multiInstanceLoopCharacteristics>
```
The result will have the pattern: `["pizza", "pasta"]`.

- when only `loopDataOutputRef` is set, all the local variables will collected in `loopDataOutputRef`. The result will be a list of maps.
```
          <multiInstanceLoopCharacteristics isSequential="false">
            <loopCardinality>2</loopCardinality>
            <loopDataOutputRef>result</loopDataOutputRef>
          </multiInstanceLoopCharacteristics>
```
The result will have the pattern: `[{"meal": "pizza", "anotherLocalVariable": "value1"}, {"meal": "pasta", "anotherLocalVariable": "value2"}]`.

Ref https://github.com/Activiti/Activiti/issues/3385
Depends on https://github.com/Activiti/Activiti/pull/3393