### PR TITLE
[AAE-2902] Add methods related to project to model interface

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ModelImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ModelImpl.java
@@ -196,6 +196,16 @@ public class ModelImpl extends AbstractAuditable<String> implements Model<Projec
     }
 
     @Override
+    public boolean hasProjects() {
+        return getProjects() != null && !getProjects().isEmpty();
+    }
+
+    @Override
+    public boolean hasMultipleProjects() {
+        return getProjects() != null && getProjects().size() > 1;
+    }
+
+    @Override
     public String toString() {
         return type + " MODEL [" + id + ", " + name + "]";
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/Model.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/Model.java
@@ -66,4 +66,8 @@ public interface Model<A extends Project, U> extends Auditable<U> {
     ModelScope getScope();
 
     void setScope(ModelScope scope);
+
+    boolean hasProjects();
+
+    boolean hasMultipleProjects();
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
@@ -234,6 +234,16 @@ public class ModelEntity extends AuditableEntity<String> implements Model<Projec
     }
 
     @Override
+    public boolean hasProjects() {
+        return getProjects() != null && !getProjects().isEmpty();
+    }
+
+    @Override
+    public boolean hasMultipleProjects() {
+        return getProjects() != null && getProjects().size() > 1;
+    }
+
+    @Override
     public List<ModelVersionEntity> getVersions() {
         return versions;
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImplTest.java
@@ -53,6 +53,8 @@ public class ModelRepositoryImplTest {
         model = new ModelEntity();
         model.setId("testModelId");
         model.setName("testNameId");
+        model.addProject(project);
+        model.addProject(new ProjectEntity());
     }
 
     @Test
@@ -65,6 +67,8 @@ public class ModelRepositoryImplTest {
         verify(modelJpaRepository, times(1)).findModelByProjectIdAndNameEqualsAndTypeEquals(project.getId(), model.getName(), processModelType.getName());
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get().getId()).isEqualTo(model.getId());
+        assertThat(result.get().hasProjects()).isTrue();
+        assertThat(result.get().hasMultipleProjects()).isTrue();
     }
 
     @Test

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -177,7 +177,7 @@ public class ModelServiceImpl implements ModelService{
             model.setScope(ModelScope.PROJECT);
         }
 
-        if(ModelScope.PROJECT.equals(model.getScope()) && model.getProjects()!=null && model.getProjects().size()>1){
+        if(ModelScope.PROJECT.equals(model.getScope()) && model.hasMultipleProjects()){
             throw new ModelScopeIntegrityException(
                 "A model at PROJECT scope can only be associated to one project");
         }
@@ -186,7 +186,7 @@ public class ModelServiceImpl implements ModelService{
     @Override
     public Model updateModel(Model modelToBeUpdated,
                              Model newModel) {
-        if(newModel.getProjects()!= null && !newModel.getProjects().isEmpty()){
+        if(newModel.hasProjects()){
             newModel.getProjects().stream().forEach(project -> checkIfModelNameExistsInProject((Project) project,newModel));
         }
         checkModelScopeIntegrity(newModel);
@@ -507,7 +507,7 @@ public class ModelServiceImpl implements ModelService{
         if(validateUsage) {
             validateModelContentAndUsage(model, fileContent.getFileContent(), getValidationContext(model, fileContent, project));
         } else {
-            this.validateModelContent(model, fileContent, project);
+            validateModelContent(model, fileContent, project);
         }
     }
 
@@ -516,7 +516,7 @@ public class ModelServiceImpl implements ModelService{
         if(validateUsage) {
             validateModelContentAndUsage(model, fileContent.getFileContent(), getValidationContext(model, fileContent, null));
         } else {
-            this.validateModelContent(model, fileContent);
+            validateModelContent(model, fileContent);
         }
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -507,7 +507,7 @@ public class ModelServiceImpl implements ModelService{
         if(validateUsage) {
             validateModelContentAndUsage(model, fileContent.getFileContent(), getValidationContext(model, fileContent, project));
         } else {
-            validateModelContent(model, fileContent, project);
+            this.validateModelContent(model, fileContent, project);
         }
     }
 
@@ -516,7 +516,7 @@ public class ModelServiceImpl implements ModelService{
         if(validateUsage) {
             validateModelContentAndUsage(model, fileContent.getFileContent(), getValidationContext(model, fileContent, null));
         } else {
-            validateModelContent(model, fileContent);
+            this.validateModelContent(model, fileContent);
         }
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -344,7 +344,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_updateModelSuccessfully_when_updatingAValidModel() {
+    public void should_updateModelSuccessfully_when_updatingAValidModelWithProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
 
         when(modelOne.getId()).thenReturn("modelOneId");
@@ -358,6 +358,28 @@ public class ModelServiceImplTest {
         modelService.updateModel(modelTwo, modelTwo);
 
         verify(modelRepository).updateModel(modelTwo,modelTwo);
+    }
+
+    @Test
+    public void should_updateModelSuccessfully_when_updatingAValidModelWithoutProject() {
+        when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
+
+        when(modelOne.getId()).thenReturn("modelOneId");
+        when(modelOne.getName()).thenReturn("name");
+        when(modelOne.getType()).thenReturn(modelType.getName());
+
+        when(modelRepository.findModelByNameInProject(projectOne, "name", modelType.getName())).thenReturn(Optional.empty());
+
+        Model modelThree = new ModelImpl();
+        modelThree.setId("modelThreeId");
+        modelThree.setName("name");
+        modelThree.setType(modelType.getName());
+
+        when(modelRepository.updateModel(modelThree, modelThree)).thenReturn(modelThree);
+
+        modelService.updateModel(modelThree, modelThree);
+
+        verify(modelRepository).updateModel(modelThree,modelThree);
     }
 
     private ModelImpl createModelImpl() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -211,6 +211,7 @@ public class ModelServiceImplTest {
         when(modelTwo.getName()).thenReturn("name");
         when(modelTwo.getType()).thenReturn(modelType.getName());
         when(modelTwo.getScope()).thenReturn(null);
+        when(modelTwo.hasProjects()).thenReturn(true);
         when(modelTwo.getProjects()).thenReturn(Set.of(projectOne));
 
         when(modelOne.getId()).thenReturn("modelOneId");


### PR DESCRIPTION
In the modeling community, the relationship between projects and models has changed now to be a `manyToMany` so it would be useful to create some methods in the Model interface that help us to manage that relationship. For example:

- hasProjects
- hasMultipleProjets

See comments in this PR: https://github.com/Alfresco/alfresco-modeling-service/pull/74