### PR TITLE
Refactor validators to re-use constructor

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/ModelValidationError.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/ModelValidationError.java
@@ -25,9 +25,28 @@ public class ModelValidationError {
     private String validatorSetName;
     private String problem;
     private String description;
-    private boolean isWarning;
+    private boolean isWarning = false;
     private String errorCode;
     private String referenceId;
+
+    public ModelValidationError() {
+    }
+
+    public ModelValidationError(String problem, String description) {
+        this.problem = problem;
+        this.description = description;
+    }
+
+    public ModelValidationError(String problem, String description, String validatorSetName) {
+        this(problem, description);
+        this.validatorSetName = validatorSetName;
+    }
+
+    public ModelValidationError(String problem, String description, String validatorSetName,
+        boolean isWarning) {
+        this(problem, description, validatorSetName);
+        this.isWarning = isWarning;
+    }
 
     public String getValidatorSetName() {
         return validatorSetName;
@@ -76,7 +95,7 @@ public class ModelValidationError {
     public void setReferenceId(String referenceId) {
         this.referenceId = referenceId;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/ModelValidationErrorProducer.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/ModelValidationErrorProducer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.activiti.cloud.modeling.api;
 
 /**
@@ -21,31 +22,13 @@ package org.activiti.cloud.modeling.api;
 public interface ModelValidationErrorProducer {
 
     default ModelValidationError createModelValidationError(String problem,
-                                                            String description) {
-        return createModelValidationError(problem,
-                                          description,
-                                          null);
-    }
-
-    default ModelValidationError createModelValidationError(String problem,
-                                                            String description,
-                                                            String schema) {
-        return createModelValidationError(false,
-                                          problem,
-                                          description,
-                                          schema,
-                                          null);
-    }
-
-    default ModelValidationError createModelValidationError(String problem,
                                                             String description,
                                                             String schema,
                                                             String errorCode) {
-        return createModelValidationError(false,
-                                          problem,
-                                          description,
-                                          schema,
-                                          errorCode);
+        ModelValidationError modelValidationError = new ModelValidationError(problem, description,
+            schema);
+        modelValidationError.setErrorCode(errorCode);
+        return modelValidationError;
     }
 
     default ModelValidationError createModelValidationError(String problem,
@@ -53,37 +36,11 @@ public interface ModelValidationErrorProducer {
                                                             String schema,
                                                             String errorCode,
                                                             String referenceId) {
-        ModelValidationError validationError = createModelValidationError(false,
-            problem,
-            description,
-            schema,
-            errorCode);
+
+        ModelValidationError validationError = new ModelValidationError(problem, description, schema);
+        validationError.setErrorCode(errorCode);
         validationError.setReferenceId(referenceId);
         return validationError;
     }
 
-    default ModelValidationError createModelValidationError(boolean warning,
-                                                            String problem,
-                                                            String description,
-                                                            String schema) {
-        return createModelValidationError(warning,
-                                          problem,
-                                          description,
-                                          schema,
-                                          null);
-    }
-
-    default ModelValidationError createModelValidationError(boolean warning,
-                                                            String problem,
-                                                            String description,
-                                                            String schema,
-                                                            String errorCode) {
-        ModelValidationError modelValidationError = new ModelValidationError();
-        modelValidationError.setWarning(warning);
-        modelValidationError.setProblem(problem);
-        modelValidationError.setDescription(description);
-        modelValidationError.setValidatorSetName(schema);
-        modelValidationError.setErrorCode(errorCode);
-        return modelValidationError;
-    }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeValidationControllerIT.java
@@ -34,6 +34,7 @@ import org.activiti.cloud.modeling.api.JsonModelType;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelContentValidator;
 import org.activiti.cloud.modeling.api.ModelExtensionsValidator;
+import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
 import org.activiti.cloud.modeling.core.error.SemanticModelValidationException;
 import org.activiti.cloud.modeling.repository.ModelRepository;
@@ -97,18 +98,18 @@ public class GenericJsonModelTypeValidationControllerIT {
     }
 
     private void validateInvalidContent() {
-        SemanticModelValidationException exception = new SemanticModelValidationException(Collections
-                .singletonList(genericJsonContentValidator.createModelValidationError("Content invalid",
-                                                                                      "The content is invalid!!")));
+      SemanticModelValidationException exception = new SemanticModelValidationException(Collections
+                .singletonList(
+                    new ModelValidationError("Content invalid", "The content is invalid!!")));
 
         doThrow(exception).when(genericJsonContentValidator).validateModelContent(any(byte[].class),
                                                                                   any(ValidationContext.class));
     }
 
     private void validateInvalidExtensions() {
-        SemanticModelValidationException exception = new SemanticModelValidationException(Collections
-                .singletonList(genericJsonContentValidator.createModelValidationError("Extensions invalid",
-                                                                                      "The extensions are invalid!!")));
+      SemanticModelValidationException exception = new SemanticModelValidationException(Collections
+                .singletonList(
+                    new ModelValidationError("Extensions invalid", "The extensions are invalid!!")));
 
         doThrow(exception).when(genericJsonExtensionsValidator).validateModelExtensions(any(byte[].class),
                                                                                         any(ValidationContext.class));
@@ -400,8 +401,8 @@ public class GenericJsonModelTypeValidationControllerIT {
 
     @Test
     public void should_throwExceptionAndCallGenericJsonContentUsageValidatorA_when_validatingInvalidModelContent() throws IOException {
-        SemanticModelValidationException exception = new SemanticModelValidationException(Collections
-            .singletonList(genericJsonContentValidator.createModelValidationError("Content invalid", "The content is invalid!!")));
+      SemanticModelValidationException exception = new SemanticModelValidationException(Collections
+            .singletonList(new ModelValidationError("Content invalid", "The content is invalid!!")));
 
         doThrow(exception).when(genericJsonContentValidator).validateModelContent(any(Model.class), any(byte[].class), any(ValidationContext.class), any(boolean.class));
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
@@ -34,6 +34,7 @@ import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelContentValidator;
 import org.activiti.cloud.modeling.api.ModelExtensionsValidator;
 import org.activiti.cloud.modeling.api.ModelType;
+import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
 import org.activiti.cloud.modeling.core.error.SemanticModelValidationException;
 import org.activiti.cloud.modeling.repository.ModelRepository;
@@ -97,18 +98,18 @@ public class GenericNonJsonModelTypeValidationControllerIT {
     }
 
     private void validateInvalidContent() {
-        SemanticModelValidationException exception = new SemanticModelValidationException(Collections
-                .singletonList(genericNonJsonContentValidator.createModelValidationError("Content invalid",
-                                                                                         "The content is invalid!!")));
+      SemanticModelValidationException exception = new SemanticModelValidationException(Collections
+                .singletonList(
+                    new ModelValidationError("Content invalid", "The content is invalid!!")));
 
         doThrow(exception).when(genericNonJsonContentValidator).validateModelContent(any(byte[].class),
                                                                                      any(ValidationContext.class));
     }
 
     private void validateInvalidExtensions() {
-        SemanticModelValidationException exception = new SemanticModelValidationException(Collections
-                .singletonList(genericNonJsonContentValidator.createModelValidationError("Extensions invalid",
-                                                                                         "The extensions are invalid!!")));
+      SemanticModelValidationException exception = new SemanticModelValidationException(Collections
+                .singletonList(
+                    new ModelValidationError("Extensions invalid", "The extensions are invalid!!")));
 
         doThrow(exception).when(genericNonJsonExtensionsValidator).validateModelExtensions(any(byte[].class),
                                                                                            any(ValidationContext.class));

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
@@ -106,9 +106,7 @@ public abstract class JsonSchemaModelValidator implements ModelValidator {
         String schema = Optional.ofNullable(validationException.getViolatedSchema())
                 .map(Schema::getSchemaLocation)
                 .orElse(null);
-        return createModelValidationError(validationException.getErrorMessage(),
-                                          description,
-                                          schema);
+        return new ModelValidationError(validationException.getErrorMessage(), description, schema);
     }
 
     private String resolveExpression(String message, String  pointerToViolation, JSONObject prcessExtenstionJson) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionMessageMappingValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionMessageMappingValidator.java
@@ -80,10 +80,10 @@ public class ProcessExtensionMessageMappingValidator implements ProcessExtension
     private List<ModelValidationError> validate(MappingModel mappingModel) {
         return mappingModel.getProcessVariableMappings().entrySet().stream()
             .filter((variable) -> !variable.getKey().matches(PAYLOAD_PATTERN))
-            .map(variable -> createModelValidationError(
-                format(INVALID_PAYLOAD_NAME_ERROR, mappingModel.getFlowNode().getName(), mappingModel.getProcessId()),
-                format(INVALID_PAYLOAD_NAME_ERROR_DESCRIPTION, mappingModel.getProcessId(), mappingModel.getFlowNode().getId(), variable.getKey())
-            ))
+            .map(
+                variable -> new ModelValidationError(
+                    format(INVALID_PAYLOAD_NAME_ERROR, mappingModel.getFlowNode().getName(), mappingModel.getProcessId()),
+                    format(INVALID_PAYLOAD_NAME_ERROR_DESCRIPTION, mappingModel.getProcessId(), mappingModel.getFlowNode().getId(), variable.getKey())))
             .collect(Collectors.toList());
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
@@ -78,11 +78,10 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
                 .map(bpmnModel -> validateBpmnModel(model,
                                                           context,
                                                           bpmnModel))
-                .orElseGet(() -> Stream.of(createModelValidationError(
-                        format(UNKNOWN_PROCESS_ID_VALIDATION_ERROR_PROBLEM,
-                               model.getId()),
-                        format(UNKNOWN_PROCESS_ID_VALIDATION_ERROR_DESCRIPTION,
-                               model.getId()))))
+                .orElseGet(() -> Stream.of(
+                    new ModelValidationError(format(UNKNOWN_PROCESS_ID_VALIDATION_ERROR_PROBLEM,
+                        model.getId()), format(UNKNOWN_PROCESS_ID_VALIDATION_ERROR_DESCRIPTION,
+                        model.getId()))))
                 .collect(Collectors.toList());
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsProcessVariablesValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsProcessVariablesValidator.java
@@ -26,7 +26,6 @@ import org.activiti.cloud.modeling.api.process.ProcessVariable;
 import org.activiti.cloud.modeling.api.process.ProcessVariableMapping;
 import org.activiti.cloud.modeling.api.process.ServiceTaskActionType;
 import org.activiti.cloud.services.modeling.converter.BpmnProcessModelContent;
-import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.Optional;
@@ -77,14 +76,13 @@ public class ProcessExtensionsProcessVariablesValidator implements ProcessExtens
                                                                           String processId,
                                                                           Set<String> availableProcessVariables) {
         Object variableName = action == INPUTS ? processVariableMapping.getValue() : processVariableMappingKey;
-        return processVariableMapping.getType() == VARIABLE &&
+      return processVariableMapping.getType() == VARIABLE &&
                 !availableProcessVariables.contains(variableName) ?
-                Optional.of(createModelValidationError(
-                        format(UNKNOWN_PROCESS_VARIABLE_VALIDATION_ERROR_PROBLEM,
-                               variableName),
-                        format(UNKNOWN_PROCESS_VARIABLE_VALIDATION_ERROR_DESCRIPTION,
-                               processId,
-                               variableName))) :
+                Optional.of(new ModelValidationError(
+                    format(UNKNOWN_PROCESS_VARIABLE_VALIDATION_ERROR_PROBLEM,
+                        variableName), format(UNKNOWN_PROCESS_VARIABLE_VALIDATION_ERROR_DESCRIPTION,
+                    processId,
+                    variableName))) :
                 Optional.empty();
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsTaskMappingsValidator.java
@@ -100,12 +100,11 @@ public class ProcessExtensionsTaskMappingsValidator implements ProcessExtensions
                                                   extensionMapping,
                                                   taskConstants,
                                                   context))
-                .orElseGet(() -> Stream.of(createModelValidationError(
-                        format(UNKNOWN_TASK_VALIDATION_ERROR_PROBLEM,
-                               taskId),
-                        format(UNKNOWN_TASK_VALIDATION_ERROR_DESCRIPTION,
-                               processId,
-                               taskId))));
+                .orElseGet(() -> Stream.of(
+                    new ModelValidationError(format(UNKNOWN_TASK_VALIDATION_ERROR_PROBLEM,
+                        taskId), format(UNKNOWN_TASK_VALIDATION_ERROR_DESCRIPTION,
+                        processId,
+                        taskId))));
     }
 
     private Stream<ModelValidationError> validateTaskMappings(

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/TaskMappingsServiceTaskImplementationValidator.java
@@ -82,17 +82,16 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
         Optional<String> implementationTask = getTaskImplementation(taskMapping.getFlowNode());
 
         if (implementationTask.isPresent() && isConnector(implementationTask) && !availableConnectorActions.containsKey(implementationTask.get())) {
-            return Optional.of(createModelValidationError(
-                format(UNKNOWN_CONNECTOR_ACTION_VALIDATION_ERROR_PROBLEM,
-                    taskMapping.getAction().name(),
-                    taskMapping.getFlowNode().getId(),
-                    implementationTask.get()),
-                format(UNKNOWN_CONNECTOR_ACTION_VALIDATION_ERROR_DESCRIPTION,
-                    taskMapping.getProcessId(),
-                    taskMapping.getAction().name(),
-                    taskMapping.getFlowNode().getId(),
-                    implementationTask.get())
-            )).stream();
+          return Optional.of(
+              new ModelValidationError(format(UNKNOWN_CONNECTOR_ACTION_VALIDATION_ERROR_PROBLEM,
+                  taskMapping.getAction().name(),
+                  taskMapping.getFlowNode().getId(),
+                  implementationTask.get()),
+                  format(UNKNOWN_CONNECTOR_ACTION_VALIDATION_ERROR_DESCRIPTION,
+                      taskMapping.getProcessId(),
+                      taskMapping.getAction().name(),
+                      taskMapping.getFlowNode().getId(),
+                      implementationTask.get()))).stream();
         }
 
         return taskMapping
@@ -136,7 +135,7 @@ public class TaskMappingsServiceTaskImplementationValidator implements TaskMappi
                     .filter(parameter -> parameter.equals(connectorParameterName))
                     .findFirst()
                     .map(parameter -> Optional.<ModelValidationError>empty())
-                    .orElseGet(() -> Optional.of(createModelValidationError(
+                    .orElseGet(() -> Optional.of(new ModelValidationError(
                         format(UNKNOWN_CONNECTOR_PARAMETER_VALIDATION_ERROR_PROBLEM,
                             actionType.name().toLowerCase(),
                             connectorParameterName),

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelCallActivityValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelCallActivityValidator.java
@@ -104,13 +104,12 @@ public class BpmnModelCallActivityValidator implements BpmnModelValidator {
         String calledElement = callActivity.getCalledElement();
 
         if (isEmpty(calledElement)) {
-            return Optional.of(createModelValidationError(format(NO_REFERENCE_FOR_CALL_ACTIVITY_PROBLEM,
-                                                                 callActivity.getId(),
-                                                                 mainProcess),
-                                                          format(NO_REFERENCE_FOR_CALL_ACTIVITY_DESCRIPTION,
-                                                                 callActivity.getId(),
-                                                                 mainProcess),
-                                                          NO_REFERENCE_FOR_CALL_ACTIVITY_REFERENCE_NAME)
+            return Optional.of(
+                new ModelValidationError(format(NO_REFERENCE_FOR_CALL_ACTIVITY_PROBLEM,
+                    callActivity.getId(),
+                    mainProcess), format(NO_REFERENCE_FOR_CALL_ACTIVITY_DESCRIPTION,
+                    callActivity.getId(),
+                    mainProcess), NO_REFERENCE_FOR_CALL_ACTIVITY_REFERENCE_NAME)
             );
         }
         else if (calledElement.matches(expressionRegex)) {
@@ -120,13 +119,13 @@ public class BpmnModelCallActivityValidator implements BpmnModelValidator {
             String calledElementId = calledElement.replace("process-",
                                                            "");
             return !availableProcessesIds.contains(calledElementId) ?
-                    Optional.of(createModelValidationError(INVALID_CALL_ACTIVITY_REFERENCE_PROBLEM,
-                                                           format(INVALID_CALL_ACTIVITY_REFERENCE_DESCRIPTION,
-                                                                  callActivity.getId(),
-                                                                  calledElementId,
-                                                                  mainProcess,
-                                                                  INVALID_CALL_ACTIVITY_REFERENCE_NAME),
-                                                           INVALID_CALL_ACTIVITY_REFERENCE_NAME)) : Optional.empty();
+                    Optional.of(new ModelValidationError(INVALID_CALL_ACTIVITY_REFERENCE_PROBLEM,
+                        format(INVALID_CALL_ACTIVITY_REFERENCE_DESCRIPTION,
+                            callActivity.getId(),
+                            calledElementId,
+                            mainProcess,
+                            INVALID_CALL_ACTIVITY_REFERENCE_NAME),
+                        INVALID_CALL_ACTIVITY_REFERENCE_NAME)) : Optional.empty();
         }
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelEngineValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelEngineValidator.java
@@ -43,9 +43,8 @@ public class BpmnModelEngineValidator implements BpmnModelValidator {
     }
 
     private ModelValidationError toModelValidationError(ValidationError validationError) {
-        return createModelValidationError(validationError.isWarning(),
-                                          validationError.getProblem(),
-                                          validationError.getDefaultDescription(),
-                                          validationError.getValidatorSetName());
+        return new ModelValidationError(validationError.getProblem(),
+            validationError.getDefaultDescription(), validationError.getValidatorSetName(),
+            validationError.isWarning());
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
@@ -109,9 +109,9 @@ public class BpmnModelServiceTaskImplementationValidator implements BpmnModelVal
                 .filter(implementation -> implementation.equals(serviceTask.getImplementation()))
                 .findFirst()
                 .map(implementation -> Optional.<ModelValidationError>empty())
-                .orElseGet(() -> Optional.of(createModelValidationError(INVALID_SERVICE_IMPLEMENTATION_PROBLEM,
-                                                                        format(INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION,
-                                                                               serviceTask.getId()),
-                                                                        SERVICE_USER_TASK_VALIDATOR_NAME)));
+                .orElseGet(() -> Optional.of(
+                    new ModelValidationError(INVALID_SERVICE_IMPLEMENTATION_PROBLEM,
+                        format(INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION,
+                            serviceTask.getId()), SERVICE_USER_TASK_VALIDATOR_NAME)));
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
@@ -53,8 +53,8 @@ public class BpmnModelUserTaskAssigneeValidator implements BpmnModelValidator {
             return Optional.empty();
         }
 
-        return Optional.of(createModelValidationError(NO_ASSIGNEE_PROBLEM_TITLE,
-                                                      NO_ASSIGNEE_DESCRIPTION,
-                                                      USER_TASK_ASSIGNEE_VALIDATOR_NAME));
+        return Optional.of(
+            new ModelValidationError(NO_ASSIGNEE_PROBLEM_TITLE, NO_ASSIGNEE_DESCRIPTION,
+                USER_TASK_ASSIGNEE_VALIDATOR_NAME));
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/project/ProjectConsistencyValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/project/ProjectConsistencyValidator.java
@@ -43,7 +43,7 @@ public class ProjectConsistencyValidator implements ProjectValidator {
                 .stream()
                 .findFirst()
                 .map(model -> Stream.<ModelValidationError>empty())
-                .orElseGet(() -> Stream.of(createModelValidationError(EMPTY_PROJECT_PROBLEM,
-                                                                      EMPTY_PROJECT_DESCRIPTION)));
+                .orElseGet(() -> Stream.of(
+                    new ModelValidationError(EMPTY_PROJECT_PROBLEM, EMPTY_PROJECT_DESCRIPTION)));
     }
 }


### PR DESCRIPTION
Instead of using utility method from the internal interface, it's better to provide meaningful constructors