### PR TITLE
Use different names for API clients

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionsApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionsApiClient.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
+@FeignClient(value = "processDefinitionsApiClient",
     url = "${runtime.url}",
     path = "${runtime.path}",
     configuration = {ClientConfiguration.class})

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceApiClient.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
+@FeignClient(value = "processInstanceApiClient",
     url = "${runtime.url}",
     path = "${runtime.path}",
     configuration = {ClientConfiguration.class})

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksApiClient.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
+@FeignClient(value = "processInstanceTasksApiClient",
     url = "${runtime.url}",
     path = "${runtime.path}",
     configuration = {ClientConfiguration.class})

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskApiClient.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
+@FeignClient(value = "taskApiClient",
     url = "${runtime.url}",
     path = "${runtime.path}",
     configuration = {ClientConfiguration.class})

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableApiClient.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableApiClient.java
@@ -18,7 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.services.rest.api.configuration.ClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 
-@FeignClient(value = "runtime",
+@FeignClient(value = "taskVariableApiClient",
     url = "${runtime.url}",
     path = "${runtime.path}",
     configuration = {ClientConfiguration.class},


### PR DESCRIPTION
The same name (`runtime`) was used for different clients, which was causing conflict.

Fixes https://github.com/Activiti/Activiti/issues/3508.