### PR TITLE
feat(AAE-3198): Support BPMN Error exceptions to include the error root cause / stack trace

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationErrorImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationErrorImpl.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.api.process.model.impl;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
@@ -43,18 +44,16 @@ public class IntegrationErrorImpl extends CloudRuntimeEntityImpl implements Inte
         this.integrationRequest = integrationRequest;
         this.integrationContext = integrationRequest.getIntegrationContext();
         this.errorClassName = error.getClass().getName();
-
-        if (CloudBpmnError.class.isInstance(error)) {
-            this.errorCode = CloudBpmnError.class.cast(error).getErrorCode();
-        } else {
-            this.errorCode = error.getMessage();
-        }
+        this.errorCode = Optional.of(error)
+                                 .filter(CloudBpmnError.class::isInstance)
+                                 .map(CloudBpmnError.class::cast)
+                                 .map(CloudBpmnError::getErrorCode)
+                                 .orElse(null);
 
         Throwable cause = findRootCause(error);
 
         this.errorMessage = cause.getMessage();
         this.stackTraceElements = Arrays.asList(cause.getStackTrace());
-
     }
 
     @Override

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
@@ -19,20 +19,38 @@ public class CloudBpmnError extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    private final String errorCode;
+
     public CloudBpmnError(String errorCode) {
       super(errorCode);
 
-      if (errorCode == null) {
-          throw new IllegalArgumentException("Error Code must not be null.");
-        }
-        if (errorCode.length() < 1) {
-          throw new IllegalArgumentException("Error Code must not be empty.");
-        }
+      requireValidErrorCode(errorCode);
+
+      this.errorCode = errorCode;
+
+    }
+
+    public CloudBpmnError(String errorCode, Throwable cause) {
+        super(cause);
+
+        requireValidErrorCode(errorCode);
+
+        this.errorCode = errorCode;
 
     }
 
     public String getErrorCode() {
-      return getMessage();
+      return this.errorCode;
+    }
+
+    protected void requireValidErrorCode(String errorCode) {
+        if (errorCode == null) {
+            throw new IllegalArgumentException("Error Code must not be null.");
+        }
+        if (errorCode.length() < 1) {
+            throw new IllegalArgumentException("Error Code must not be empty.");
+        }
+
     }
 
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
@@ -22,12 +22,15 @@ public class CloudBpmnError extends RuntimeException {
     private final String errorCode;
 
     public CloudBpmnError(String errorCode) {
-      super(errorCode);
+      this(errorCode, errorCode);
+    }
 
-      requireValidErrorCode(errorCode);
+    public CloudBpmnError(String errorCode, String message) {
+        super(message);
 
-      this.errorCode = errorCode;
+        requireValidErrorCode(errorCode);
 
+        this.errorCode = errorCode;
     }
 
     public CloudBpmnError(String errorCode, Throwable cause) {
@@ -36,7 +39,6 @@ public class CloudBpmnError extends RuntimeException {
         requireValidErrorCode(errorCode);
 
         this.errorCode = errorCode;
-
     }
 
     public String getErrorCode() {

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationError.java
@@ -25,11 +25,13 @@ public interface IntegrationError extends CloudRuntimeEntity {
     IntegrationContext getIntegrationContext();
 
     IntegrationRequest getIntegrationRequest();
-    
+
+    public String getErrorCode();
+
     public List<StackTraceElement> getStackTraceElements();
 
     public String getErrorMessage();
 
     public String getErrorClassName();
-    
+
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
@@ -109,8 +109,8 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
         }
     }
 
-    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnError'")
-    public void mockTypeIntegrationCloudBpmnErrorSender(IntegrationRequest integrationRequest) {
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnErrorRootCause'")
+    public void mockTypeIntegrationCloudBpmnErrorRootCauseSender(IntegrationRequest integrationRequest) {
         try {
 
             throw new Error("Root Cause");
@@ -124,6 +124,20 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
         }
     }
 
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnError'")
+    public void mockTypeIntegrationCloudBpmnErrorSender(IntegrationRequest integrationRequest) {
+        try {
+
+            throw new Error("Root Cause");
+
+        } catch (Error error) {
+            Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
+                                                                                 connectorProperties,
+                                                                                 new CloudBpmnError("ERROR_CODE"))
+                                                                       .buildMessage();
+            integrationErrorSender.send(message);
+        }
+    }
     private void verifyEventAndCreateResults(IntegrationRequest event) {
         assertThat(event.getIntegrationContext().getId()).isNotEmpty();
         assertThat(event).isNotNull();

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
@@ -115,7 +115,7 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
 
             raiseErrorCause("Error code message");
 
-        } catch (Error error) {
+        } catch (Error cause) {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                  connectorProperties,
                                                                                  new CloudBpmnError("ERROR_CODE"))
@@ -130,10 +130,10 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
 
             raiseErrorCause("Error cause message");
 
-        } catch (Error error) {
+        } catch (Error cause) {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                  connectorProperties,
-                                                                                 new CloudBpmnError("ERROR_CODE", error))
+                                                                                 new CloudBpmnError("ERROR_CODE", cause))
                                                                        .buildMessage();
             integrationErrorSender.send(message);
         }
@@ -145,10 +145,10 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
 
             raiseErrorCause("Error code message");
 
-        } catch (Error error) {
+        } catch (Error cause) {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                  connectorProperties,
-                                                                                 new CloudBpmnError("ERROR_CODE", error.getMessage()))
+                                                                                 new CloudBpmnError("ERROR_CODE", cause.getMessage()))
                                                                        .buildMessage();
             integrationErrorSender.send(message);
         }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
@@ -109,11 +109,26 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
         }
     }
 
