### PR TITLE
Restructure the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
   - "${HOME}/.m2/repository"
 stages:
-- name: activiti-cloud-build
+- name: build all
 - name: activiti-cloud-api
 - name: activiti-cloud-service-common
 - name: activiti-cloud-acceptance-tests
@@ -13,9 +13,9 @@ stages:
   if: type != pull_request
 jobs:
   include:
-  - name: activiti-cloud-build
-    stage: activiti-cloud-build
-    script: travis_wait 120 ${MAVEN_CMD} -N && ${MAVEN_CMD} -f activiti-cloud-build/pom.xml
+  - name: build all
+    stage: build all
+    script: mvn clean install -B -DinstallAtEnd=true -DskipTests
   - name: activiti-cloud-api
     stage: activiti-cloud-api
     script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-api/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,13 @@ jobs:
   include:
   - name: build
     stage: build
-    script:
-      - mvn clean install -B -DskipTests -DskipSwaggerGen
-      - aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
+    script: |
+      (
+      set -e
+      thisShouldFailAndStopWithoutCallingNextCommand
+      mvn clean install -B -DskipTests -DskipSwaggerGen
+      aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
+      )
   - name: activiti-cloud-api
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ import:
   - source: Activiti/activiti-scripts:.travis.java.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
+
 cache:
   directories:
   - "${HOME}/.m2/repository"
+
 env:
   global:
     - MAVEN_VERIFY_CMD="mvn verify -B -DinstallAtEnd=true"
+
 stages:
 - name: test
 - name: publish reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ jobs:
     stage: build
     script:
       - mvn clean install -B -DskipTests -DskipSwaggerGen
-      - aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" \
-        --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
+      - aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
   - name: activiti-cloud-api
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 import:
-  - source: Activiti/activiti-scripts:.travis.java.yml@dev-elias-restructure-pipeline
-  - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
-  - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
+  - source: Activiti/activiti-scripts:.travis.java.yml@master
+  - source: Activiti/activiti-scripts:.travis.awscli-install.yml@master
+  - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,52 @@
-import: Activiti/activiti-scripts:.travis.java.yml@master
+import:
+  - source: Activiti/activiti-scripts:.travis.java.yml@master
+  - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
+  - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
 install: skip
-before_cache:
-  #  do not cache snapshots as they will come from AWS S3
-  - find ${M2_REPOSITORY_DIR} -type d -name "*SNAPSHOT" -exec rm -rf {} +
 cache:
   directories:
   - "${HOME}/.m2/repository"
 env:
   global:
-    - M2_REPOSITORY_DIR=${HOME}/.m2/repository
-    - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
-    - S3_M2_REPOSITORY_DIR=${S3_BASE_DIR}/act-cloud/m2/repo/${TRAVIS_BUILD_ID}
-    - S3_JACCO_DIR=${S3_BASE_DIR}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
+    - MAVEN_VERIFY_CMD="mvn verify -B -DinstallAtEnd=true"
 stages:
-- name: build
 - name: test
 - name: publish reports
 - name: tag_deploy_updatebot
   if: type != pull_request
 
-before_install: pip install --user awscli
-before_script: aws s3 sync ${S3_M2_REPOSITORY_DIR} ${M2_REPOSITORY_DIR} --quiet
-
 jobs:
   include:
-  - name: build
-    stage: build
-    script: |
-      (
-      set -e
-      mvn clean install -B -DskipTests -DskipSwaggerGen
-      aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
-      )
   - name: activiti-cloud-api
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-api/pom.xml
   - name: activiti-cloud-service-common
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-service-common/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-service-common/pom.xml
   - name: activiti-cloud-acceptance-tests
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-acceptance-tests/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-acceptance-tests/pom.xml
   - name: activiti-cloud-runtime-bundle-service
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-runtime-bundle-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-runtime-bundle-service/pom.xml
   - name: activiti-cloud-messages-service
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-messages-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-messages-service/pom.xml
   - name: activiti-cloud-query-service
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-query-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-query-service/pom.xml
   - name: activiti-cloud-notifications-graphql-service
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-notifications-graphql-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-notifications-graphql-service/pom.xml
   - name: activiti-cloud-audit-service
     stage: test
-    script: travis_wait 120 ${MAVEN_TEST_CMD} -f activiti-cloud-audit-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-audit-service/pom.xml
   - name: activiti-cloud-modeling-service
-    script: travis_wait 120 ${MAVEN_TEST_CMD} -f activiti-cloud-modeling-service/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-modeling-service/pom.xml
     stage: test
   - name: activiti-cloud-connectors
     stage: test
-    script: ${MAVEN_TEST_CMD} -f activiti-cloud-connectors/pom.xml
+    script: ${MAVEN_VERIFY_CMD} -f activiti-cloud-connectors/pom.xml
   - name: publish reports
     stage: publish reports
     before_script: aws s3 sync ${S3_JACCO_DIR} .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 import:
