### PR TITLE
fix(AAE-3196): support ability to filter Service Tasks by status

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudBPMNActivityImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudBPMNActivityImpl.java
@@ -29,6 +29,7 @@ public class CloudBPMNActivityImpl extends CloudRuntimeEntityImpl implements Clo
     private String elementId;
     private String processDefinitionId;
     private String processInstanceId;
+    private CloudBPMNActivity.BPMNActivityStatus status;
 
     public CloudBPMNActivityImpl() { }
 
@@ -109,6 +110,15 @@ public class CloudBPMNActivityImpl extends CloudRuntimeEntityImpl implements Clo
     }
 
     @Override
+    public CloudBPMNActivity.BPMNActivityStatus getStatus() {
+        return status;
+    }
+
+
+    public void setStatus(CloudBPMNActivity.BPMNActivityStatus status) {
+        this.status = status;
+    }
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
@@ -118,7 +128,8 @@ public class CloudBPMNActivityImpl extends CloudRuntimeEntityImpl implements Clo
                                                executionId,
                                                id,
                                                processDefinitionId,
-                                               processInstanceId);
+                                               processInstanceId,
+                                               status);
         return result;
     }
 
@@ -140,7 +151,8 @@ public class CloudBPMNActivityImpl extends CloudRuntimeEntityImpl implements Clo
                Objects.equals(executionId, other.executionId) &&
                Objects.equals(id, other.id) &&
                Objects.equals(processDefinitionId, other.processDefinitionId) &&
-               Objects.equals(processInstanceId, other.processInstanceId);
+               Objects.equals(processInstanceId, other.processInstanceId) &&
+               Objects.equals(status, other.status);
     }
 
     @Override
@@ -160,6 +172,8 @@ public class CloudBPMNActivityImpl extends CloudRuntimeEntityImpl implements Clo
                .append(processDefinitionId)
                .append(", processInstanceId=")
                .append(processInstanceId)
+               .append(", status=")
+               .append(status)
                .append(", super()=")
                .append(super.toString())
                .append("]");

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBPMNActivity.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBPMNActivity.java
@@ -21,6 +21,11 @@ import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
 public interface CloudBPMNActivity extends CloudRuntimeEntity,
         BPMNActivity {
 
+    public static enum BPMNActivityStatus {
+        STARTED, COMPLETED, CANCELLED, ERROR
+    }
+
     String getId();
 
+    BPMNActivityStatus getStatus();
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/BPMNActivityEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/BPMNActivityEntity.java
@@ -40,10 +40,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 })
 public class BPMNActivityEntity extends ActivitiEntityMetadata implements CloudBPMNActivity {
 
-    public static enum BPMNActivityStatus {
-        STARTED, COMPLETED, CANCELLED, ERROR
-    }
-
     /** The unique identifier of this historic activity instance. */
     @Id
     private String id;
@@ -106,6 +102,7 @@ public class BPMNActivityEntity extends ActivitiEntityMetadata implements CloudB
               appVersion);
     }
 
+    @Override
     public String getId() {
         return id;
     }
@@ -135,6 +132,7 @@ public class BPMNActivityEntity extends ActivitiEntityMetadata implements CloudB
         return processInstanceId;
     }
 
+    @Override
     public BPMNActivityStatus getStatus() {
         return status;
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNActivityRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNActivityRepository.java
@@ -17,8 +17,8 @@ package org.activiti.cloud.services.query.app.repository;
 
 import java.util.List;
 
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.activiti.cloud.services.query.model.QBPMNActivityEntity;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
@@ -42,7 +42,7 @@ public interface BPMNActivityRepository extends PagingAndSortingRepository<BPMNA
     }
 
     List<BPMNActivityEntity> findByProcessInstanceIdAndStatus(String processInstanceId,
-                                                              BPMNActivityStatus status);
+                                                              CloudBPMNActivity.BPMNActivityStatus status);
 
     List<BPMNActivityEntity> findByProcessInstanceId(String processInstanceId);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCancelledEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCancelledEventHandler.java
@@ -21,10 +21,10 @@ import javax.persistence.EntityManager;
 
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCancelledEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -44,7 +44,7 @@ public class BPMNActivityCancelledEventHandler extends BaseBPMNActivityEventHand
         BPMNActivityEntity bpmnActivityEntity = findOrCreateBPMNActivityEntity(event);
 
         bpmnActivityEntity.setCancelledDate(new Date(activityEvent.getTimestamp()));
