### PR TITLE
fix(GH-3574): Added root execution context message headers support 

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
 @Transactional
 public class MessageProducerCommandContextCloseListener implements CommandContextCloseListener {
 
+    public static final String ROOT_EXECUTION_CONTEXT = "rootExecutionContext";
     public static final String PROCESS_ENGINE_EVENTS = "processEngineEvents";
 
     private final ProcessEngineChannels producer;
@@ -58,6 +59,7 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
         List<CloudRuntimeEvent<?, ?>> events = commandContext.getGenericAttribute(PROCESS_ENGINE_EVENTS);
 
         if (events != null && !events.isEmpty()) {
+            ExecutionContext rootExecutionContext = commandContext.getGenericAttribute(ROOT_EXECUTION_CONTEXT);
 
             // Add runtime bundle context attributes to every event
             CloudRuntimeEvent<?, ?>[] payload = events.stream()
@@ -67,7 +69,7 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
                                                       .toArray(CloudRuntimeEvent<?, ?>[]::new);
 
             // Inject message headers with null execution context as there may be events from several process instances
-            Message<CloudRuntimeEvent<?, ?>[]> message = messageBuilderChainFactory.create(null)
+            Message<CloudRuntimeEvent<?, ?>[]> message = messageBuilderChainFactory.create(rootExecutionContext)
                                                                                    .withPayload(payload)
                                                                                    .build();
             // Send message to audit producer channel

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppender.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppender.java
@@ -45,19 +45,19 @@ public class ExecutionContextMessageBuilderAppender implements MessageBuilderApp
 
 
             if(processInstance != null) { 
-                request.setHeader(ExecutionContextMessageHeaders.BUSINESS_KEY, processInstance.getBusinessKey())
-                    .setHeader(ExecutionContextMessageHeaders.PROCESS_INSTANCE_ID, processInstance.getId())
-                    .setHeader(ExecutionContextMessageHeaders.PROCESS_NAME, processInstance.getName());
+                request.setHeader(ExecutionContextMessageHeaders.ROOT_BUSINESS_KEY, processInstance.getBusinessKey())
+                    .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_INSTANCE_ID, processInstance.getId())
+                    .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_NAME, processInstance.getName());
                 
                 // Let's try extract parent process info from super execution if exists
                 applyParent(processInstance, request);
             }
 
             if(processDefinition != null) { 
-                request.setHeader(ExecutionContextMessageHeaders.PROCESS_DEFINITION_ID, processDefinition.getId())
-                    .setHeader(ExecutionContextMessageHeaders.PROCESS_DEFINITION_KEY, processDefinition.getKey())
-                    .setHeader(ExecutionContextMessageHeaders.PROCESS_DEFINITION_VERSION, processDefinition.getVersion())
-                    .setHeader(ExecutionContextMessageHeaders.PROCESS_DEFINITION_NAME, processDefinition.getName());
+                request.setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_ID, processDefinition.getId())
+                    .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_KEY, processDefinition.getKey())
+                    .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_VERSION, processDefinition.getVersion())
+                    .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_NAME, processDefinition.getName());
             }
 
             if(deploymentEntity != null) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppender.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppender.java
@@ -36,24 +36,22 @@ public class ExecutionContextMessageBuilderAppender implements MessageBuilderApp
     @Override
     public <P> MessageBuilder<P> apply(MessageBuilder<P> request) {
         Assert.notNull(request, "request must not be null");
-        
+
         if(executionContext != null) {
             ExecutionEntity processInstance = executionContext.getProcessInstance();
             ProcessDefinition processDefinition = executionContext.getProcessDefinition();
             DeploymentEntity deploymentEntity = executionContext.getDeployment();
 
-
-
-            if(processInstance != null) { 
+            if(processInstance != null) {
                 request.setHeader(ExecutionContextMessageHeaders.ROOT_BUSINESS_KEY, processInstance.getBusinessKey())
                     .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_INSTANCE_ID, processInstance.getId())
                     .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_NAME, processInstance.getName());
-                
+
                 // Let's try extract parent process info from super execution if exists
                 applyParent(processInstance, request);
             }
 
-            if(processDefinition != null) { 
+            if(processDefinition != null) {
                 request.setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_ID, processDefinition.getId())
                     .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_KEY, processDefinition.getKey())
                     .setHeader(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_VERSION, processDefinition.getVersion())
@@ -63,34 +61,34 @@ public class ExecutionContextMessageBuilderAppender implements MessageBuilderApp
             if(deploymentEntity != null) {
                  request.setHeader(ExecutionContextMessageHeaders.DEPLOYMENT_ID, deploymentEntity.getId())
                         .setHeader(ExecutionContextMessageHeaders.DEPLOYMENT_NAME, deploymentEntity.getName())
-                        .setHeader(ExecutionContextMessageHeaders.APP_VERSION, deploymentEntity.getVersion());
+                        .setHeader(ExecutionContextMessageHeaders.DEPLOYMENT_VERSION, deploymentEntity.getVersion());
             }
-            
+
         }
 
         return request;
 
     }
