### PR TITLE
fix(AAE-3761): Some BPMN errors are not shown in Service Task view

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
@@ -30,12 +30,15 @@ import org.activiti.cloud.services.audit.jpa.converters.json.ListOfStackTraceEle
 @DiscriminatorValue(value = IntegrationErrorReceivedEventEntity.INTEGRATION_ERROR_RECEIVED_EVENT)
 public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity {
 
-    private static final int LENGTH_VARCHAR_255 = 255;
+    private static final int ERROR_MESSAGE_LENGTH = 255;
 
     protected static final String INTEGRATION_ERROR_RECEIVED_EVENT = "IntegrationErrorReceivedEvent";
 
     private String errorCode;
+
+    @Column(length = ERROR_MESSAGE_LENGTH)
     private String errorMessage;
+
     private String errorClassName;
 
     @Convert(converter = ListOfStackTraceElementsJpaJsonConverter.class)
@@ -48,7 +51,7 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
         super(event);
 
         this.errorMessage = event.getErrorCode();
-        this.errorMessage = StringUtils.truncate(event.getErrorMessage(), LENGTH_VARCHAR_255);
+        this.errorMessage = StringUtils.truncate(event.getErrorMessage(), ERROR_MESSAGE_LENGTH);
         this.errorClassName = event.getErrorClassName();
         this.stackTraceElements = event.getStackTraceElements();
     }
@@ -65,7 +68,7 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
         return errorMessage;
     }
     public void setErrorMessage(String errorMessage) {
-        this.errorMessage = StringUtils.truncate(errorMessage, LENGTH_VARCHAR_255);
+        this.errorMessage = StringUtils.truncate(errorMessage, ERROR_MESSAGE_LENGTH);
     }
 
     public String getErrorClassName() {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
@@ -30,6 +30,8 @@ import org.activiti.cloud.services.audit.jpa.converters.json.ListOfStackTraceEle
 @DiscriminatorValue(value = IntegrationErrorReceivedEventEntity.INTEGRATION_ERROR_RECEIVED_EVENT)
 public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity {
 
+    private static final int LENGTH_VARCHAR_255 = 255;
+
     protected static final String INTEGRATION_ERROR_RECEIVED_EVENT = "IntegrationErrorReceivedEvent";
 
     private String errorCode;
@@ -46,7 +48,7 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
         super(event);
 
         this.errorMessage = event.getErrorCode();
-        this.errorMessage = event.getErrorMessage();
+        this.errorMessage = StringUtils.truncate(event.getErrorMessage(), LENGTH_VARCHAR_255);
         this.errorClassName = event.getErrorClassName();
         this.stackTraceElements = event.getStackTraceElements();
     }
@@ -62,15 +64,20 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
     public String getErrorMessage() {
         return errorMessage;
     }
-
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = StringUtils.truncate(errorMessage, LENGTH_VARCHAR_255);
+    }
 
     public String getErrorClassName() {
         return errorClassName;
     }
 
-
     public List<StackTraceElement> getStackTraceElements() {
         return stackTraceElements;
+    }
+
+    public void setStackTraceElements(List<StackTraceElement> stackTraceElements) {
+        this.stackTraceElements = stackTraceElements;
     }
 
     @Override
@@ -118,4 +125,5 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
                .append("]");
         return builder.toString();
     }
