### PR TITLE
fix(notification): update spring.sleuth.integration.patterns property 

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/ws/src/main/resources/META-INF/graphql-ws.properties
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/main/resources/META-INF/graphql-ws.properties
@@ -10,4 +10,4 @@ spring.activiti.cloud.services.notifications.graphql.ws.allowed-origins=*
 spring.activiti.cloud.services.notifications.graphql.ws.buffer-count=50
 spring.activiti.cloud.services.notifications.graphql.ws.buffer-timespan-ms=1000
 
-spring.sleuth.integration.patterns=!hystrixStreamOutput*,!channel,!clientInboundChannel*,!clientOutboundChannel*,!brokerChannel*,*
+spring.sleuth.integration.patterns=!hystrixStreamOutput*,!channel*,!clientInboundChannel*,!clientOutboundChannel*,!brokerChannel*,*


### PR DESCRIPTION
to add missing default functional channels exclusion rule to match 

https://github.com/spring-cloud/spring-cloud-sleuth/blob/7ef8f3886af61263b7811df1283c5091a469266b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/messaging/SleuthIntegrationMessagingProperties.java#L36

Ref https://github.com/Activiti/Activiti/issues/3609