### PR TITLE
Changed resource descriptor name for the applications api response 

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/QueryLinkRelationProvider.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/QueryLinkRelationProvider.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.activiti.cloud.services.query.model.ApplicationEntity;
 import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
@@ -50,6 +51,9 @@ public class QueryLinkRelationProvider implements LinkRelationProvider {
         resourceRelationDescriptors.put(TaskVariableEntity.class,
                                         new ResourceRelationDescriptor("variable",
                                                                        "variables"));
+        resourceRelationDescriptors.put(ApplicationEntity.class,
+                                        new ResourceRelationDescriptor("application",
+                                                                        "applications"));
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/QueryLinkRelationProviderTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/QueryLinkRelationProviderTest.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.query.rest;
 
 import org.activiti.cloud.services.query.model.ActivitiEntityMetadata;
+import org.activiti.cloud.services.query.model.ApplicationEntity;
 import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
@@ -77,6 +78,15 @@ public class QueryLinkRelationProviderTest {
     }
 
     @Test
+    public void getItemResourceRelForShouldReturnApplicationWhenIsApplicationEntity() {
+        //when
+        LinkRelation itemResourceRel = relProvider.getItemResourceRelFor(ApplicationEntity.class);
+
+        //then
+        assertThat(itemResourceRel.value()).isEqualTo("application");
+    }
+
+    @Test
     public void getCollectionResourceRelForShouldReturnProcessDefinitionsWhenIsProcessDefinitionEntity() {
         //when
         LinkRelation collectionResourceRel = relProvider.getCollectionResourceRelFor(ProcessDefinitionEntity.class);
@@ -119,6 +129,15 @@ public class QueryLinkRelationProviderTest {
 
         //then
         assertThat(collectionResourceRel.value()).isEqualTo("variables");
+    }
+
+    @Test
+    public void getCollectionResourceRelForShouldReturnApplicationsWhenIsApplicationEntity() {
+        //when
+        LinkRelation collectionResourceRel = relProvider.getCollectionResourceRelFor(ApplicationEntity.class);
+
+        //then
+        assertThat(collectionResourceRel.value()).isEqualTo("applications");
     }
 
     @Test
@@ -174,4 +193,14 @@ public class QueryLinkRelationProviderTest {
         //then
         assertThat(supports).isFalse();
     }
+
+    @Test
+    public void shouldSupportApplicationEntity() {
+        //when
+        boolean supports = relProvider.supports(LinkRelationProvider.LookupContext.forType(ApplicationEntity.class));
+
+        //then
+        assertThat(supports).isTrue();
+    }
+    
 }


### PR DESCRIPTION
Right now when calling /applications with request mapping application/hal+json we get "applicationEntities" as name of the resources in the response. This PR is to fix the name and get "applications" as name of the list in the response. We will not use the request with hal+json but would be right change it to use the same naming convetions as other apis.

eg. current response
`{
    "_embedded": {
        "applicationEntities": [
            {`