### PR TITLE
Activiti/Activiti#3418 Give feign clients meaningful names to avoid Ribbon problems

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionsApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionsApiClient.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
-    url = "${runtime.url}",
-    path = "${runtime.path}",
+@FeignClient(value = "processDefinitions",
+    url = "processDefinitionsUrl",
+    path = "processDefinitionsUrl",
     configuration = {ClientConfiguration.class})
 public interface ProcessDefinitionsApiClient extends ProcessDefinitionController {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceApiClient.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
-    url = "${runtime.url}",
-    path = "${runtime.path}",
+@FeignClient(value = "processInstances",
+    url = "processInstancesUrl",
+    path = "processInstancesPath",
     configuration = {ClientConfiguration.class})
 public interface ProcessInstanceApiClient extends ProcessInstanceController {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksApiClient.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
-    url = "${runtime.url}",
-    path = "${runtime.path}",
+@FeignClient(value = "processInstanceTasks",
+    url = "processInstanceTasksUrl",
+    path = "processInstanceTasksPath",
     configuration = {ClientConfiguration.class})
 public interface ProcessInstanceTasksApiClient extends ProcessInstanceTasksController {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskApiClient.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
-    url = "${runtime.url}",
-    path = "${runtime.path}",
+@FeignClient(value = "tasks",
+    url = "tasksUrl",
+    path = "tasksPath",
     configuration = {ClientConfiguration.class})
 public interface TaskApiClient extends TaskController{
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableApiClient.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
-    url = "${runtime.url}",
-    path = "${runtime.path}",
+@FeignClient(value = "tasksVariables",
+    url = "tasksVariablesUrl",
+    path = "tasksVariablesPath",
     configuration = {ClientConfiguration.class},
     decode404 = true)
 public interface TaskVariableApiClient extends TaskVariableController{


### PR DESCRIPTION
Addressing: Activiti/Activiti#3418

In order to prevent errors in third-party projects using the new feign clients, such as:
```
java.lang.IllegalStateException: Failed to load ApplicationContext. 
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: 
Caused by: org.springframework.beans.factory.BeanCreationException: 
Error creating bean with name 'org.activiti.cloud.services.rest.api.TaskApiClient': FactoryBean threw exception on object creation; nested exception is java.lang.IllegalStateException: 
No Feign Client for loadBalancing defined. Did you forget to include spring-cloud-starter-netflix-ribbon?
```