-    
+
     protected <P> MessageBuilder<P> applyParent(ExecutionEntity processInstance, MessageBuilder<P> request) {
         // Let's do it lazy way
         if (processInstance.getSuperExecutionId() != null) {
             Optional.ofNullable(processInstance.getSuperExecution())
                 .ifPresent(superExecution -> {
                     request.setHeader(ExecutionContextMessageHeaders.PARENT_PROCESS_INSTANCE_ID, superExecution.getProcessInstanceId());
-                    
+
                     // Let's do it lazy way
-                    if(superExecution.getProcessInstanceId() != null) { 
+                    if(superExecution.getProcessInstanceId() != null) {
                         Optional.ofNullable(superExecution.getProcessInstance())
                             .ifPresent(parentInstance -> {
-                                request.setHeader(ExecutionContextMessageHeaders.PARENT_PROCESS_INSTANCE_NAME, parentInstance.getName());                                
+                                request.setHeader(ExecutionContextMessageHeaders.PARENT_PROCESS_INSTANCE_NAME, parentInstance.getName());
                             });
                     }
                 });
         }
-        
+
         return request;
     }
-    
+
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageHeaders.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageHeaders.java
@@ -16,23 +16,23 @@
 package org.activiti.cloud.services.events.message;
 
 /**
- * Internal message header key names used in messages with IntegrationContext payload type  
+ * Internal message header key names used in messages with IntegrationContext payload type
  *
  */
 class ExecutionContextMessageHeaders {
-    
+
     public final static String MESSAGE_PAYLOAD_TYPE = "messagePayloadType";
-    public final static String BUSINESS_KEY = "businessKey";
-    public final static String PARENT_PROCESS_INSTANCE_ID = "parentProcessInstanceId";
-    public final static String PROCESS_INSTANCE_ID = "processInstanceId";
-    public final static String PROCESS_NAME = "processName";
-    public final static String PROCESS_DEFINITION_ID = "processDefinitionId";
-    public final static String PROCESS_DEFINITION_KEY = "processDefinitionKey";
-    public final static String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
-    public final static String PROCESS_DEFINITION_NAME = "processDefinitionName";
+    public final static String ROOT_BUSINESS_KEY = "rootBusinessKey";
+    public final static String ROOT_PROCESS_INSTANCE_ID = "rootProcessInstanceId";
+    public final static String ROOT_PROCESS_NAME = "rootProcessName";
+    public final static String ROOT_PROCESS_DEFINITION_ID = "rootProcessDefinitionId";
+    public final static String ROOT_PROCESS_DEFINITION_KEY = "rootProcessDefinitionKey";
+    public final static String ROOT_PROCESS_DEFINITION_VERSION = "rootProcessDefinitionVersion";
+    public final static String ROOT_PROCESS_DEFINITION_NAME = "rootProcessDefinitionName";
     public final static String DEPLOYMENT_ID = "deploymentId";
     public final static String DEPLOYMENT_NAME = "deploymentName";
+    public final static String PARENT_PROCESS_INSTANCE_ID = "parentProcessInstanceId";
     public final static String PARENT_PROCESS_INSTANCE_NAME = "parentProcessInstanceName";
     public final static String APP_VERSION = "appVersion";
-    
+
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageHeaders.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/ExecutionContextMessageHeaders.java
@@ -19,7 +19,7 @@ package org.activiti.cloud.services.events.message;
  * Internal message header key names used in messages with IntegrationContext payload type
  *
  */
-class ExecutionContextMessageHeaders {
+public class ExecutionContextMessageHeaders {
 
     public final static String MESSAGE_PAYLOAD_TYPE = "messagePayloadType";
     public final static String ROOT_BUSINESS_KEY = "rootBusinessKey";
@@ -31,8 +31,7 @@ class ExecutionContextMessageHeaders {
     public final static String ROOT_PROCESS_DEFINITION_NAME = "rootProcessDefinitionName";
     public final static String DEPLOYMENT_ID = "deploymentId";
     public final static String DEPLOYMENT_NAME = "deploymentName";
+    public final static String DEPLOYMENT_VERSION = "deploymentVersion";
     public final static String PARENT_PROCESS_INSTANCE_ID = "parentProcessInstanceId";
     public final static String PARENT_PROCESS_INSTANCE_NAME = "parentProcessInstanceName";
-    public final static String APP_VERSION = "appVersion";
-
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppenderTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppenderTest.java
@@ -67,15 +67,15 @@ public class ExecutionContextMessageBuilderAppenderTest {
         Message<CloudRuntimeEvent<?,?>> message = request.build();
 
         assertThat(message.getHeaders())
-                .containsEntry(ExecutionContextMessageHeaders.BUSINESS_KEY, MOCK_BUSINESS_KEY)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_INSTANCE_ID, MOCK_PROCESS_INSTANCE_ID)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_DEFINITION_ID, MOCK_PROCESS_DEFINITION_ID)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_DEFINITION_KEY, MOCK_PROCESS_DEFINITION_KEY)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_BUSINESS_KEY, MOCK_BUSINESS_KEY)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_INSTANCE_ID, MOCK_PROCESS_INSTANCE_ID)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_ID, MOCK_PROCESS_DEFINITION_ID)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_KEY, MOCK_PROCESS_DEFINITION_KEY)
                 .containsEntry(ExecutionContextMessageHeaders.PARENT_PROCESS_INSTANCE_ID, MOCK_PARENT_PROCESS_INSTANCE_ID)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_DEFINITION_VERSION, MOCK_PROCESS_DEFINITION_VERSION)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_NAME, MOCK_PROCESS_NAME)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_VERSION, MOCK_PROCESS_DEFINITION_VERSION)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_NAME, MOCK_PROCESS_NAME)
                 .containsEntry(ExecutionContextMessageHeaders.PARENT_PROCESS_INSTANCE_NAME, MOCK_PARENT_PROCESS_NAME)
