### PR TITLE
fix(GH-3449): ProcessInstanceTasksController#getTasks throw error 

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
@@ -15,15 +15,14 @@
  */
 package org.activiti.cloud.services.query.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.querydsl.core.annotations.PropertyType;
-import com.querydsl.core.annotations.QueryType;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -36,11 +35,18 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.task.model.Task;
 import org.activiti.cloud.api.task.model.QueryCloudTask;
 import org.activiti.cloud.api.task.model.events.CloudTaskCreatedEvent;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.PropertyType;
+import com.querydsl.core.annotations.QueryType;
 
 @Entity(name = "Task")
 @Table(name = "TASK",
@@ -141,13 +147,15 @@ public class TaskEntity extends ActivitiEntityMetadata implements QueryCloudTask
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false,
             foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
-    private Set<TaskCandidateUser> taskCandidateUsers;
+    @Fetch(FetchMode.SUBSELECT)
+    private Set<TaskCandidateUser> taskCandidateUsers = new LinkedHashSet<>();
 
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "taskId", referencedColumnName = "id", insertable = false, updatable = false,
             foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
-    private Set<TaskCandidateGroup> taskCandidateGroups;
+    @Fetch(FetchMode.SUBSELECT)
+    private Set<TaskCandidateGroup> taskCandidateGroups = new LinkedHashSet<>();
 
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY)
@@ -395,6 +403,7 @@ public class TaskEntity extends ActivitiEntityMetadata implements QueryCloudTask
         this.taskCandidateUsers = taskCandidateUsers;
     }
 
+    @Override
     public List<String> getCandidateUsers(){
         return this.taskCandidateUsers != null ? this.taskCandidateUsers
                        .stream()
@@ -402,6 +411,7 @@ public class TaskEntity extends ActivitiEntityMetadata implements QueryCloudTask
                        .collect(Collectors.toList()) : Collections.emptyList();
     }
 
+    @Override
     public List<String> getCandidateGroups(){
         return this.taskCandidateGroups != null ? this.taskCandidateGroups
                        .stream()
@@ -525,6 +535,7 @@ public class TaskEntity extends ActivitiEntityMetadata implements QueryCloudTask
         this.completedFrom = completedFrom;
     }
 
+    @Override
     public String getCompletedBy(){
         return completedBy;
     }

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -1601,7 +1601,7 @@ public class QueryTasksIT {
     }
 
     @Test
-    public void should_getTasks_withCandidateUsers_by_ProcessInstance() {
+    public void should_getTasks_withCandidateUsersAndGroups_by_ProcessInstance() {
         //given
         Task task1 = taskEventContainedBuilder.aTaskWithUserCandidate("Task1",
                                                                       "testuser",
@@ -1621,8 +1621,8 @@ public class QueryTasksIT {
             assertThat(responseEntity.getBody()).isNotNull();
             Collection<Task> tasks = responseEntity.getBody().getContent();
             assertThat(tasks.iterator().next())
-                .extracting(Task::getName, Task::getCandidateUsers)
-                .contains(tuple(task1.getName(), Collections.singletonList("testuser")));
+                .extracting(Task::getName, Task::getCandidateUsers, Task::getCandidateGroups)
+                .contains(task1.getName(), Collections.singletonList("testuser"), Collections.emptyList());
         });
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -24,10 +24,12 @@ import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
+
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.Task.TaskStatus;
@@ -979,6 +981,14 @@ public class QueryTasksIT {
                                          PAGED_TASKS_RESPONSE_TYPE);
     }
 
+    private ResponseEntity<PagedModel<Task>> executeRequestGetTasks(ProcessInstance processInstance) {
+        return testRestTemplate.exchange("/v1/process-instances/{processInstanceId}/tasks",
+                                         HttpMethod.GET,
+                                         keycloakTokenProducer.entityWithAuthorizationHeader(),
+                                         PAGED_TASKS_RESPONSE_TYPE,
+                                         processInstance.getId());
+    }
+
     private ResponseEntity<Task> executeRequestGetTasksById(String id) {
         return testRestTemplate.exchange(TASKS_URL + "/" + id,
                 HttpMethod.GET,
@@ -1588,6 +1598,32 @@ public class QueryTasksIT {
                 .containsExactly(task1.getId());
         });
 
+    }
+
+    @Test
+    public void should_getTasks_withCandidateUsers_by_ProcessInstance() {
+        //given
+        Task task1 = taskEventContainedBuilder.aTaskWithUserCandidate("Task1",
+                                                                      "testuser",
+                                                                      runningProcessInstance);
+
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+
+            //when
+            ResponseEntity<PagedModel<Task>> responseEntity = executeRequestGetTasks(runningProcessInstance);
+
+            //then
+            assertThat(responseEntity).isNotNull();
+            assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            assertThat(responseEntity.getBody()).isNotNull();
+            Collection<Task> tasks = responseEntity.getBody().getContent();
+            assertThat(tasks.iterator().next())
+                .extracting(Task::getName, Task::getCandidateUsers)
+                .contains(tuple(task1.getName(), Collections.singletonList("testuser")));
+        });
     }
 
     @Test


### PR DESCRIPTION
This PR ensures that Task candidate users and groups are fetched from database and initialized by persistent provider using `@Fetch(FetchMode.SUBSELECT)` annotation directive. This will resolve lazy collection initialization exception outside of persistent session context when rest controller needs to build response entity model.

Fixes https://github.com/Activiti/Activiti/issues/3449