### PR TITLE
fix(audit-liquibase): remove IF NOT EXISTS from audit_event_event_id_idx

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/05-alter.oracle.schema.m11.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/05-alter.oracle.schema.m11.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS audit_event_event_id_idx ON audit_event(event_id);
+CREATE INDEX audit_event_event_id_idx ON audit_event(event_id);

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
@@ -64,6 +64,11 @@
   </changeSet>
 
   <changeSet author="activiti-audit" id="alter5-oracle-schema-m11" dbms="oracle">
+    <preConditions onFail="CONTINUE">
+      <not>
+        <indexExists indexName="audit_event_event_id_idx"/>
+      </not>
+    </preConditions>  
     <sqlFile dbms="oracle"
              encoding="utf8"
              path="changelog/05-alter.oracle.schema.m11.sql"
@@ -71,7 +76,6 @@
              splitStatements="true"
              stripComments="true"/>
   </changeSet>
-
 
   <changeSet author="activiti-audit"
              id="initial-schema-m3" dbms="postgresql">


### PR DESCRIPTION
Unfortunately Oracle does not support the `IF NOT EXISTS` clause for CREATE statements, so we need to remove it from DDL:

```
CREATE INDEX audit_event_event_id_idx ON audit_event(event_id);
```

and add it as precondition to Liquibase manifest:

```
    <preConditions onFail="CONTINUE">
      <not>
        <indexExists indexName="audit_event_event_id_idx"/>
      </not>
    </preConditions>  
```

Fixes https://github.com/Activiti/Activiti/issues/3592