-        bpmnActivityEntity.setStatus(BPMNActivityStatus.CANCELLED);
+        bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.CANCELLED);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCompletedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityCompletedEventHandler.java
@@ -21,10 +21,10 @@ import javax.persistence.EntityManager;
 
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -43,7 +43,7 @@ public class BPMNActivityCompletedEventHandler extends BaseBPMNActivityEventHand
         BPMNActivityEntity bpmnActivityEntity = findOrCreateBPMNActivityEntity(event);
 
         bpmnActivityEntity.setCompletedDate(new Date(activityEvent.getTimestamp()));
-        bpmnActivityEntity.setStatus(BPMNActivityStatus.COMPLETED);
+        bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.COMPLETED);
 
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -21,10 +21,10 @@ import javax.persistence.EntityManager;
 
 import org.activiti.api.process.model.events.BPMNActivityEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -44,7 +44,7 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
 
         // Activity can be cyclical, so we just update the status and started date anyways
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
-        bpmnActivityEntity.setStatus(BPMNActivityStatus.STARTED);
+        bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -22,11 +22,11 @@ import javax.persistence.EntityManager;
 
 import org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity.IntegrationContextStatus;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +58,7 @@ public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHa
             entity.setOutBoundVariables(integrationEvent.getEntity().getOutBoundVariables());
 
             BPMNActivityEntity bpmnActivityEntity = entity.getBpmnActivity();
-            bpmnActivityEntity.setStatus(BPMNActivityStatus.ERROR);
+            bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.ERROR);
         });
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDiagramControllerBase.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDiagramControllerBase.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.activiti.bpmn.BpmnAutoLayout;
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.services.query.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
@@ -29,7 +30,6 @@ import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
-import org.activiti.cloud.services.query.model.BPMNActivityEntity.BPMNActivityStatus;
 import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessModelEntity;
