### PR TITLE
fix(GH-3674):  split ProcessDeployedEvents into message per process definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,15 +52,15 @@ jobs:
         env:
           MAVEN_VERSION: 3.6.3
 
-    #   - name: Cache Maven packages
-    #     uses: actions/cache@v2
-    #     with:
-    #       path: ~/.m2
-    #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-    #       restore-keys: ${{ runner.os }}-m2
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn -B clean verify
+        run: mvn -B verify
 
       - name: Install jx-release-version
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn -B verify
+        run: mvn -B clean install
 
       - name: Install jx-release-version
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,15 +52,15 @@ jobs:
         env:
           MAVEN_VERSION: 3.6.3
 
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+    #   - name: Cache Maven packages
+    #     uses: actions/cache@v2
+    #     with:
+    #       path: ~/.m2
+    #       key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+    #       restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn -B clean install
+        run: mvn -B clean verify
 
       - name: Install jx-release-version
         if: ${{ github.event_name == 'push' }}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -76,7 +76,7 @@ import org.springframework.context.annotation.PropertySources;
     @PropertySource(value="classpath:/activiti-audit-producer.properties", ignoreResourceNotFound = true) // optional override
 })
 public class CloudEventsAutoConfiguration {
-    
+
     @Bean
     @ConditionalOnMissingBean
     public RuntimeBundleInfoAppender runtimeBundleInfoAppender(RuntimeBundleProperties properties) {
@@ -88,7 +88,7 @@ public class CloudEventsAutoConfiguration {
     public CloudRuntimeEventMessageBuilderFactory cloudRuntimeEventMessageBuilderFactory(RuntimeBundleProperties properties) {
         return new CloudRuntimeEventMessageBuilderFactory(properties);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public ExecutionContextMessageBuilderFactory executionContextMessageBuilderFactory(RuntimeBundleProperties properties) {
@@ -265,7 +265,7 @@ public class CloudEventsAutoConfiguration {
                                                                    ProcessEngineEventsAggregator eventsAggregator) {
         return new CloudProcessUpdatedProducer(eventConverter,
                                                eventsAggregator);
-    } 
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -320,7 +320,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudActivityCancelledProducer(converter,
                                                   eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudSignalReceivedProducer cloudSignalReceivedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -328,7 +328,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudSignalReceivedProducer(converter,
                                                eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerFiredProducer cloudTimerFiredProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -336,7 +336,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudTimerFiredProducer(converter,
                                            eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerScheduledProducer cloudTimerScheduledProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -344,7 +344,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudTimerScheduledProducer(converter,
                                                eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerCancelledProducer cloudTimerCancelledProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -352,7 +352,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudTimerCancelledProducer(converter,
                                                eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerFailedProducer cloudTimerFailedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -360,7 +360,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudTimerFailedProducer(converter,
                                             eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerExecutedProducer cloudTimerExecutedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -368,7 +368,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudTimerExecutedProducer(converter,
                                               eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudTimerRetriesDecrementedProducer cloudTimerRetriesDecrementedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -389,10 +389,12 @@ public class CloudEventsAutoConfiguration {
     @Bean
     public CloudProcessDeployedProducer cloudProcessDeployedProducer(RuntimeBundleInfoAppender runtimeBundleInfoAppender,
                                                                      ProcessEngineChannels processEngineChannels,
-                                                                     RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory) {
+                                                                     RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
+                                                                     RuntimeBundleProperties properties) {
         return new CloudProcessDeployedProducer(runtimeBundleInfoAppender,
                                                 processEngineChannels,
-                                                runtimeBundleMessageBuilderFactory);
+                                                runtimeBundleMessageBuilderFactory,
+                                                properties);
     }
 
     @Bean
@@ -400,7 +402,7 @@ public class CloudEventsAutoConfiguration {
     public RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory(RuntimeBundleProperties properties) {
         return new RuntimeBundleMessageBuilderFactory(properties);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudMessageSentProducer cloudMessageSentProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -408,7 +410,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudMessageSentProducer(converter,
                                             eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudMessageWaitingProducer cloudMessageWaitingProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -416,7 +418,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudMessageWaitingProducer(converter,
                                                eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudMessageReceivedProducer cloudMessageReceivedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -424,7 +426,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudMessageReceivedProducer(converter,
                                                 eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudErrorReceivedProducer cloudErrorReceivedProducer(ToCloudProcessRuntimeEventConverter converter,
@@ -432,7 +434,7 @@ public class CloudEventsAutoConfiguration {
         return new CloudErrorReceivedProducer(converter,
                                               eventsAggregator);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public CloudMessageSubscriptionCancelledProducer cloudMessageSubscriptionCancelledProducer(ToCloudProcessRuntimeEventConverter converter,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/RuntimeBundleProperties.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/RuntimeBundleProperties.java
@@ -18,11 +18,16 @@ package org.activiti.cloud.services.events.configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 @Configuration
 @ConfigurationProperties(prefix = "activiti.cloud.runtime-bundle")
+@Validated
 public class RuntimeBundleProperties {
-	
+
     @Value("${spring.application.name}")
     private String rbSpringAppName;
 
@@ -35,8 +40,9 @@ public class RuntimeBundleProperties {
     @Value("${activiti.cloud.application.name:}")
     private String appName;
 
+    @Valid
     private RuntimeBundleEventsProperties eventsProperties = new RuntimeBundleEventsProperties();
-    
+
     public String getRbSpringAppName() {
         return rbSpringAppName;
     }
@@ -89,7 +95,11 @@ public class RuntimeBundleProperties {
 
     public static class RuntimeBundleEventsProperties {
 
+
         private boolean integrationAuditEventsEnabled = true;
+
+        @Positive
+        private int chunkSize = 100;
 
         public boolean isIntegrationAuditEventsEnabled() {
             return integrationAuditEventsEnabled;
@@ -98,5 +108,14 @@ public class RuntimeBundleProperties {
         public void setIntegrationAuditEventsEnabled(boolean integrationAuditEventsEnabled) {
             this.integrationAuditEventsEnabled = integrationAuditEventsEnabled;
         }
+
+        public Integer getChunkSize() {
+            return chunkSize;
+        }
+
+        public void setChunkSize(Integer chunkSize) {
+            this.chunkSize = chunkSize;
+        }
+
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
@@ -21,6 +21,7 @@ import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
 import org.springframework.context.event.EventListener;
@@ -35,14 +36,17 @@ public class CloudProcessDeployedProducer {
     private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
     private ProcessEngineChannels producer;
     private RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory;
-    private int chunkSize = 100;
+    private int chunkSize;
 
     public CloudProcessDeployedProducer(RuntimeBundleInfoAppender runtimeBundleInfoAppender,
                                         ProcessEngineChannels producer,
-                                        RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory) {
+                                        RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
+                                        RuntimeBundleProperties properties) {
         this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
         this.producer = producer;
         this.runtimeBundleMessageBuilderFactory = runtimeBundleMessageBuilderFactory;
+        this.chunkSize = properties.getEventsProperties()
+                                   .getChunkSize();
     }
 
     @EventListener
@@ -80,6 +84,14 @@ public class CloudProcessDeployedProducer {
         runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(cloudProcessDeployedEvent);
 
         return cloudProcessDeployedEvent;
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
+    }
+
+    public void setChunkSize(int chunkSize) {
+        this.chunkSize = chunkSize;
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
@@ -24,6 +24,7 @@ import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.Message;
 
 public class CloudProcessDeployedProducer {
 
@@ -48,10 +49,13 @@ public class CloudProcessDeployedProducer {
     }
 
     protected void sendCloudProcessDeployedEvent(CloudProcessDeployedEvent cloudProcessDeployedEvent) {
-        producer.auditProducer().send(
-            runtimeBundleMessageBuilderFactory.create()
-                                              .withPayload(new CloudRuntimeEvent<?, ?>[] { cloudProcessDeployedEvent })
-                                              .build());
+        CloudRuntimeEvent<?, ?>[] payload = new CloudRuntimeEvent<?, ?>[]{cloudProcessDeployedEvent};
+
+        Message<?> message = runtimeBundleMessageBuilderFactory.create()
+                                                               .withPayload(payload)
+                                                               .build();
+        producer.auditProducer()
+                .send(message);
     }
 
     protected CloudProcessDeployedEvent toCloudProcessDeployedEvent(ProcessDeployedEvent processDeployedEvent) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
@@ -23,15 +23,13 @@ import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderAppenderChain;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 
@@ -56,6 +54,9 @@ public class CloudProcessDeployedProducerTest {
 
     @Mock
     private ProcessEngineChannels producer;
+
+    @Spy
+    private RuntimeBundleProperties properties = new RuntimeBundleProperties();
 
     @Mock
     private MessageChannel auditProducer;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
@@ -15,10 +15,6 @@
  */
 package org.activiti.cloud.services.events.listeners;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.events.ProcessDeployedEvent;
 import org.activiti.api.runtime.event.impl.ProcessDeployedEventImpl;
@@ -27,26 +23,27 @@ import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderAppenderChain;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
-import org.assertj.core.util.Streams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
-import org.springframework.messaging.Message;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class CloudProcessDeployedProducerTest {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
@@ -15,6 +15,18 @@
  */
 package org.activiti.cloud.services.events.listeners;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.events.ProcessDeployedEvent;
 import org.activiti.api.runtime.event.impl.ProcessDeployedEventImpl;
@@ -24,29 +36,24 @@ import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties.RuntimeBundleEventsProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderAppenderChain;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
-
+@ExtendWith(MockitoExtension.class)
 public class CloudProcessDeployedProducerTest {
 
-    @InjectMocks
     private CloudProcessDeployedProducer processDeployedProducer;
 
     @Mock
@@ -72,32 +79,38 @@ public class CloudProcessDeployedProducerTest {
 
     @BeforeEach
     public void setUp() {
-        initMocks(this);
         when(producer.auditProducer()).thenReturn(auditProducer);
         when(runtimeBundleMessageBuilderFactory.create()).thenReturn(messageBuilderAppenderChain);
+        final RuntimeBundleEventsProperties eventsProperties = new RuntimeBundleEventsProperties();
+        eventsProperties.setChunkSize(2);
+        properties.setEventsProperties(eventsProperties);
+        processDeployedProducer = new CloudProcessDeployedProducer(runtimeBundleInfoAppender, producer, runtimeBundleMessageBuilderFactory, properties);
     }
 
     @Test
-    public void shouldSendMessageWithDeployedProcessesWhenWebApplicationTypeIsServlet() {
+    public void should_sendMessageWithDeployedProcessesInChunks() {
         //given
         ProcessDefinition def1 = mock(ProcessDefinition.class);
         ProcessDefinition def2 = mock(ProcessDefinition.class);
-        List<ProcessDeployedEvent> processDeployedEventList = Arrays.asList(new ProcessDeployedEventImpl(def1,
-                                                                                                         "content1"),
-                                                                            new ProcessDeployedEventImpl(def2,
-                                                                                                         "content2"));
+        ProcessDefinition def3 = mock(ProcessDefinition.class);
+        List<ProcessDeployedEvent> processDeployedEventList = Arrays
+            .asList(
+                new ProcessDeployedEventImpl(def1, "content1"),
+                new ProcessDeployedEventImpl(def2, "content2"),
+                new ProcessDeployedEventImpl(def3, "content3"));
         given(messageBuilderAppenderChain.withPayload(any())).willReturn(MessageBuilder.withPayload(new CloudRuntimeEvent<?, ?>[2]));
 
         //when
         processDeployedProducer.sendProcessDeployedEvents(new ProcessDeployedEvents(processDeployedEventList));
 
         //then
-        verify(runtimeBundleInfoAppender, times(2)).appendRuntimeBundleInfoTo(any(CloudRuntimeEventImpl.class));
-        verify(messageBuilderAppenderChain).withPayload(messagePayloadCaptor.capture());
-        verify(auditProducer).send(any());
+        verify(runtimeBundleInfoAppender, times(3)).appendRuntimeBundleInfoTo(any(CloudRuntimeEventImpl.class));
+        verify(messageBuilderAppenderChain, times(2)).withPayload(messagePayloadCaptor.capture());
+        verify(auditProducer, times(2)).send(any());
 
-        List<CloudProcessDeployedEvent> cloudProcessDeployedEvents = Arrays.asList(messagePayloadCaptor.getValue())
-                .stream()
+        List<CloudRuntimeEvent<?, ?>[]> values = messagePayloadCaptor.getAllValues();
+        List<CloudProcessDeployedEvent> cloudProcessDeployedEvents = Arrays.stream(
+            values.get(0))
                 .map(CloudProcessDeployedEvent.class::cast)
                 .collect(Collectors.toList());
         assertThat(cloudProcessDeployedEvents)
@@ -107,5 +120,14 @@ public class CloudProcessDeployedProducerTest {
                                     "content1"),
                               tuple(def2,
                                     "content2"));
+
+        assertThat(Arrays.stream(
+            values.get(1))
+            .map(CloudProcessDeployedEvent.class::cast)
+            .collect(Collectors.toList()))
+            .extracting(CloudProcessDeployedEvent::getEntity,
+                CloudProcessDeployedEvent::getProcessModelContent)
+            .containsOnly(tuple(def3,
+                "content3"));
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
@@ -36,7 +36,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -25,28 +25,23 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Profile(AUDIT_PRODUCER_IT)
 @TestComponent
 @EnableBinding(AuditConsumer.class)
 public class AuditConsumerStreamHandler {
 
-    private Map<String, Object> receivedHeaders = new HashMap<>();
+    private volatile Map<String, Object> receivedHeaders = new HashMap<>();
 
-    private List<CloudRuntimeEvent<?,?>> latestReceivedEvents = new ArrayList<>();
-    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new ArrayList<>();
+    private volatile List<CloudRuntimeEvent<?,?>> latestReceivedEvents = new ArrayList<>();
+    private volatile List<CloudRuntimeEvent<?,?>> allReceivedEvents = new ArrayList<>();
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
-        System.out.println("receive: " + Thread.currentThread() + ",streamHandler: " + this + ", events: " + events.length);
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
-
-        System.out.println("before addAll: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents.size());
-
         allReceivedEvents = new ArrayList<>(allReceivedEvents);
         allReceivedEvents.addAll(latestReceivedEvents);
-
-        System.out.println("after addAll: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents.size());
         receivedHeaders = new LinkedHashMap<>(headers);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -25,7 +25,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 
 import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Profile(AUDIT_PRODUCER_IT)
 @TestComponent

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -40,7 +40,7 @@ public class AuditConsumerStreamHandler {
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
-        allReceivedEvents.addAll(Arrays.asList(events));
+        allReceivedEvents.addAll(latestReceivedEvents);
         receivedHeaders = new LinkedHashMap<>(headers);
     }
 
@@ -61,5 +61,4 @@ public class AuditConsumerStreamHandler {
         latestReceivedEvents.clear();
         receivedHeaders.clear();
     }
-
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -38,12 +38,15 @@ public class AuditConsumerStreamHandler {
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
-        System.out.println("receive: " + Thread.currentThread() + ",streamHandler: " + this + ", events: " + events);
+        System.out.println("receive: " + Thread.currentThread() + ",streamHandler: " + this + ", events: " + events.length);
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
+
+        System.out.println("before addAll: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents.size());
+
         allReceivedEvents = new ArrayList<>(allReceivedEvents);
         allReceivedEvents.addAll(latestReceivedEvents);
 
-        System.out.println("after receive: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents);
+        System.out.println("after addAll: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents.size());
         receivedHeaders = new LinkedHashMap<>(headers);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -25,7 +25,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 
 import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Profile(AUDIT_PRODUCER_IT)
 @TestComponent
@@ -35,11 +34,12 @@ public class AuditConsumerStreamHandler {
     private Map<String, Object> receivedHeaders = new HashMap<>();
 
     private List<CloudRuntimeEvent<?,?>> latestReceivedEvents = new ArrayList<>();
-    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new CopyOnWriteArrayList<>();
+    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new ArrayList<>();
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
+        allReceivedEvents = new ArrayList<>(allReceivedEvents);
         allReceivedEvents.addAll(latestReceivedEvents);
         receivedHeaders = new LinkedHashMap<>(headers);
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -24,12 +24,7 @@ import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Profile(AUDIT_PRODUCER_IT)
 @TestComponent
@@ -44,7 +39,8 @@ public class AuditConsumerStreamHandler {
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
-        allReceivedEvents.addAll(latestReceivedEvents);
+        allReceivedEvents = new ArrayList<>(allReceivedEvents);
+        allReceivedEvents.addAll(Arrays.asList(events));
         receivedHeaders = new LinkedHashMap<>(headers);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -38,9 +38,12 @@ public class AuditConsumerStreamHandler {
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
+        System.out.println("receive: " + Thread.currentThread() + ",streamHandler: " + this + ", events: " + events);
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
         allReceivedEvents = new ArrayList<>(allReceivedEvents);
         allReceivedEvents.addAll(latestReceivedEvents);
+
+        System.out.println("after receive: " + Thread.currentThread() + ",streamHandler: " + this + ", allReceivedEvents: " + allReceivedEvents);
         receivedHeaders = new LinkedHashMap<>(headers);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Headers;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Profile(AUDIT_PRODUCER_IT)
 @TestComponent
@@ -34,12 +35,11 @@ public class AuditConsumerStreamHandler {
     private Map<String, Object> receivedHeaders = new HashMap<>();
 
     private List<CloudRuntimeEvent<?,?>> latestReceivedEvents = new ArrayList<>();
-    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new ArrayList<>();
+    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new CopyOnWriteArrayList<>();
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(@Headers Map<String, Object> headers, CloudRuntimeEvent<?,?> ... events) {
         latestReceivedEvents = new ArrayList<>(Arrays.asList(events));
-        allReceivedEvents = new ArrayList<>(allReceivedEvents);
         allReceivedEvents.addAll(Arrays.asList(events));
         receivedHeaders = new LinkedHashMap<>(headers);
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -95,6 +95,8 @@ public class ExclusiveGatewayAuditProducerIT {
 
     @BeforeEach
     public void setUp() {
+        streamHandler.clear();
+
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("hruser");
         ResponseEntity<PagedModel<CloudProcessDefinition>> processDefinitions = getProcessDefinitions();
         assertThat(processDefinitions.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -120,9 +120,9 @@ public class ExclusiveGatewayAuditProducerIT {
     @Test
     public void testProcessExecutionWithExclusiveGateway() {
         //when
-        System.out.println("Before clear:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+        System.out.println("Before clear:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
         streamHandler.getAllReceivedEvents().clear();
-        System.out.println("After clear: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+        System.out.println("After clear: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
 
         ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate.startProcess(
             new StartProcessPayloadBuilder()
@@ -149,13 +149,13 @@ public class ExclusiveGatewayAuditProducerIT {
         CloudTask task = processInstanceRestTemplate.getTasks(processInstance).getBody().iterator().next();
         String taskId = task.getId();
 
-        System.out.println("Before Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+        System.out.println("Before Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
 
         await().untilAsserted(() -> {
 
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
 
-            System.out.println("Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+            System.out.println("Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -67,7 +67,7 @@ import java.util.*;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class,
     initializers = {RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
 public class ExclusiveGatewayAuditProducerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -121,6 +121,8 @@ public class ExclusiveGatewayAuditProducerIT {
     public void testProcessExecutionWithExclusiveGateway() {
         //when
         streamHandler.getAllReceivedEvents().clear();
+        System.out.println("Thread: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+
         ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate.startProcess(
             new StartProcessPayloadBuilder()
                 .withProcessDefinitionKey(EXCLUSIVE_GATEWAY_PROCESS)
@@ -149,6 +151,8 @@ public class ExclusiveGatewayAuditProducerIT {
         await().untilAsserted(() -> {
 
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
+
+            System.out.println("Await thread: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -15,22 +15,6 @@
  */
 package org.activiti.cloud.starter.tests.services.audit;
 
-import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_CREATED;
-import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_UPDATED;
-import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
-import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
-import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.*;
-import static org.activiti.api.process.model.events.SequenceFlowEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN;
-import static org.activiti.api.task.model.events.TaskCandidateUserEvent.TaskCandidateUserEvents.TASK_CANDIDATE_USER_ADDED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_COMPLETED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_CREATED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_UPDATED;
-import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.ALL_REQUIRED_HEADERS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
-
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
@@ -64,6 +48,19 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.*;
 
+import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_CREATED;
+import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_UPDATED;
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.*;
+import static org.activiti.api.process.model.events.SequenceFlowEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN;
+import static org.activiti.api.task.model.events.TaskCandidateUserEvent.TaskCandidateUserEvents.TASK_CANDIDATE_USER_ADDED;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.*;
+import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.ALL_REQUIRED_HEADERS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
@@ -92,7 +89,6 @@ public class ExclusiveGatewayAuditProducerIT {
     @Autowired
     private KeycloakTokenProducer keycloakSecurityContextClientRequestInterceptor;
 
-
     @BeforeEach
     public void setUp() {
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("hruser");
@@ -104,7 +100,6 @@ public class ExclusiveGatewayAuditProducerIT {
         for (CloudProcessDefinition pd : processDefinitions.getBody().getContent()) {
             processDefinitionIds.put(pd.getKey(), pd.getId());
         }
-        System.out.println("setUp:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
     }
 
     private ResponseEntity<PagedModel<CloudProcessDefinition>> getProcessDefinitions() {
@@ -120,9 +115,7 @@ public class ExclusiveGatewayAuditProducerIT {
     @Test
     public void testProcessExecutionWithExclusiveGateway() {
         //when
-        System.out.println("Before clear:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
         streamHandler.getAllReceivedEvents().clear();
-        System.out.println("After clear: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
 
         ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate.startProcess(
             new StartProcessPayloadBuilder()
@@ -149,13 +142,8 @@ public class ExclusiveGatewayAuditProducerIT {
         CloudTask task = processInstanceRestTemplate.getTasks(processInstance).getBody().iterator().next();
         String taskId = task.getId();
 
-        System.out.println("Before Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
-
         await().untilAsserted(() -> {
-
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
-
-            System.out.println("Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -95,8 +95,6 @@ public class ExclusiveGatewayAuditProducerIT {
 
     @BeforeEach
     public void setUp() {
-        streamHandler.clear();
-
         keycloakSecurityContextClientRequestInterceptor.setKeycloakTestUser("hruser");
         ResponseEntity<PagedModel<CloudProcessDefinition>> processDefinitions = getProcessDefinitions();
         assertThat(processDefinitions.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -120,8 +120,9 @@ public class ExclusiveGatewayAuditProducerIT {
     @Test
     public void testProcessExecutionWithExclusiveGateway() {
         //when
+        System.out.println("Before clear:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
         streamHandler.getAllReceivedEvents().clear();
-        System.out.println("Thread: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+        System.out.println("After clear: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
 
         ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate.startProcess(
             new StartProcessPayloadBuilder()
@@ -148,11 +149,13 @@ public class ExclusiveGatewayAuditProducerIT {
         CloudTask task = processInstanceRestTemplate.getTasks(processInstance).getBody().iterator().next();
         String taskId = task.getId();
 
+        System.out.println("Before Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+
         await().untilAsserted(() -> {
 
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getAllReceivedEvents();
 
-            System.out.println("Await thread: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
+            System.out.println("Await: " + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents());
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -104,7 +104,7 @@ public class ExclusiveGatewayAuditProducerIT {
         for (CloudProcessDefinition pd : processDefinitions.getBody().getContent()) {
             processDefinitionIds.put(pd.getKey(), pd.getId());
         }
-
+        System.out.println("setUp:" + Thread.currentThread() + ",streamHandler: " + streamHandler + ", streamHandler.getAllReceivedEvents(): " + streamHandler.getAllReceivedEvents().size());
     }
 
     private ResponseEntity<PagedModel<CloudProcessDefinition>> getProcessDefinitions() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -67,7 +67,7 @@ import java.util.*;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DirtiesContext
 @ContextConfiguration(classes = ServicesAuditITConfiguration.class,
     initializers = {RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
 public class ExclusiveGatewayAuditProducerIT {


### PR DESCRIPTION
Part of https://github.com/Activiti/Activiti/issues/3674

This PR improves default strategy for publishing process deployed events using configured chunk size in runtime bundle properties. The default chunk size is set to 100 events per message.

To change the defaul chunk size, use `activiti.cloud.runtime-bundle.events-properties.chunk-size` configuration property.