### PR TITLE
fix(messages): add support for filtering non-serializable message headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Running on Travis, requires the following environment variable to be set:
 | GITHUB_TOKEN | Github token for git service account |
 | SRCCLR_API_TOKEN | Source clear api token |
 
+

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessageAggregatorProperties.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessageAggregatorProperties.java
@@ -20,7 +20,7 @@ import org.springframework.expression.Expression;
 
 /**
  * Configuration properties for the Messages Service.
- * 
+ *
  */
 @ConfigurationProperties(MessageAggregatorProperties.PREFIX)
 public class MessageAggregatorProperties {
@@ -36,7 +36,12 @@ public class MessageAggregatorProperties {
      * Persistence message store entity: table prefix in RDBMS, collection name in MongoDb, etc
      */
     private String messageStoreEntity;
-    
+
+    /**
+     * Comma separated list of input headers to be removed, i.e. kafka_consumer
+     */
+    private String[] inputHeadersToRemove;
+
 
     public Expression getGroupTimeout() {
         return this.groupTimeout;
@@ -52,6 +57,14 @@ public class MessageAggregatorProperties {
 
     public void setMessageStoreEntity(String messageStoreEntity) {
         this.messageStoreEntity = messageStoreEntity;
+    }
+
+    public String[] getInputHeadersToRemove() {
+        return inputHeadersToRemove;
+    }
+
+    public void setInputHeadersToRemove(String[] headersToRemove) {
+        this.inputHeadersToRemove = headersToRemove;
     }
 
 }

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessageAggregatorProperties.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessageAggregatorProperties.java
@@ -40,7 +40,12 @@ public class MessageAggregatorProperties {
     /**
      * Comma separated list of input headers to be removed, i.e. kafka_consumer
      */
-    private String[] inputHeadersToRemove;
+    private String[] inputHeadersToRemove = new String[] {};
+
+    /**
+     * HeaderChannelRegistry reaper delay so that the the channel mapping is retained for at least the specified time, i.e.
+     */
+    private String headerChannelsTimeToLiveExpression = null;
 
 
     public Expression getGroupTimeout() {
@@ -65,6 +70,16 @@ public class MessageAggregatorProperties {
 
     public void setInputHeadersToRemove(String[] headersToRemove) {
         this.inputHeadersToRemove = headersToRemove;
+    }
+
+
+    public String getHeaderChannelsTimeToLiveExpression() {
+        return headerChannelsTimeToLiveExpression;
+    }
+
+
+    public void setHeaderChannelsTimeToLiveExpression(String headerChannelsTimeToLiveExpression) {
+        this.headerChannelsTimeToLiveExpression = headerChannelsTimeToLiveExpression;
     }
 
 }

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
@@ -111,7 +111,7 @@ public class MessagesCoreAutoConfiguration {
                                                    aggregator,
                                                    interceptor,
                                                    adviceChain,
-                                                   properties.getInputHeadersToRemove());
+                                                   properties);
     }
 
     @Bean

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/integration/MessageConnectorIntegrationFlow.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/integration/MessageConnectorIntegrationFlow.java
@@ -36,7 +36,6 @@ import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.integration.handler.advice.IdempotentReceiverInterceptor;
-import org.springframework.integration.support.channel.HeaderChannelRegistry;
 import org.springframework.messaging.Message;
 
 public class MessageConnectorIntegrationFlow extends IntegrationFlowAdapter {
@@ -68,17 +67,12 @@ public class MessageConnectorIntegrationFlow extends IntegrationFlowAdapter {
                                             .orElse(new String[] {});
     }
 
-    HeaderChannelRegistry r;
-
     @Override
     protected IntegrationFlowDefinition<?> buildFlow() {
         return this.from(processor.input())
                    .headerFilter(inputHeadersToRemove)
                    .gateway(flow -> flow.log(LoggingHandler.Level.DEBUG)
-                                        .enrichHeaders(enricher -> enricher.defaultOverwrite(true)
-                                                                           .header(DISCARD_CHANNEL, DISCARD_CHANNEL)
-                                                                           .header(ERROR_CHANNEL, ERROR_CHANNEL)
-                                                                           .header(REPLY_CHANNEL, REPLY_CHANNEL))
+                                        .enrichHeaders(enricher -> enricher.headerChannelsToString())
                                         .filter(Message.class,
                                                 this::filterMessage,
                                                 filterSpec -> filterSpec.id(FILTER_MESSAGE)

--- a/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
+++ b/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
@@ -5,3 +5,5 @@ spring.cloud.stream.bindings.input.group=messageConnector
 spring.cloud.stream.bindings.output.destination=commandConsumer
 spring.cloud.stream.bindings.output.contentType=application/json
 spring.cloud.stream.bindings.output.producer.required-groups=messageConnector
+
+activiti.cloud.services.messages.input-headers-to-remove=kafka_consumer

--- a/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
+++ b/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
@@ -7,3 +7,4 @@ spring.cloud.stream.bindings.output.contentType=application/json
 spring.cloud.stream.bindings.output.producer.required-groups=messageConnector
 
 activiti.cloud.services.messages.input-headers-to-remove=kafka_consumer
+activiti.cloud.services.messages.header-channels-time-to-live-expression=headers['headerChannelsTTL'] ?: 120000

--- a/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
+++ b/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
@@ -7,4 +7,4 @@ spring.cloud.stream.bindings.output.contentType=application/json
 spring.cloud.stream.bindings.output.producer.required-groups=messageConnector
 
 activiti.cloud.services.messages.input-headers-to-remove=kafka_consumer
-activiti.cloud.services.messages.header-channels-time-to-live-expression=headers['headerChannelsTTL'] ?: 120000
+activiti.cloud.services.messages.header-channels-time-to-live-expression=headers['headerChannelsTTL']?:60000

--- a/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -43,6 +43,7 @@ import org.activiti.api.process.model.events.MessageSubscriptionEvent.MessageSub
 import org.activiti.api.process.model.payloads.MessageEventPayload;
 import org.activiti.cloud.services.messages.core.aggregator.MessageConnectorAggregator;
 import org.activiti.cloud.services.messages.core.channels.MessageConnectorProcessor;
+import org.activiti.cloud.services.messages.core.config.MessageAggregatorProperties;
 import org.activiti.cloud.services.messages.core.controlbus.ControlBusGateway;
 import org.activiti.cloud.services.messages.core.correlation.Correlations;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -123,6 +124,9 @@ public abstract class AbstractMessagesCoreIntegrationTests {
     protected PlatformTransactionManager transactionManager;
 
     @Autowired
+    protected MessageAggregatorProperties messageAggregatorProperties;
+
+    @Autowired
     protected AbstractMessageChannel output;
 
     @TestConfiguration
@@ -141,6 +145,11 @@ public abstract class AbstractMessagesCoreIntegrationTests {
             return MessageChannels.queue()
                                   .get();
         }
+    }
+
+    @Test
+    public void shouldConfigureInputHeadersToRemove() throws InterruptedException, JsonProcessingException {
+        assertThat(messageAggregatorProperties.getInputHeadersToRemove()).contains("kafka_consumer");
     }
 
     @Test

--- a/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -148,8 +148,13 @@ public abstract class AbstractMessagesCoreIntegrationTests {
     }
 
     @Test
-    public void shouldConfigureInputHeadersToRemove() throws InterruptedException, JsonProcessingException {
+    public void shouldConfigureInputHeadersToRemove() {
         assertThat(messageAggregatorProperties.getInputHeadersToRemove()).contains("kafka_consumer");
+    }
+
+    @Test
+    public void shouldConfigureHeaderChannelsTimeToLiveExpression() {
+        assertThat(messageAggregatorProperties.getHeaderChannelsTimeToLiveExpression()).contains("headers['headerChannelsTTL'] ?: 120000");
     }
 
     @Test

--- a/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -154,7 +154,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
 
     @Test
     public void shouldConfigureHeaderChannelsTimeToLiveExpression() {
-        assertThat(messageAggregatorProperties.getHeaderChannelsTimeToLiveExpression()).contains("headers['headerChannelsTTL'] ?: 120000");
+        assertThat(messageAggregatorProperties.getHeaderChannelsTimeToLiveExpression()).contains("headers['headerChannelsTTL']?:60000");
     }
 
     @Test


### PR DESCRIPTION
Kafka binder is now adding `kafka_consumer` message header with non-serializable Java object that breaks the serialization for the message events store aggregator. This PR adds support for messages service to be able sanitize Kafka headers from input channel and convert Spring Integration support channels injected into headers to string names.