### PR TITLE
fix: optimize websockets notification message handler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Set preview version
         if: ${{ contains(github.head_ref, 'preview') }}
         run: |
-          BRANCH_NAME=${GITHUB_HEAD_REF#refs/heads/}
-          echo 0.0.1-${BRANCH_NAME/\//-}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION
+          GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
+          echo 0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION
 
       - name: Set VERSION env variable
         if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.messaging.Message;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
@@ -90,7 +91,7 @@ public class EngineEventsConsumerAutoConfiguration {
         @ConditionalOnMissingBean(name = "engineEventsIntegrationFlow")
         public IntegrationFlow engineEventsIntegrationFlow(EngineEventsConsumerMessageHandler engineEventsMessageHandler) {
             return IntegrationFlows.from(EngineEventsConsumerChannels.SOURCE)
-                                   .log()
+                                   .log(LoggingHandler.Level.DEBUG)
                                    .handle(engineEventsMessageHandler)
                                    .get();
         }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
@@ -87,7 +87,7 @@ public class EngineEventsConsumerAutoConfiguration {
         }
 
         @Bean
-        @ConditionalOnMissingBean
+        @ConditionalOnMissingBean(name = "engineEventsIntegrationFlow")
         public IntegrationFlow engineEventsIntegrationFlow(EngineEventsConsumerMessageHandler engineEventsMessageHandler) {
             return IntegrationFlows.from(EngineEventsConsumerChannels.SOURCE)
                                    .log()

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
@@ -15,10 +15,6 @@
  */
 package org.activiti.cloud.services.notifications.graphql.events.consumer;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.activiti.cloud.services.notifications.graphql.events.RoutingKeyResolver;
 import org.activiti.cloud.services.notifications.graphql.events.SpELTemplateRoutingKeyResolver;
 import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
@@ -35,16 +31,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.messaging.Message;
-
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import reactor.extra.processor.TopicProcessor;
+import reactor.core.publisher.Sinks;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Notification Gateway configuration that enables messaging channel bindings
  * and scans for MessagingGateway on interfaces to create GatewayProxyFactoryBeans.
- *
  */
 @Configuration
 @EnableBinding(EngineEventsConsumerChannels.class)
@@ -83,23 +82,29 @@ public class EngineEventsConsumerAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         public EngineEventsConsumerMessageHandler engineEventsMessageHandler(Transformer engineEventsTransformer,
-                                                                             FluxSink<Message<List<EngineEvent>>> engineEventsSink) {
+                                                                             Sinks.Many<Message<List<EngineEvent>>> engineEventsSink) {
             return new EngineEventsConsumerMessageHandler(engineEventsTransformer, engineEventsSink);
         }
 
+        @Bean
+        @ConditionalOnMissingBean
+        public IntegrationFlow engineEventsIntegrationFlow(EngineEventsConsumerMessageHandler engineEventsMessageHandler) {
+            return IntegrationFlows.from(EngineEventsConsumerChannels.SOURCE)
+                                   .log()
+                                   .handle(engineEventsMessageHandler)
+                                   .get();
+        }
     }
 
     @Configuration
     public static class EngineEventsFluxProcessorConfiguration implements SmartLifecycle {
 
         private final List<Subscriber<Message<List<EngineEvent>>>> subscribers = new ArrayList<>();
-        private boolean running;
+        private boolean running = false;
 
-        private TopicProcessor<Message<List<EngineEvent>>> engineEventsProcessor = TopicProcessor.<Message<List<EngineEvent>>>builder()
-                                                                                                 .autoCancel(false)
-                                                                                                 .share(true)
-                                                                                                 .bufferSize(1024)
-                                                                                                 .build();
+        private Sinks.Many<Message<List<EngineEvent>>> engineEventsProcessor = Sinks.many()
+                                                                                    .multicast()
+                                                                                    .directBestEffort();
         @Autowired
         public EngineEventsFluxProcessorConfiguration() {
         }
@@ -112,26 +117,28 @@ public class EngineEventsConsumerAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         public Flux<Message<List<EngineEvent>>> engineEventsFlux() {
-            return engineEventsProcessor.publish()
-                                        .autoConnect(0);
+            return engineEventsProcessor.asFlux();
         }
 
         @Bean
         @ConditionalOnMissingBean
-        public FluxSink<Message<List<EngineEvent>>> engineEventsSink() {
-            return engineEventsProcessor.sink();
+        public Sinks.Many<Message<List<EngineEvent>>> engineEventsSink() {
+            return engineEventsProcessor;
         }
 
         @Override
         public void start() {
-            subscribers.forEach(s -> engineEventsProcessor.subscribe(s));
-            running = true;
+            if(!running) {
+                subscribers.forEach(s -> engineEventsFlux().subscribe(s));
+
+                running = true;
+            }
         }
 
         @Override
         public void stop() {
             try {
-                engineEventsProcessor.onComplete();
+                engineEventsProcessor.tryEmitComplete();
             } finally {
                 running = false;
             }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
@@ -54,7 +54,7 @@ public class EngineEventsConsumerMessageHandler {
                     List<Map<String, Object>> events = message.getPayload();
                     String routingKey = (String) message.getHeaders().get("routingKey");
 
-                    logger.info("Recieved source message with routingKey: {}", routingKey);
+                    logger.debug("Recieved source message {} with routingKey: {}", message, routingKey);
 
                     return Flux.fromIterable(transformer.transform(events))
                                    .collectList()

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
@@ -63,7 +63,6 @@ public class EngineEventsConsumerMessageHandler {
                 })
                 .doOnNext(processorSink::tryEmitNext)
                 .doOnError(error -> logger.error("Error handling message ", error))
-                .retry(3)
                 .subscribe();
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerMessageHandler.java
@@ -24,26 +24,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Sinks;
 
 public class EngineEventsConsumerMessageHandler {
 
     private static Logger logger = LoggerFactory.getLogger(EngineEventsConsumerMessageHandler.class);
 
-    private final FluxSink<Message<List<EngineEvent>>> processorSink;
+    private final Sinks.Many<Message<List<EngineEvent>>> processorSink;
     private final Transformer transformer;
 
     public EngineEventsConsumerMessageHandler(Transformer transformer,
-                                      FluxSink<Message<List<EngineEvent>>> engineEventsSink)
+                                              Sinks.Many<Message<List<EngineEvent>>> engineEventsSink)
     {
         this.processorSink = engineEventsSink;
         this.transformer = transformer;
     }
 
-    @StreamListener(EngineEventsConsumerChannels.SOURCE)
+    @ServiceActivator
     public void receive(Message<List<Map<String, Object>>> input) {
 
         // Let's process and transform message from input stream
@@ -59,9 +61,9 @@ public class EngineEventsConsumerMessageHandler {
                                    .map(list -> MessageBuilder.<List<EngineEvent>>createMessage(list,
                                                                                                 message.getHeaders()));
                 })
-                .doOnNext(processorSink::next)
+                .doOnNext(processorSink::tryEmitNext)
                 .doOnError(error -> logger.error("Error handling message ", error))
-                .retry()
+                .retry(3)
                 .subscribe();
     }
 }


### PR DESCRIPTION
This PR changes the following:

- [x] Update to replace deprecated Project Reactor processor API with Sinks 
- [x] Update to replace buffered event processor with direct best effort multicast sink
- [x] Update to replace deprecated StreamListener with IntegrationFlow implementation
- [x] Update to change default log level to DEBUG
- [x] Remove redundant retry from message stream