-                .containsEntry(ExecutionContextMessageHeaders.PROCESS_DEFINITION_NAME, MOCK_PROCESS_DEFINITION_NAME)
+                .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_NAME, MOCK_PROCESS_DEFINITION_NAME)
                 .containsEntry(ExecutionContextMessageHeaders.DEPLOYMENT_ID, MOCK_DEPLOYMENT_ID)
                 .containsEntry(ExecutionContextMessageHeaders.DEPLOYMENT_NAME, MOCK_DEPLOYMENT_NAME)
                 .containsEntry(ExecutionContextMessageHeaders.APP_VERSION, MOCK_APP_VERSION);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppenderTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/ExecutionContextMessageBuilderAppenderTest.java
@@ -78,7 +78,7 @@ public class ExecutionContextMessageBuilderAppenderTest {
                 .containsEntry(ExecutionContextMessageHeaders.ROOT_PROCESS_DEFINITION_NAME, MOCK_PROCESS_DEFINITION_NAME)
                 .containsEntry(ExecutionContextMessageHeaders.DEPLOYMENT_ID, MOCK_DEPLOYMENT_ID)
                 .containsEntry(ExecutionContextMessageHeaders.DEPLOYMENT_NAME, MOCK_DEPLOYMENT_NAME)
-                .containsEntry(ExecutionContextMessageHeaders.APP_VERSION, MOCK_APP_VERSION);
+                .containsEntry(ExecutionContextMessageHeaders.DEPLOYMENT_VERSION, MOCK_APP_VERSION);
 
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -118,8 +118,8 @@ public class AuditProducerIT {
 
     public static final String ROUTING_KEY_HEADER = "routingKey";
     public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
-    public static final String[] REQUIRED_EXECUTION_CONTEXT_HEADERS = {"processInstanceId", "processDefinitionId", "processDefinitionKey", "processDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
-    public static final String[] OPTIONAL_EXECUTION_CONTEXT_HEADERS = {"businessKey", "processName", "processDefinitionName"};
+    public static final String[] REQUIRED_EXECUTION_CONTEXT_HEADERS = {"rootProcessInstanceId", "rootProcessDefinitionId", "rootProcessDefinitionKey", "rootProcessDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
+    public static final String[] OPTIONAL_EXECUTION_CONTEXT_HEADERS = {"rootBusinessKey", "rootProcessName", "rootProcessDefinitionName"};
 
     public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS,
         REQUIRED_EXECUTION_CONTEXT_HEADERS)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -118,10 +118,11 @@ public class AuditProducerIT {
 
     public static final String ROUTING_KEY_HEADER = "routingKey";
     public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
-    public static final String[] REQIURED_EXECUTION_CONTEXT_HEADERS = {"processInstanceId", "processDefinitionId", "processDefinitionKey", "processDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
+    public static final String[] REQUIRED_EXECUTION_CONTEXT_HEADERS = {"processInstanceId", "processDefinitionId", "processDefinitionKey", "processDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
     public static final String[] OPTIONAL_EXECUTION_CONTEXT_HEADERS = {"businessKey", "processName", "processDefinitionName"};
 
-    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS, REQIURED_EXECUTION_CONTEXT_HEADERS)
+    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS,
+        REQUIRED_EXECUTION_CONTEXT_HEADERS)
                                                               .flatMap(Stream::of)
                                                               .toArray(String[]::new);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.starter.tests.services.audit;
 
 import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_CREATED;
 import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_UPDATED;
+import static org.activiti.api.process.model.events.ApplicationEvent.ApplicationEvents.APPLICATION_DEPLOYED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_CANCELLED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
@@ -42,7 +43,6 @@ import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TAS
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_CREATED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_SUSPENDED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_UPDATED;
-import static org.activiti.api.process.model.events.ApplicationEvent.ApplicationEvents.APPLICATION_DEPLOYED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -118,9 +118,12 @@ public class AuditProducerIT {
 
     public static final String ROUTING_KEY_HEADER = "routingKey";
     public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
-    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS)
-        .flatMap(Stream::of)
-        .toArray(String[]::new);
+    public static final String[] REQIURED_EXECUTION_CONTEXT_HEADERS = {"processInstanceId", "processDefinitionId", "processDefinitionKey", "processDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
+    public static final String[] OPTIONAL_EXECUTION_CONTEXT_HEADERS = {"businessKey", "processName", "processDefinitionName"};
+
+    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS, REQIURED_EXECUTION_CONTEXT_HEADERS)
+                                                              .flatMap(Stream::of)
+                                                              .toArray(String[]::new);
 
     public static final String AUDIT_PRODUCER_IT = "AuditProducerIT";
     private static final String SIMPLE_PROCESS = "SimpleProcess";
@@ -202,6 +205,7 @@ public class AuditProducerIT {
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getLatestReceivedEvents();
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(OPTIONAL_EXECUTION_CONTEXT_HEADERS);
 
             assertThat(receivedEvents)
                 .extracting(event -> event.getEventType().name())


### PR DESCRIPTION
This PR adds support for injecting root execution context attributes into engine events message headers. The producer and consumers will be able inspect message headers to correlate, route, and filter message events with the following root exection context headers if available:

- [x] rootProcessInstanceId
- [x] rootProcessDefinitionId
- [x] rootProcessDefinitionKey
- [x] rootProcessDefinitionVersion
- [x] deploymentId
- [x] deploymentName
- [x] deploymentVersion

Optional root execution context may include:

- [x] rootBusinessKey
- [x] rootProcessName
- [x] rootProcessDefinitionName

This can be used to enable support for Spring Cloud Stream partitioned query and audit consumers with consistent message routing between partitions using rootProcessInstanceId hash value , i.e.

```
# split engine events stream to 10 partitions
spring.cloud.stream.bindings.auditProducer.producer.partition-count=10

# Use rootProcessInstanceId header to route message between partitions or use random hash value if missing header
spring.cloud.stream.bindings.auditProducer.producer.partition-key-expression=headers['rootProcessInstanceId']?:T(java.lang.Math).random()*100
```

Fixes https://github.com/Activiti/Activiti/issues/3574