### PR TITLE
feat(GH-3565): add support for email template extensions in modeling Api and json schema

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/Extensions.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/Extensions.java
@@ -15,14 +15,14 @@
  */
 package org.activiti.cloud.modeling.api.process;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 /**
  * Model extensions
@@ -39,6 +39,9 @@ public class Extensions {
 
     @JsonProperty("constants")
     private Map<String,  Map<String, Constant>> constants = new HashMap<>();
+
+    @JsonProperty("templates")
+    private Map<String,  Map<String, Constant>> templates = new HashMap<>();
 
     public Map<String, ProcessVariable> getProcessVariables() {
         return processVariables;
@@ -64,13 +67,20 @@ public class Extensions {
         this.constants = constants;
     }
 
+    public Map<String, Map<String, Constant>> getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(Map<String, Map<String, Constant>> templates) {
+        this.templates = templates;
+    }
+
     public Map<String,Object> getAsMap(){
         Map<String,Object> extensions = new HashMap<>();
         extensions.put("properties",this.processVariables);
         extensions.put("mappings",this.variablesMappings);
         extensions.put("constants",this.constants);
+        extensions.put("templates",this.templates);
         return extensions;
     }
-
-
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/TemplateMapping.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/TemplateMapping.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.modeling.api.process;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Email template mapping item
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class TemplateMapping {
+
+    private TemplateMappingType type;
+
+    private String value;
+
+    public TemplateMappingType getType() {
+        return type;
+    }
+
+    public void setType(TemplateMappingType type) {
+        this.type = type;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/TemplateMappingType.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/TemplateMappingType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.modeling.api.process;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum TemplateMappingType {
+    FILE,VARIABLE;
+
+    @JsonCreator
+    public static TemplateMappingType fromValue(String value) {
+        return Optional.ofNullable(value)
+                .map(String::toUpperCase)
+                .map(TemplateMappingType::valueOf)
+                .orElse(null);
+    }
+
+    @JsonValue
+    public String getValue() {
+        return name().toLowerCase();
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
@@ -54,10 +54,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelValidationError;
@@ -86,6 +87,8 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = ModelingRestApplication.class)
 @WebAppConfiguration
@@ -1378,4 +1381,5 @@ public class ModelControllerIT {
         assertThat(resultActions.andReturn().getResponse().getErrorMessage())
                 .isEqualTo(String.format("A model with the same type already exists within the project with id: %s", project.getId()));
     }
+
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-templates-extensions.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/invalid-templates-extensions.json
@@ -1,0 +1,17 @@
+{
+  "id": "process-db995012-b417-4cea-a981",
+  "extensions": {
+    "Process_test": {
+      "templates": {
+        "Task1": {
+          "type": "file",
+          "value": null
+        },
+        "Task2": {
+          "type": "something",
+          "value": "file1"
+        }
+      }
+    }
+  }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
@@ -1,0 +1,21 @@
+{
+  "id": "process-db995012-b417-4cea-a981",
+  "extensions": {
+    "Process_test": {
+      "templates": {
+        "Task1": {
+          "type": "file",
+          "value": "file://c/project/email.html"
+        },
+        "Task2": {
+          "type": "variable",
+          "value": "file1"
+        },
+        "@": {
+          "type": "file",
+          "value": "classpath:email.html"
+        }
+      }
+    }
+  }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -20,9 +20,37 @@
         "properties": { "$ref": "#/definitions/properties" },
         "mappings": { "$ref": "#/definitions/mappings" },
         "constants": { "$ref": "#/definitions/constants" },
+        "templates": { "$ref": "#/definitions/templates" },
         "assignments": { "$ref": "#/definitions/assignments" }
       }
     },
+    "templates": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/template"
+        }
+      }
+    },
+    "template": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "file",
+            "variable"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },    
     "properties": {
       "type": "object",
       "patternProperties": {


### PR DESCRIPTION
This PR updates the modeling backend service Api and json schema to add support for email template extensions.

Depends on https://github.com/Activiti/Activiti/pull/3562

Fixes https://github.com/Activiti/Activiti/issues/3565