@@ -42,11 +42,11 @@ public abstract class ProcessInstanceDiagramControllerBase {
     protected final ProcessModelRepository processModelRepository;
 
     protected final BPMNSequenceFlowRepository bpmnSequenceFlowRepository;
-    
+
     protected final EntityFinder entityFinder;
 
     protected final ProcessInstanceRepository processInstanceRepository;
-    
+
     protected final BPMNActivityRepository bpmnActivityRepository;
 
     protected final ProcessDiagramGeneratorWrapper processDiagramGenerator;
@@ -58,7 +58,7 @@ public abstract class ProcessInstanceDiagramControllerBase {
                                             ProcessInstanceRepository processInstanceRepository,
                                             BPMNActivityRepository bpmnActivityRepository,
                                             EntityFinder entityFinder) {
-        
+
         this.processInstanceRepository = processInstanceRepository;
         this.processModelRepository = processModelRepository;
         this.entityFinder = entityFinder;
@@ -74,7 +74,7 @@ public abstract class ProcessInstanceDiagramControllerBase {
 
         if(!bpmnModel.hasDiagramInterchangeInfo())
             new BpmnAutoLayout(bpmnModel).execute();
-        
+
         List<String> highLightedActivities = resolveStartedActivitiesIds(processInstanceId);
         List<String> highLightedFlows = resolveCompletedFlows(bpmnModel, processInstanceId);
 
@@ -94,7 +94,7 @@ public abstract class ProcessInstanceDiagramControllerBase {
     }
 
     protected List<String> resolveStartedActivitiesIds(String processInstanceId) {
-        return bpmnActivityRepository.findByProcessInstanceIdAndStatus(processInstanceId, BPMNActivityStatus.STARTED)
+        return bpmnActivityRepository.findByProcessInstanceIdAndStatus(processInstanceId, CloudBPMNActivity.BPMNActivityStatus.STARTED)
                                      .stream()
                                      .map(BPMNActivityEntity::getElementId)
                                      .distinct()

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
@@ -26,6 +26,7 @@ import org.activiti.cloud.services.query.rest.predicate.ServiceTasksFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
@@ -63,9 +64,11 @@ public class ProcessInstanceServiceTasksAdminController {
 
     @RequestMapping(value = "/service-tasks", method = RequestMethod.GET)
     public PagedModel<EntityModel<CloudBPMNActivity>> getTasks(@PathVariable String processInstanceId,
+                                                               @QuerydslPredicate(root = BPMNActivityEntity.class) Predicate predicate,
                                                                Pageable pageable) {
 
-        Predicate filter = new ServiceTasksFilter().extend(bPMNActivityEntity.processInstanceId.eq(processInstanceId));
+        Predicate filter = new ServiceTasksFilter().extend(bPMNActivityEntity.processInstanceId.eq(processInstanceId)
+                                                                                               .and(predicate));
 
         Page<BPMNActivityEntity> page = taskRepository.findAll(filter,
                                                                pageable);

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -193,6 +193,31 @@ public class QueryAdminProcessServiceTasksIT {
                                                              .extracting(CloudBPMNActivity::getStatus, BPMNActivity::getActivityType)
                                                              .contains(tuple(CloudBPMNActivity.BPMNActivityStatus.STARTED, SERVICE_TASK_TYPE));
         });
+
+        // and given
+        BPMNActivityImpl taskActivity = new BPMNActivityImpl(SERVICE_TASK_ELEMENT_ID, "Service Task", SERVICE_TASK_TYPE);
+        taskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        taskActivity.setProcessInstanceId(process.getId());
+        taskActivity.setExecutionId(UUID.randomUUID().toString());
+
+        eventsAggregator.addEvents(new CloudBPMNActivityCompletedEventImpl(taskActivity, processDefinitionId, process.getId()));
+
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+            //when
+            ResponseEntity<PagedModel<CloudBPMNActivity>> responseEntity = testRestTemplate.exchange(PROC_URL + "/" + process.getId() + "/service-tasks?status={status}",
+                                                                                                     HttpMethod.GET,
+                                                                                                     keycloakTokenProducer.entityWithAuthorizationHeader(),
+                                                                                                     PAGED_TASKS_RESPONSE_TYPE,
+                                                                                                     CloudBPMNActivity.BPMNActivityStatus.COMPLETED);
+            //then
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(responseEntity.getBody()).isNotNull();
+            assertThat(responseEntity.getBody().getContent()).hasSize(1)
+                                                             .extracting(CloudBPMNActivity::getStatus, BPMNActivity::getActivityType)
+                                                             .contains(tuple(CloudBPMNActivity.BPMNActivityStatus.COMPLETED, SERVICE_TASK_TYPE));
+        });
     }
 
     @Test
@@ -229,6 +254,7 @@ public class QueryAdminProcessServiceTasksIT {
         //given
         ProcessInstanceImpl process = startSimpleProcessInstance();
 
+
         //when
         eventsAggregator.sendAll();
 
@@ -252,6 +278,32 @@ public class QueryAdminProcessServiceTasksIT {
                                                              .extracting(CloudBPMNActivity::getStatus, BPMNActivity::getActivityType)
                                                              .contains(tuple(CloudBPMNActivity.BPMNActivityStatus.STARTED, SERVICE_TASK_TYPE));
         });
+
+        // and given
+        BPMNActivityImpl taskActivity = new BPMNActivityImpl(SERVICE_TASK_ELEMENT_ID, "Service Task", SERVICE_TASK_TYPE);
+        taskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        taskActivity.setProcessInstanceId(process.getId());
+        taskActivity.setExecutionId(UUID.randomUUID().toString());
+
+        eventsAggregator.addEvents(new CloudBPMNActivityCompletedEventImpl(taskActivity, processDefinitionId, process.getId()));
+
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+            //when
+            ResponseEntity<PagedModel<CloudBPMNActivity>> responseEntity = testRestTemplate.exchange("/admin/v1/service-tasks?status={status}",
+                                                                                       HttpMethod.GET,
+                                                                                       keycloakTokenProducer.entityWithAuthorizationHeader(),
+                                                                                       PAGED_TASKS_RESPONSE_TYPE,
+                                                                                       CloudBPMNActivity.BPMNActivityStatus.COMPLETED);
+            //then
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(responseEntity.getBody()).isNotNull();
+            assertThat(responseEntity.getBody().getContent()).hasSize(1)
+                                                             .extracting(CloudBPMNActivity::getStatus, BPMNActivity::getActivityType)
+                                                             .contains(tuple(CloudBPMNActivity.BPMNActivityStatus.COMPLETED, SERVICE_TASK_TYPE));
+        });
+
     }
 
     @Test


### PR DESCRIPTION
This PR adds ability to filter Service Tasks by status, i.e. STARTED, COMPLETED, ERROR, CANCELLED

- [x] GET /admin/v1/{processInstanceId}/service-tasks?status={status}
- [x] GET /admin/v1/service-tasks?status={status}

Fixes https://github.com/Activiti/Activiti/issues/3427