### PR TITLE
fix: enable forceJavacCompilerUse in build pom

### DIFF
--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -399,6 +399,7 @@ limitations under the License.]]>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <optimize>true</optimize>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR enables compiler option forceJavacCompilerUse  to be able to see compile errors.