### PR TITLE
Bump resteasy dependency to keycloak server one

### DIFF
--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -40,6 +40,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <java-semver.version>0.9.0</java-semver.version>
     <keycloak.version>12.0.3</keycloak.version>
+    <resteasy.version>3.13.2.Final</resteasy.version>
     <logstash.version>6.6</logstash.version>
     <springfox.version>3.0.0</springfox.version>
     <swagger.version>1.5.20</swagger.version>
@@ -128,6 +129,13 @@
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-client</artifactId>
         <version>${keycloak.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-bom</artifactId>
+        <version>${resteasy.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.github.zafarkhaja</groupId>


### PR DESCRIPTION
fix security issue https://nvd.nist.gov/vuln/detail/CVE-2016-6348