### PR TITLE
fix(GH-3684): synchronize integration context audit event with integration context request

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
@@ -15,8 +15,6 @@
  */
 package org.activiti.services.connectors;
 
-import java.util.stream.Stream;
-
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationRequestedEventImpl;
@@ -28,6 +26,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.stream.Stream;
 
 public class IntegrationRequestSender {
     public static final String CONNECTOR_TYPE = "connectorType";
@@ -56,10 +56,11 @@ public class IntegrationRequestSender {
     public void sendIntegrationRequest(IntegrationRequest event) {
 
         resolver.resolveDestination(event.getIntegrationContext().getConnectorType()).send(buildIntegrationRequestMessage(event));
+
+        sendAuditEvent(event);
     }
 
     //send audit event is included in the the transaction because the audit chanel is transacted
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void sendAuditEvent(IntegrationRequest integrationRequest) {
         if (runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()) {
             CloudIntegrationRequestedEventImpl integrationRequested = new CloudIntegrationRequestedEventImpl(integrationRequest.getIntegrationContext());

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
@@ -50,8 +50,6 @@ public class IntegrationRequestSender {
         this.messageBuilderFactory = messageBuilderFactory;
     }
 
-    //the integration request itself is sent after the Activiti transaction has been committed
-    //because the connector channel is not transacted
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendIntegrationRequest(IntegrationRequest event) {
 
@@ -60,7 +58,6 @@ public class IntegrationRequestSender {
         sendAuditEvent(event);
     }
 
-    //send audit event is included in the the transaction because the audit chanel is transacted
     public void sendAuditEvent(IntegrationRequest integrationRequest) {
         if (runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()) {
             CloudIntegrationRequestedEventImpl integrationRequested = new CloudIntegrationRequestedEventImpl(integrationRequest.getIntegrationContext());


### PR DESCRIPTION
This PR fixes potential race conditions between audit events producer and integration context sender. The code change will synchronize sending integration context audit event message with integration request producer.

Fixes https://github.com/Activiti/Activiti/issues/3684