+
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/IntegrationErrorReceivedEventEntity.java
@@ -50,7 +50,7 @@ public class IntegrationErrorReceivedEventEntity extends IntegrationEventEntity 
     public IntegrationErrorReceivedEventEntity(CloudIntegrationErrorReceivedEvent event) {
         super(event);
 
-        this.errorMessage = event.getErrorCode();
+        this.errorCode = event.getErrorCode();
         this.errorMessage = StringUtils.truncate(event.getErrorMessage(), ERROR_MESSAGE_LENGTH);
         this.errorClassName = event.getErrorClassName();
         this.stackTraceElements = event.getStackTraceElements();

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/StringUtils.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/events/StringUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.events;
+
+import java.util.Optional;
+
+class StringUtils {
+
+    /**
+     *   Truncate a String to the given length with no warnings or error raised if it is bigger.
+     *
+     *   @param  value String to be truncated
+     *   @param  length  Maximum length of string
+     *
+     *   @return Returns value if value is null or value.length() is less or equal to than length, otherwise a String representing
+     *   value truncated to length.
+     */
+    public static String truncate(String value, Integer length) {
+        return Optional.ofNullable(value)
+                       .filter(it -> it.length() > length)
+                       .map(it -> it.substring(0, length))
+                       .orElse(value);
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationErrorReceivedEventImpl;
+import org.activiti.cloud.services.audit.jpa.events.IntegrationErrorReceivedEventEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+public class IntegrationErrorReceivedEventConverterTest {
+
+    @InjectMocks
+    private IntegrationErrorReceivedEventConverter converter;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void createEventEntity_should_setErrorRelatedProperties() {
+        //given
+        CloudIntegrationErrorReceivedEventImpl errorReceivedEvent = new CloudIntegrationErrorReceivedEventImpl(
+            new IntegrationContextImpl(), "errorCode", "Something went wrong",
+            RuntimeException.class.getName(),
+            Collections.singletonList(new StackTraceElement("any", "any", "any", 1)));
+        errorReceivedEvent.setSequenceNumber(1);
+
+        //when
+        IntegrationErrorReceivedEventEntity errorReceivedEventEntity = converter
+            .createEventEntity(errorReceivedEvent);
+
+        //then
+        assertThat(errorReceivedEventEntity.getIntegrationContext())
+            .isEqualTo(errorReceivedEvent.getEntity());
+        assertThat(errorReceivedEventEntity.getErrorCode())
+            .isEqualTo(errorReceivedEvent.getErrorCode());
+        assertThat(errorReceivedEventEntity.getErrorMessage())
+            .isEqualTo(errorReceivedEventEntity.getErrorMessage());
+        assertThat(errorReceivedEventEntity.getErrorClassName())
+            .isEqualTo(errorReceivedEventEntity.getErrorClassName());
+        assertThat(errorReceivedEventEntity.getStackTraceElements())
+            .isEqualTo(errorReceivedEventEntity.getStackTraceElements());
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -111,6 +111,8 @@ import org.springframework.test.context.TestPropertySource;
 @ContextConfiguration(initializers ={ RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
 public class AuditServiceIT {
 
+    private static final String ERROR_MESSAGE = "An error occurred consuming ACS API with inputs {targetFolder={}, action=CREATE_FILE}. Cause: [405] during [GET] to [https://aae-3734-env.envalfresco.com/alfresco/api/-default-/public/alfresco/versions/1/nodes/] [NodesApiClient#getNode(String,List,String,List)]: [{\"error\":{\"errorKey\":\"framework.exception.UnsupportedResourceOperation\",\"statusCode\":405,\"briefSummary\":\"09070282 The operation is unsupported\",\"stackTrace\":\"For security reasons the stack trace is no longer displayed, but the property is kept for previous versions\",\"descriptionURL\":\"https://api-explorer.alfresco.com\"}}]";
+
     @Autowired
     private EventsRestTemplate eventsRestTemplate;
 
@@ -1046,7 +1048,7 @@ public class AuditServiceIT {
 
         testEvents.add(cloudIntegrationResultReceivedEvent);
 
-        Error cause = new Error("Error Message");
+        Error cause = new Error(ERROR_MESSAGE);
         CloudBpmnError error = new CloudBpmnError("ERROR_CODE", cause);
 
         CloudIntegrationErrorReceivedEventImpl cloudIntegrationErrorReceivedEvent = new CloudIntegrationErrorReceivedEventImpl(integrationContext,
@@ -1054,8 +1056,10 @@ public class AuditServiceIT {
                                                                                                                                error.getMessage(),
                                                                                                                                error.getClass().getName(),
                                                                                                                                Arrays.asList(error.getCause()
-                                                                                                                                                  .getStackTrace()));
+
+                                                                                                                                             .getStackTrace()));
         testEvents.add(cloudIntegrationErrorReceivedEvent);
+
 
         return testEvents;
     }

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -1056,8 +1056,7 @@ public class AuditServiceIT {
                                                                                                                                error.getMessage(),
                                                                                                                                error.getClass().getName(),
                                                                                                                                Arrays.asList(error.getCause()
-
-                                                                                                                                             .getStackTrace()));
+                                                                                                                                                  .getStackTrace()));
         testEvents.add(cloudIntegrationErrorReceivedEvent);
 
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/IntegrationContextEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/IntegrationContextEntity.java
@@ -278,7 +278,7 @@ public class IntegrationContextEntity extends ActivitiEntityMetadata implements 
     }
 
     public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
+        this.errorMessage = StringUtils.truncate(errorMessage, 255);
     }
 
     @Override
@@ -520,5 +520,4 @@ public class IntegrationContextEntity extends ActivitiEntityMetadata implements 
                        .map(it -> (T) it.get(name))
                        .orElse(null);
     }
-
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/IntegrationContextEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/IntegrationContextEntity.java
@@ -51,6 +51,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 })
 public class IntegrationContextEntity extends ActivitiEntityMetadata implements CloudIntegrationContext {
 
+    public static final int ERROR_MESSAGE_LENGTH = 255;
+
     @Id
     private String id;
 
@@ -85,6 +87,7 @@ public class IntegrationContextEntity extends ActivitiEntityMetadata implements 
 
     private String errorCode;
 
+    @Column(length = ERROR_MESSAGE_LENGTH)
     private String errorMessage;
 
     private String errorClassName;
@@ -278,7 +281,7 @@ public class IntegrationContextEntity extends ActivitiEntityMetadata implements 
     }
 
     public void setErrorMessage(String errorMessage) {
-        this.errorMessage = StringUtils.truncate(errorMessage, 255);
+        this.errorMessage = StringUtils.truncate(errorMessage, ERROR_MESSAGE_LENGTH);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/StringUtils.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/StringUtils.java
@@ -17,7 +17,7 @@ package org.activiti.cloud.services.query.model;
 
 import java.util.Optional;
 
-class StringUtils {
+public class StringUtils {
 
     /**
      *   Truncate a String to the given length with no warnings or error raised if it is bigger.

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/StringUtils.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/StringUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.model;
+
+import java.util.Optional;
+
+class StringUtils {
+
+    /**
+     *   Truncate a String to the given length with no warnings or error raised if it is bigger.
+     *
+     *   @param  value String to be truncated
+     *   @param  length  Maximum length of string
+     *
+     *   @return Returns value if value is null or value.length() is less or equal to than length, otherwise a String representing
+     *   value truncated to length.
+     */
+    public static String truncate(String value, Integer length) {
+        return Optional.ofNullable(value)
+                       .filter(it -> it.length() > length)
+                       .map(it -> it.substring(0, length))
+                       .orElse(value);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -54,7 +54,7 @@ public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHa
             entity.setErrorDate(new Date(integrationEvent.getTimestamp()));
             entity.setStatus(IntegrationContextStatus.INTEGRATION_ERROR_RECEIVED);
             entity.setErrorCode(integrationEvent.getErrorCode());
-            entity.setErrorMessage(mayBeTruncate(integrationEvent.getErrorMessage(), MAX_VARCHAR_255));
+            entity.setErrorMessage(integrationEvent.getErrorMessage());
             entity.setErrorClassName(integrationEvent.getErrorClassName());
             entity.setStackTraceElements(integrationEvent.getStackTraceElements());
             entity.setInBoundVariables(integrationEvent.getEntity().getInBoundVariables());
@@ -68,12 +68,5 @@ public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHa
     @Override
     public String getHandledEvent() {
         return IntegrationEvents.INTEGRATION_ERROR_RECEIVED.name();
-    }
-
-    protected String mayBeTruncate(String input, Integer maxLength) {
-        return Optional.ofNullable(input)
-                       .filter(it -> it.length() > maxLength)
-                       .map(it -> it.substring(0, maxLength))
-                       .orElse(input);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationErrorReceivedEventHandler.java
@@ -34,8 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class IntegrationErrorReceivedEventHandler extends BaseIntegrationEventHandler implements QueryEventHandler {
 
-    private static final int MAX_VARCHAR_255 = 255;
-
     public IntegrationErrorReceivedEventHandler(IntegrationContextRepository repository,
                                                 ServiceTaskRepository serviceTaskRepository,
                                                 EntityManager entityManager) {


### PR DESCRIPTION
This PR fixes the problem with handling integration error events in Audit and Query that contain error message longer than 255 characters.

The fix will apply truncate function for error message entity attribute in order to avoid SQL error when saving error message contents to persistent backend.

