### PR TITLE
fix: Improve intermittent Notifcations Service tests

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/ws/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/services/ws/pom.xml
@@ -92,5 +92,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
@@ -206,7 +206,7 @@ public class GraphQLBrokerMessageHandlerTest {
         CountDownLatch completeLatch = new CountDownLatch(1);
 
         // Simulate stomp relay  subscription stream
-        Flux<ExecutionResult> mockStompRelayObservable = Flux.interval(Duration.ZERO, Duration.ofMillis(20))
+        Flux<ExecutionResult> mockStompRelayObservable = Flux.interval(Duration.ofMillis(100), Duration.ofMillis(10))
                                                              .take(count)
                                                              .map(i -> {
                                                                  Map<String, Object> data = new HashMap<>();
@@ -229,10 +229,10 @@ public class GraphQLBrokerMessageHandlerTest {
 
         observable.verify(Duration.ofMinutes(2));
 
-        assertThat(completeLatch.await(4000, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(completeLatch.await(2000, TimeUnit.MILLISECONDS)).isTrue();
 
         // then get last message
-        verify(this.clientOutboundChannel, times(count)).send(this.messageCaptor.capture());
+        verify(this.clientOutboundChannel, times(count+1)).send(this.messageCaptor.capture());
 
         GraphQLMessage completeMessage = messageCaptor.getValue().getPayload();
 

--- a/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.notifications.graphql.ws.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -232,11 +233,13 @@ public class GraphQLBrokerMessageHandlerTest {
         assertThat(completeLatch.await(2000, TimeUnit.MILLISECONDS)).isTrue();
 
         // then get last message
-        verify(this.clientOutboundChannel, times(count+1)).send(this.messageCaptor.capture());
+        await().untilAsserted(() -> {
+            verify(this.clientOutboundChannel, times(count+1)).send(this.messageCaptor.capture());
 
-        GraphQLMessage completeMessage = messageCaptor.getValue().getPayload();
+            GraphQLMessage completeMessage = messageCaptor.getValue().getPayload();
 
-        assertThat(completeMessage.getType()).isEqualTo(GraphQLMessageType.COMPLETE);
+            assertThat(completeMessage.getType()).isEqualTo(GraphQLMessageType.COMPLETE);
+        });
     }
 
     @Test

--- a/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
@@ -229,7 +229,7 @@ public class GraphQLBrokerMessageHandlerTest {
 
         observable.verify(Duration.ofMinutes(2));
 
-        assertThat(completeLatch.await(2000, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(completeLatch.await(4000, TimeUnit.MILLISECONDS)).isTrue();
 
         // then get last message
         verify(this.clientOutboundChannel, times(count)).send(this.messageCaptor.capture());

--- a/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/test/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerMessageHandlerTest.java
@@ -206,7 +206,7 @@ public class GraphQLBrokerMessageHandlerTest {
         CountDownLatch completeLatch = new CountDownLatch(1);
 
         // Simulate stomp relay  subscription stream
-        Flux<ExecutionResult> mockStompRelayObservable = Flux.interval(Duration.ofMillis(100), Duration.ofMillis(10))
+        Flux<ExecutionResult> mockStompRelayObservable = Flux.interval(Duration.ofSeconds(1), Duration.ofMillis(10))
                                                              .take(count)
                                                              .map(i -> {
                                                                  Map<String, Object> data = new HashMap<>();


### PR DESCRIPTION
This PR fixes intermittent test failure due to asynchronous ordered message channel wrapper implementation on the outbound mock message channel used to verify the correct delivery of messages.