### PR TITLE
[AAE-3766] Set validator logging level to debug

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ModelValidator;
 import org.activiti.cloud.modeling.api.ValidationContext;
@@ -58,11 +57,11 @@ public abstract class JsonSchemaModelValidator implements ModelValidator {
                     .build()
                     .validate(processExtensionJson);
         } catch (JSONException jsonException) {
-            log.error("Syntactic model JSON validation errors encountered",
+            log.debug("Syntactic model JSON validation errors encountered",
                       jsonException);
             throw new SyntacticModelValidationException(jsonException);
         } catch (ValidationException validationException) {
-            log.error("Semantic model validation errors encountered: " + validationException.toJSON(),
+            log.debug("Semantic model validation errors encountered: " + validationException.toJSON(),
                       validationException);
             throw new SemanticModelValidationException(validationException.getMessage(),
                                                        getValidationErrors(validationException, processExtensionJson));
@@ -71,7 +70,7 @@ public abstract class JsonSchemaModelValidator implements ModelValidator {
 
     private List<ModelValidationError> getValidationErrors(ValidationException validationException, JSONObject prcessExtenstionJson) {
         return getValidationExceptions(validationException)
-                .map(exception -> this.toModelValidationError(exception, prcessExtenstionJson))
+                .map(exception -> toModelValidationError(exception, prcessExtenstionJson))
                 .distinct()
                 .collect(Collectors.toList());
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
@@ -16,15 +16,12 @@
 package org.activiti.cloud.services.modeling.validation.process;
 
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_XML;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.xml.stream.XMLStreamException;
-
 import org.activiti.bpmn.exceptions.XMLException;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.modeling.api.ModelContentValidator;
@@ -73,7 +70,7 @@ public class ProcessModelValidator implements ModelContentValidator {
 
         if (!validationErrors.isEmpty()) {
             String messageError = "Semantic process model validation errors encountered: " + validationErrors;
-            log.error(messageError);
+            log.debug(messageError);
             throw new SemanticModelValidationException(messageError,
                                                        validationErrors);
         }
@@ -87,7 +84,7 @@ public class ProcessModelValidator implements ModelContentValidator {
                     .filter(XMLStreamException.class::isInstance)
                     .orElse(ex);
             String messageError = "Syntactic process model XML validation errors encountered: " + errorCause;
-            log.error(messageError);
+            log.debug(messageError);
             throw new SyntacticModelValidationException(messageError,
                                                         errorCause);
         }


### PR DESCRIPTION
When a user validates a model using the modeling-service, whenever the model is invalid the error and stack trace is printed in console because the logging level is set to ERROR. 

 

Change the logging level to DEBUG for all the validators loggers.