-    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnErrorRootCause'")
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnError'")
+    public void mockTypeIntegrationCloudBpmnErrorSender(IntegrationRequest integrationRequest) {
+        try {
+
+            raiseErrorCause("Error code message");
+
+        } catch (Error error) {
+            Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
+                                                                                 connectorProperties,
+                                                                                 new CloudBpmnError("ERROR_CODE"))
+                                                                       .buildMessage();
+            integrationErrorSender.send(message);
+        }
+    }
+
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnErrorCause'")
     public void mockTypeIntegrationCloudBpmnErrorRootCauseSender(IntegrationRequest integrationRequest) {
         try {
 
-            throw new Error("Root Cause");
+            raiseErrorCause("Error cause message");
 
         } catch (Error error) {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
@@ -124,20 +139,21 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
         }
     }
 
-    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnError'")
-    public void mockTypeIntegrationCloudBpmnErrorSender(IntegrationRequest integrationRequest) {
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnErrorMessage'")
+    public void mockTypeIntegrationCloudBpmnErrorMessageSender(IntegrationRequest integrationRequest) {
         try {
 
-            throw new Error("Root Cause");
+            raiseErrorCause("Error code message");
 
         } catch (Error error) {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                  connectorProperties,
-                                                                                 new CloudBpmnError("ERROR_CODE"))
+                                                                                 new CloudBpmnError("ERROR_CODE", error.getMessage()))
                                                                        .buildMessage();
             integrationErrorSender.send(message);
         }
     }
+
     private void verifyEventAndCreateResults(IntegrationRequest event) {
         assertThat(event.getIntegrationContext().getId()).isNotEmpty();
         assertThat(event).isNotNull();
@@ -153,4 +169,9 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
                             Long.valueOf(integrationRequest.getIntegrationContext().getInBoundVariables().get("var2").toString()) + 1);
         return resultVariables;
     }
+
+    public static void raiseErrorCause(String message) {
+        throw new Error(message);
+    }
+
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/ActivitiCloudConnectorApp.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
@@ -103,6 +104,21 @@ public class ActivitiCloudConnectorApp implements CommandLineRunner {
             Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                  connectorProperties,
                                                                                  error)
+                                                                       .buildMessage();
+            integrationErrorSender.send(message);
+        }
+    }
+
+    @StreamListener(value = CloudConnectorConsumerChannels.INTEGRATION_EVENT_CONSUMER, condition = "headers['type']=='CloudBpmnError'")
+    public void mockTypeIntegrationCloudBpmnErrorSender(IntegrationRequest integrationRequest) {
+        try {
+
+            throw new Error("Root Cause");
+
+        } catch (Error error) {
+            Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
+                                                                                 connectorProperties,
+                                                                                 new CloudBpmnError("ERROR_CODE", error))
                                                                        .buildMessage();
             integrationErrorSender.send(message);
         }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ConnectorsITStreamHandlers.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ConnectorsITStreamHandlers.java
@@ -74,4 +74,10 @@ public class ConnectorsITStreamHandlers {
     public IntegrationError getIntegrationError() {
         return integrationErrorReference.get();
     }
+
+    public void reset() {
+        integrationResultEventsCounter = new AtomicInteger();
+        integrationErrorEventProduced = new AtomicBoolean();
+        integrationErrorReference = new AtomicReference<>();
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -16,6 +16,7 @@
 package org.activiti.services.connectors.channel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.activiti.api.process.model.IntegrationContext;
@@ -93,10 +94,13 @@ public class ServiceTaskIntegrationErrorEventHandler {
 
                 if(CloudBpmnError.class.getName().equals(errorClassName)) {
                     if(execution.getActivityId().equals(clientId)) {
-                        CloudBpmnError cloudBpmnError = new CloudBpmnError(integrationError.getErrorMessage());
+                        // Fallback to error message for backward compatibility
+                        String errorCode = Optional.ofNullable(integrationError.getErrorCode())
+                                                   .orElse(integrationError.getErrorMessage());
+
+                        CloudBpmnError cloudBpmnError = new CloudBpmnError(errorCode);
                         cloudBpmnError.setStackTrace(integrationError.getStackTraceElements()
                                                                      .toArray(new StackTraceElement[] {}));
-
                         try {
                             managementService.executeCommand(new PropagateCloudBpmnErrorCmd(cloudBpmnError,
                                                                                             execution));


### PR DESCRIPTION
This PR adds support for Cloud BPMN Error exceptions to capture and propagate the error root cause message/stack trace from cloud connectors, i.e.

```java
        try {

            raiseErrorCause("Error cause message");

        } catch (Error error) {
            Message<IntegrationError> message = IntegrationErrorBuilder.errorFor(integrationRequest,
                                                                                 connectorProperties,
                                                                                 new CloudBpmnError("ERROR_CODE", error))
                                                                       .buildMessage();
            integrationErrorSender.send(message);
        }

       public static void raiseErrorCause(String message) {
          throw new Error(message);
       }
```

After that the IntegrationError will propagate BPMN error code, error cause message and error cause stack trace to Runtime Bundle to produce audit CloudIntegrationErrorResult event to propagate error cause message and stack trace to Audit and Query.

The CloudBpmnError class has been extended with additional constructors to support error detail message or error cause exception parameters:

```java
public class CloudBpmnError extends RuntimeException {

    private static final long serialVersionUID = 1L;

    private final String errorCode;

    public CloudBpmnError(String errorCode) {
      this(errorCode, errorCode);
    }

    public CloudBpmnError(String errorCode, String message) {
        super(message);

        requireValidErrorCode(errorCode);

        this.errorCode = errorCode;
    }

    public CloudBpmnError(String errorCode, Throwable cause) {
        super(cause);

        requireValidErrorCode(errorCode);

        this.errorCode = errorCode;
    }

    public String getErrorCode() {
      return this.errorCode;
    }
}
```