-  - source: Activiti/activiti-scripts:.travis.java.yml@master
+  - source: Activiti/activiti-scripts:.travis.java.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
-install: skip
 cache:
   directories:
   - "${HOME}/.m2/repository"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,33 @@
 import: Activiti/activiti-scripts:.travis.java.yml@master
 install: true
+
+before_cache:
+  #  do not cache snapshots as they will come from AWS S3
+  - find ${M2_REPOSITORY_DIR} -type d -name "*SNAPSHOT" -exec rm -rf {} +
 cache:
   directories:
   - "${HOME}/.m2/repository"
 env:
+  - M2_REPOSITORY_DIR=${HOME}/.m2/repository
   - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
+  - S3_M2_REPOSITORY_DIR=${S3_BASE_DIR}/act-cloud/m2/repo/${TRAVIS_BUILD_ID}
+  - S3_JACCO_DIR=${S3_BASE_DIR}}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
 stages:
 - name: build
 - name: test
+- name: publish reports
 - name: tag_deploy_updatebot
   if: type != pull_request
+
+before_script: aws s3 sync ${S3_M2_REPOSITORY_DIR} ${M2_REPOSITORY_DIR} --quiet
 jobs:
   include:
   - name: build
     stage: build
-    script: mvn clean install -B -DskipTests -DskipSwaggerGen
+    script:
+      - mvn clean install -B -DskipTests -DskipSwaggerGen
+      - aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" \
+        --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
   - name: activiti-cloud-api
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml
@@ -45,6 +58,10 @@ jobs:
   - name: activiti-cloud-connectors
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-connectors/pom.xml
+  - name: publish reports
+    stage: publish reports
+    before_script: aws s3 sync ${S3_JACCO_DIR} .
+    script: bash <(curl -s https://codecov.io/bash)
   - name: tag_deploy_updatebot
     stage: tag_deploy_updatebot
     script: |
@@ -55,7 +72,8 @@ jobs:
       git push -f -q https://${GITHUB_TOKEN}@github.com/Activiti/activiti-cloud.git v$(cat VERSION) || travis_terminate 1
       mvn clean deploy -DskipTests  || travis_terminate 1
       export VERSION=$(cat VERSION)| make updatebot/push-version || travis_terminate 1
-after_success: bash <(curl -s https://codecov.io/bash)
+after_success:
+  - aws s3 sync . ${S3_JACCO_DIR} --exclude "*" --include "*jacoco.xml"
 after_failure:
 - cat **/target/surefire-reports/*.xml | grep -B 1 -A 10 "<error"
 - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 10 "<error"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ stages:
 - name: tag_deploy_updatebot
   if: type != pull_request
 
+before_install: pip install --user awscli
 before_script: aws s3 sync ${S3_M2_REPOSITORY_DIR} ${M2_REPOSITORY_DIR} --quiet
+
 jobs:
   include:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ import:
   - source: Activiti/activiti-scripts:.travis.java.yml@master
   - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
-install: true
+install: skip
 cache:
   directories:
   - "${HOME}/.m2/repository"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 import: Activiti/activiti-scripts:.travis.java.yml@master
-
+install: skip
 before_cache:
   #  do not cache snapshots as they will come from AWS S3
   - find ${M2_REPOSITORY_DIR} -type d -name "*SNAPSHOT" -exec rm -rf {} +

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - M2_REPOSITORY_DIR=${HOME}/.m2/repository
     - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
     - S3_M2_REPOSITORY_DIR=${S3_BASE_DIR}/act-cloud/m2/repo/${TRAVIS_BUILD_ID}
-    - S3_JACCO_DIR=${S3_BASE_DIR}}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
+    - S3_JACCO_DIR=${S3_BASE_DIR}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
 stages:
 - name: build
 - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ cache:
   directories:
   - "${HOME}/.m2/repository"
 env:
-  - M2_REPOSITORY_DIR=${HOME}/.m2/repository
-  - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
-  - S3_M2_REPOSITORY_DIR=${S3_BASE_DIR}/act-cloud/m2/repo/${TRAVIS_BUILD_ID}
-  - S3_JACCO_DIR=${S3_BASE_DIR}}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
+  global:
+    - M2_REPOSITORY_DIR=${HOME}/.m2/repository
+    - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
+    - S3_M2_REPOSITORY_DIR=${S3_BASE_DIR}/act-cloud/m2/repo/${TRAVIS_BUILD_ID}
+    - S3_JACCO_DIR=${S3_BASE_DIR}}/act-cloud/jacoco/${TRAVIS_BUILD_ID}
 stages:
 - name: build
 - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
   - name: build
     stage: build
-    script: mvn clean install -B -DinstallAtEnd=true -DskipTests
+    script: mvn clean install -B -DinstallAtEnd=true -DskipTests -DskipSwaggerGen
   - name: activiti-cloud-api
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 import: Activiti/activiti-scripts:.travis.java.yml@master
-install: true
 
 before_cache:
   #  do not cache snapshots as they will come from AWS S3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,50 +3,48 @@ install: true
 cache:
   directories:
   - "${HOME}/.m2/repository"
+env:
+  - MAVEN_TEST_CMD="mvn clean verify -B -DinstallAtEnd=true"
 stages:
-- name: build all
-- name: activiti-cloud-api
-- name: activiti-cloud-service-common
-- name: activiti-cloud-acceptance-tests
-- name: activiti-cloud-services
+- name: build
+- name: test
 - name: tag_deploy_updatebot
   if: type != pull_request
 jobs:
   include:
-  - name: build all
-    stage: build all
+  - name: build
+    stage: build
     script: mvn clean install -B -DinstallAtEnd=true -DskipTests
   - name: activiti-cloud-api
-    stage: activiti-cloud-api
-    script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-api/pom.xml
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml
   - name: activiti-cloud-service-common
-    stage: activiti-cloud-service-common
-    script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-service-common/pom.xml
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-service-common/pom.xml
   - name: activiti-cloud-acceptance-tests
-    stage: activiti-cloud-acceptance-tests
-    # acceptance tests depend on runtime bundle dependencies, so we need to build rb first - rb tests will be run in next stage
-    script: |
-      mvn clean install -B -DskipTests -DskipSwaggerGen -f activiti-cloud-runtime-bundle-service/pom.xml || travis_terminate 1
-      travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-acceptance-tests/pom.xml || travis_terminate 1
-  - name: activiti-cloud-runtime-bundle-service_and_activiti-cloud-messages-service
-    stage: activiti-cloud-services
-    script: |
-      travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-runtime-bundle-service/pom.xml || travis_terminate 1
-      travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-messages-service/pom.xml || travis_terminate 1
-  - name: activiti-cloud-query-service_and_activiti-cloud-notifications-graphql-service
-    stage: activiti-cloud-services
-    script: |
-      travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-query-service/pom.xml || travis_terminate 1
-      travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-notifications-graphql-service/pom.xml || travis_terminate 1
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-acceptance-tests/pom.xml
+  - name: activiti-cloud-runtime-bundle-service
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-runtime-bundle-service/pom.xml
+  - name: activiti-cloud-messages-service
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-messages-service/pom.xml
+  - name: activiti-cloud-query-service
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-query-service/pom.xml
+  - name: activiti-cloud-notifications-graphql-service
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-notifications-graphql-service/pom.xml
   - name: activiti-cloud-audit-service
-    stage: activiti-cloud-services
-    script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-audit-service/pom.xml
+    stage: test
+    script: travis_wait 120 ${MAVEN_TEST_CMD} -f activiti-cloud-audit-service/pom.xml
   - name: activiti-cloud-modeling-service
-    script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-modeling-service/pom.xml
-    stage: activiti-cloud-services
+    script: travis_wait 120 ${MAVEN_TEST_CMD} -f activiti-cloud-modeling-service/pom.xml
+    stage: test
   - name: activiti-cloud-connectors
-    stage: activiti-cloud-services
-    script: travis_wait 120 ${MAVEN_CMD} -f activiti-cloud-connectors/pom.xml
+    stage: test
+    script: ${MAVEN_TEST_CMD} -f activiti-cloud-connectors/pom.xml
   - name: tag_deploy_updatebot
     stage: tag_deploy_updatebot
     script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
   - name: build
     stage: build
-    script: mvn clean install -B -DinstallAtEnd=true -DskipTests -DskipSwaggerGen
+    script: mvn clean install -B -DskipTests -DskipSwaggerGen
   - name: activiti-cloud-api
     stage: test
     script: ${MAVEN_TEST_CMD} -f activiti-cloud-api/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ import:
   - source: Activiti/activiti-scripts:.travis.java.yml@master
   - source: Activiti/activiti-scripts:.travis.awscli-install.yml@dev-elias-restructure-pipeline
   - source: Activiti/activiti-scripts:.travis.maven-s3-config.yml@dev-elias-restructure-pipeline
-install: skip
+install: true
 cache:
   directories:
   - "${HOME}/.m2/repository"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
     script: |
       (
       set -e
-      thisShouldFailAndStopWithoutCallingNextCommand
       mvn clean install -B -DskipTests -DskipSwaggerGen
       aws s3 sync ${M2_REPOSITORY_DIR} ${S3_M2_REPOSITORY_DIR} --quiet --exclude "*" --include "org/activiti/*SNAPSHOT*" --exclude "*javadoc.jar*" --exclude "*sources.jar*"
       )

--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -206,6 +206,15 @@
   </modules>
   <repositories>
     <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>activiti-releases</id>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>
     </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,15 @@
   </properties>
   <repositories>
     <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>activiti-releases</id>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>
     </repository>


### PR DESCRIPTION
- build the entire repository skipping test: use `install` goal to have the artifacts cached and available in the next stage
- run the tests for submodules in parallel: use `verify` goal so that the cache is not updated

Closes https://github.com/Activiti/Activiti/issues/3470