### PR TITLE
fix(GH-3702): use activiti.cloud.application.name scope for Rb channel binding destinations

### DIFF
--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
@@ -45,6 +45,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-logging</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorDestinationBuilderImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorDestinationBuilderImpl.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.connectors.starter.channels;
 
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
+import org.springframework.util.ObjectUtils;
 
 public class IntegrationErrorDestinationBuilderImpl implements IntegrationErrorDestinationBuilder {
 
@@ -30,8 +31,11 @@ public class IntegrationErrorDestinationBuilderImpl implements IntegrationErrorD
     public String buildDestination(IntegrationRequest event) {
         String errorDestinationOverride = connectorProperties.getErrorDestinationOverride();
 
-        String destination = (errorDestinationOverride == null || errorDestinationOverride.isEmpty())
-                ? "integrationError" + connectorProperties.getMqDestinationSeparator() + event.getServiceFullName() : errorDestinationOverride;
+        String destination = ObjectUtils.isEmpty(errorDestinationOverride)
+            ? new StringBuilder("integrationError").append(connectorProperties.getMqDestinationSeparator())
+                                                   .append(event.getAppName())
+                                                   .toString()
+            : errorDestinationOverride;
 
         return destination;
     }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.connectors.starter.channels;
 
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
+import org.springframework.util.ObjectUtils;
 
 public class IntegrationResultDestinationBuilderImpl implements IntegrationResultDestinationBuilder {
 
@@ -30,8 +31,11 @@ public class IntegrationResultDestinationBuilderImpl implements IntegrationResul
     public String buildDestination(IntegrationRequest event) {
         String resultDestinationOverride = connectorProperties.getErrorDestinationOverride();
 
-        String destination = (resultDestinationOverride == null || resultDestinationOverride.isEmpty())
-                ? "integrationResult" + connectorProperties.getMqDestinationSeparator() + event.getServiceFullName() : resultDestinationOverride;
+        String destination = ObjectUtils.isEmpty(resultDestinationOverride)
+                ? new StringBuilder("integrationResult").append(connectorProperties.getMqDestinationSeparator())
+                                                        .append(event.getAppName())
+                                                        .toString()
+                : resultDestinationOverride;
 
         return destination;
     }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
@@ -29,7 +29,7 @@ public class IntegrationResultDestinationBuilderImpl implements IntegrationResul
 
     @Override
     public String buildDestination(IntegrationRequest event) {
-        String resultDestinationOverride = connectorProperties.getErrorDestinationOverride();
+        String resultDestinationOverride = connectorProperties.getResultDestinationOverride();
 
         String destination = ObjectUtils.isEmpty(resultDestinationOverride)
                 ? new StringBuilder("integrationResult").append(connectorProperties.getMqDestinationSeparator())

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationErrorBuilder.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationErrorBuilder.java
@@ -15,8 +15,6 @@
  */
 package org.activiti.cloud.connectors.starter.model;
 
-import java.util.Objects;
-
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
@@ -24,6 +22,8 @@ import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Objects;
 
 public class IntegrationErrorBuilder {
 
@@ -74,7 +74,7 @@ public class IntegrationErrorBuilder {
 
         return MessageBuilder.withPayload(integrationError)
                              .setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
-                             .setHeader("targetService",
-                                        integrationRequest.getServiceFullName());
+                             .setHeader("targetAppName", integrationRequest.getAppName())
+                             .setHeader("targetService", integrationRequest.getServiceFullName());
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilder.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilder.java
@@ -15,14 +15,14 @@
  */
 package org.activiti.cloud.connectors.starter.model;
 
-import java.util.Map;
-
-import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
+import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Map;
 
 public class IntegrationResultBuilder {
 
@@ -63,7 +63,8 @@ public class IntegrationResultBuilder {
     }
 
     public MessageBuilder<IntegrationResult> getMessageBuilder() {
-        return MessageBuilder.withPayload((IntegrationResult)integrationResult).setHeader("targetService",
-                                                                       requestEvent.getServiceFullName());
+        return MessageBuilder.withPayload((IntegrationResult)integrationResult)
+                             .setHeader("targetAppName", requestEvent.getAppName())
+                             .setHeader("targetService", requestEvent.getServiceFullName());
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/resources/activiti-cloud-connector.properties
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/resources/activiti-cloud-connector.properties
@@ -3,6 +3,6 @@ activiti.cloud.connector.service-type=${activiti.cloud.service.type:}
 activiti.cloud.connector.service-version=${activiti.cloud.service.version:}
 activiti.cloud.connector.app-name=${activiti.cloud.application.name:}
 activiti.cloud.connector.app-version=${activiti.cloud.application.version:}
-activiti.cloud.connector.mq-destination-separator=${activiti.cloud.mq.destination.separator:_}
+activiti.cloud.connector.mq-destination-separator=${activiti.cloud.messaging.destination-separator}
 activiti.cloud.connector.result-destination-override=${ACT_INT_RES_CONSUMER:}
 activiti.cloud.connector.error-destination-override=${ACT_INT_ERR_CONSUMER:}

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderTest.java
@@ -15,10 +15,6 @@
  */
 package org.activiti.cloud.connectors.starter.channels;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -26,6 +22,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class IntegrationResultDestinationBuilderTest {
 
@@ -57,7 +57,7 @@ public class IntegrationResultDestinationBuilderTest {
         String result = subject.buildDestination(integrationRequest);
 
         // then
-        assertThat(result).isEqualTo("integrationResult.myApp");
+        assertThat(result).isEqualTo("integrationResult.myAppName");
 
     }
 

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationErrorBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationErrorBuilderTest.java
@@ -15,10 +15,6 @@
  */
 package org.activiti.cloud.connectors.starter.model;
 
-import static org.activiti.test.Assertions.assertThat;
-
-import java.util.Collections;
-
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
@@ -28,12 +24,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 
+import java.util.Collections;
+
+import static org.activiti.test.Assertions.assertThat;
+
 public class IntegrationErrorBuilderTest {
 
     private static final String PROC_INST_ID = "procInstId";
     private static final String PROC_DEF_ID = "procDefId";
     private static final String ACTIVITY_ELEMENT_ID = "activitiElementId";
-    private static final String RB_NAME = "appName";
+    private static final String RB_NAME = "rbName";
+    private static final String APP_NAME = "appName";
 
     private ConnectorProperties connectorProperties = new ConnectorProperties();
 
@@ -49,7 +50,8 @@ public class IntegrationErrorBuilderTest {
         integrationContext.setProcessInstanceId(PROC_INST_ID);
 
         IntegrationRequestImpl integrationRequestEvent = new IntegrationRequestImpl(integrationContext);
-        integrationRequestEvent.setAppName(RB_NAME);
+        integrationRequestEvent.setAppName(APP_NAME);
+        integrationRequestEvent.setServiceFullName(RB_NAME);
 
         //when
         IntegrationError integrationError = IntegrationErrorBuilder.errorFor(integrationRequestEvent,
@@ -80,6 +82,7 @@ public class IntegrationErrorBuilderTest {
         integrationContext.setProcessInstanceId(PROC_INST_ID);
 
         IntegrationRequestImpl integrationRequestEvent = new IntegrationRequestImpl(integrationContext);
+        integrationRequestEvent.setAppName(APP_NAME);
         integrationRequestEvent.setServiceFullName(RB_NAME);
 
         //when
@@ -91,6 +94,7 @@ public class IntegrationErrorBuilderTest {
         //then
         Assertions.assertThat(message.getHeaders())
                   .containsEntry(MessageHeaders.CONTENT_TYPE, "application/json")
-                  .containsEntry("targetService", RB_NAME);
+                  .containsEntry("targetService", RB_NAME)
+                  .containsEntry("targetAppName", APP_NAME);
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
@@ -89,7 +89,7 @@ public class IntegrationResultBuilderTest {
                 .buildMessage();
 
         //then
-        assertThat(message.getHeaders()).containsEntry("targetService", RB_NAME)
-                                        .containsEntry("targetAppName", APP_NAME);
+        Assertions.assertThat(message.getHeaders()).containsEntry("targetService", RB_NAME)
+                                                   .containsEntry("targetAppName", APP_NAME);
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
@@ -89,7 +89,7 @@ public class IntegrationResultBuilderTest {
                 .buildMessage();
 
         //then
-        Assertions.assertThat(message.getHeaders()).containsEntry("targetService", RB_NAME)
-                                                   .containsEntry("targetAppName", APP_NAME);
+        assertThat(message.getHeaders()).containsEntry("targetService", RB_NAME)
+                                        .containsEntry("targetAppName", APP_NAME);
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/model/IntegrationResultBuilderTest.java
@@ -15,30 +15,29 @@
  */
 package org.activiti.cloud.connectors.starter.model;
 
-import static org.activiti.test.Assertions.assertThat;
-
-import java.util.Collections;
-
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.IntegrationResult;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
+
+import java.util.Collections;
+
+import static org.activiti.test.Assertions.assertThat;
 
 public class IntegrationResultBuilderTest {
 
     private static final String PROC_INST_ID = "procInstId";
     private static final String PROC_DEF_ID = "procDefId";
     private static final String ACTIVITY_ELEMENT_ID = "activitiElementId";
-    private static final String RB_NAME = "appName";
+    private static final String RB_NAME = "rbName";
+    private static final String APP_NAME = "appName";
     private static final String VAR = "var";
     private static final String VALUE = "value";
 
-    @Autowired
-    private ConnectorProperties connectorProperties;
+    private ConnectorProperties connectorProperties = new ConnectorProperties();
 
     @Test
     public void shouldBuildIntegrationResultBasedOnInformationFromIntegrationRequest() throws Exception {
@@ -50,7 +49,8 @@ public class IntegrationResultBuilderTest {
         integrationContext.setProcessInstanceId(PROC_INST_ID);
 
         IntegrationRequestImpl integrationRequestEvent = new IntegrationRequestImpl(integrationContext);
-        integrationRequestEvent.setAppName(RB_NAME);
+        integrationRequestEvent.setAppName(APP_NAME);
+        integrationRequestEvent.setServiceFullName(RB_NAME);
 
         //when
         IntegrationResult resultEvent = IntegrationResultBuilder
@@ -80,14 +80,16 @@ public class IntegrationResultBuilderTest {
         integrationContext.setProcessInstanceId(PROC_INST_ID);
 
         IntegrationRequestImpl integrationRequestEvent = new IntegrationRequestImpl(integrationContext);
+        integrationRequestEvent.setAppName(APP_NAME);
         integrationRequestEvent.setServiceFullName(RB_NAME);
+
         //when
         Message<IntegrationResult> message = IntegrationResultBuilder
                 .resultFor(integrationRequestEvent, connectorProperties)
                 .buildMessage();
 
         //then
-        Assertions.assertThat(message.getHeaders()).containsEntry("targetService",
-                                                                  RB_NAME);
+        Assertions.assertThat(message.getHeaders()).containsEntry("targetService", RB_NAME)
+                                                   .containsEntry("targetAppName", APP_NAME);
     }
 }

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -15,13 +15,6 @@
  */
 package org.activiti.cloud.connectors.starter.test.it;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.IntegrationError;
@@ -33,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.messaging.Message;
@@ -41,6 +35,13 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
@@ -58,6 +59,9 @@ public class ActivitiCloudConnectorServiceIT {
 
     @Autowired
     private ConnectorsITStreamHandlers streamHandler;
+
+    @Value("${activiti.cloud.application.name}")
+    private String appName;
 
     private final static String PROCESS_INSTANCE_ID = "processInstanceId-" + UUID.randomUUID().toString();
     private final static String PROCESS_DEFINITION_ID = "myProcessDefinitionId";
@@ -87,7 +91,7 @@ public class ActivitiCloudConnectorServiceIT {
         integrationContext.setProcessDefinitionId(PROCESS_DEFINITION_ID);
         integrationContext.addInBoundVariables(variables);
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
-        integrationRequest.setAppName("mock-rb");
+        integrationRequest.setAppName(appName);
         integrationRequest.setServiceFullName("mock-rb");
         integrationRequest.setServiceType("runtime-bundle");
         integrationRequest.setServiceVersion("1");
@@ -257,7 +261,7 @@ public class ActivitiCloudConnectorServiceIT {
         integrationContext.setProcessDefinitionId(PROCESS_DEFINITION_ID);
 
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
-        integrationRequest.setAppName("mock-rb");
+        integrationRequest.setAppName(appName);
         integrationRequest.setServiceFullName("mock-rb");
         integrationRequest.setServiceType("runtime-bundle");
         integrationRequest.setServiceVersion("1");

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
@@ -1,19 +1,19 @@
 spring.application.name=test-streams
 activiti.cloud.application.name=test-rb-app
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsProducer.destination=messages
 spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
 
-spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.integrationErrorConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsConsumer.destination=messages
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
 
-spring.cloud.stream.bindings.runtimeCmdProducer.destination=commandConsumer_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.runtimeCmdProducer.destination=commandConsumer${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.runtimeCmdProducer.contentType=application/json
 
-spring.cloud.stream.bindings.commandConsumer.destination=commandConsumer_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.commandConsumer.destination=commandConsumer${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.commandConsumer.contentType=application/json

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
@@ -1,16 +1,19 @@
 spring.application.name=test-streams
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult_mock-rb
+activiti.cloud.application.name=test-rb-app
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsProducer.destination=messages
 spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
 
-spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError_mock-rb
+spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.integrationErrorConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsConsumer.destination=messages
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
-spring.cloud.stream.bindings.runtimeCmdProducer.destination=commandConsumer
+
+spring.cloud.stream.bindings.runtimeCmdProducer.destination=commandConsumer_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.runtimeCmdProducer.contentType=application/json
-spring.cloud.stream.bindings.commandConsumer.destination=commandConsumer
+
+spring.cloud.stream.bindings.commandConsumer.destination=commandConsumer_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.commandConsumer.contentType=application/json

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -66,7 +66,8 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {
                 "spring.datasource.platform=postgresql",
-                "spring.application.name=messages-app",
+                "activiti.cloud.application.name=messages-app",
+                "spring.application.name=rb",
                 "spring.jmx.enabled=false",
         })
 @DirtiesContext

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/rb/MultipleRbMessagesIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/rb/MultipleRbMessagesIT.java
@@ -15,13 +15,6 @@
  */
 package org.activiti.cloud.messages.integration.tests.rb;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import org.activiti.api.model.shared.Payload;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
@@ -53,6 +46,11 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @Testcontainers
 class MultipleRbMessagesIT {
@@ -134,11 +132,13 @@ class MultipleRbMessagesIT {
                                                                      .run();
 
         rb1Context = new SpringApplicationBuilder(RbApplication.class).properties("server.port=8081",
-                                                                                  "spring.application.name=rb1")
+                                                                                  "activiti.cloud.application.name=messages-app1",
+                                                                                  "spring.application.name=rb")
                                                                       .run();
 
         rb2Context = new SpringApplicationBuilder(RbApplication.class).properties("server.port=8082",
-                                                                                  "spring.application.name=rb2")
+                                                                                  "activiti.cloud.application.name=messages-app2",
+                                                                                  "spring.application.name=rb")
                                                                       .run();
 
     }

--- a/activiti-cloud-messages-service/services/core/pom.xml
+++ b/activiti-cloud-messages-service/services/core/pom.xml
@@ -15,6 +15,10 @@
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-api-process-model-impl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-config</artifactId>
+    </dependency>
     <!-- Third-party -->
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package org.activiti.cloud.services.messages.core.config;
 
-import static org.activiti.cloud.services.messages.core.integration.MessageConnectorIntegrationFlow.DISCARD_CHANNEL;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.messages.core.advice.MessageConnectorHandlerAdvice;
 import org.activiti.cloud.services.messages.core.advice.MessageReceivedHandlerAdvice;
 import org.activiti.cloud.services.messages.core.advice.SubscriptionCancelledHandlerAdvice;
@@ -32,8 +32,8 @@ import org.activiti.cloud.services.messages.core.processor.StartMessagePayloadGr
 import org.activiti.cloud.services.messages.core.release.MessageGroupReleaseChain;
 import org.activiti.cloud.services.messages.core.release.MessageGroupReleaseStrategyChain;
 import org.activiti.cloud.services.messages.core.release.MessageSentReleaseHandler;
-import org.activiti.cloud.services.messages.core.router.CommandConsumerMessageChannelResolver;
 import org.activiti.cloud.services.messages.core.router.CommandConsumerDestinationMapper;
+import org.activiti.cloud.services.messages.core.router.CommandConsumerMessageChannelResolver;
 import org.activiti.cloud.services.messages.core.router.CommandConsumerMessageRouter;
 import org.activiti.cloud.services.messages.core.support.ChainBuilder;
 import org.activiti.cloud.services.messages.core.support.LockTemplate;
@@ -74,6 +74,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import java.util.List;
 import java.util.Optional;
+
+import static org.activiti.cloud.services.messages.core.integration.MessageConnectorIntegrationFlow.DISCARD_CHANNEL;
 
 /**
  * A Processor app that performs aggregation.
@@ -122,8 +124,8 @@ public class MessagesCoreAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public CommandConsumerDestinationMapper commandConsumerDestinationMapper() {
-        return new CommandConsumerDestinationMapper();
+    public CommandConsumerDestinationMapper commandConsumerDestinationMapper(ActivitiCloudMessagingProperties properties) {
+        return new CommandConsumerDestinationMapper(properties.getDestinationSeparator());
     }
 
     @Bean

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/correlation/Correlations.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/correlation/Correlations.java
@@ -15,31 +15,29 @@
  */
 package org.activiti.cloud.services.messages.core.correlation;
 
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_CORRELATION_KEY;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_NAME;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.SERVICE_FULL_NAME;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 
+import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.*;
+
 public class Correlations {
-    
+
     public static String getCorrelationId(Message<?> message) {
         MessageHeaders headers = message.getHeaders();
-        String serviceFullName = headers.get(SERVICE_FULL_NAME, String.class);
+        String appName = headers.get(APP_NAME, String.class);
         String messageEventName = headers.get(MESSAGE_EVENT_NAME, String.class);
         String messageCorrelationKey = headers.get(MESSAGE_EVENT_CORRELATION_KEY, String.class);
-        
+
         StringBuilder builder = new StringBuilder();
-        builder.append(serviceFullName)
+        builder.append(appName)
                .append(":")
                .append(messageEventName);
-               
+
         if (messageCorrelationKey != null) {
             builder.append(":")
                    .append(messageCorrelationKey);
         }
-        
-        return builder.toString();        
+
+        return builder.toString();
     }
 }

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapper.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapper.java
@@ -21,9 +21,9 @@ import java.util.function.Function;
 public class CommandConsumerDestinationMapper implements Function<String, String> {
 
     @Override
-    public String apply(String serviceFullName) {
+    public String apply(String appName) {
         return new StringBuilder("commandConsumer").append("_")
-                                                   .append(serviceFullName)
+                                                   .append(appName)
                                                    .toString();
     }
 }

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapper.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapper.java
@@ -20,9 +20,15 @@ import java.util.function.Function;
 
 public class CommandConsumerDestinationMapper implements Function<String, String> {
 
+    private final String separator;
+
+    public CommandConsumerDestinationMapper(String separator) {
+        this.separator = separator;
+    }
+
     @Override
     public String apply(String appName) {
-        return new StringBuilder("commandConsumer").append("_")
+        return new StringBuilder("commandConsumer").append(separator)
                                                    .append(appName)
                                                    .toString();
     }

--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerMessageRouter.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/router/CommandConsumerMessageRouter.java
@@ -16,7 +16,6 @@
 
 package org.activiti.cloud.services.messages.core.router;
 
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.SERVICE_FULL_NAME;
 import org.springframework.integration.mapping.MessageMappingException;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.messaging.Message;
@@ -26,6 +25,8 @@ import org.springframework.messaging.core.DestinationResolver;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+
+import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.APP_NAME;
 
 public class CommandConsumerMessageRouter extends AbstractMessageRouter {
 
@@ -37,11 +38,10 @@ public class CommandConsumerMessageRouter extends AbstractMessageRouter {
 
     @Override
     protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
-        String serviceFullName = message.getHeaders()
-                                        .get(SERVICE_FULL_NAME,
-                                             String.class);
+        String appName = message.getHeaders()
+                                .get(APP_NAME, String.class);
 
-        MessageChannel messageChannel = Optional.ofNullable(serviceFullName)
+        MessageChannel messageChannel = Optional.ofNullable(appName)
                                                 .map(destinationResolver::resolveDestination)
                                                 .orElseThrow(() -> new MessageMappingException(message,
                                                                       "Unable to determine target channel for message"));

--- a/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
+++ b/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
@@ -1,8 +1,8 @@
-spring.cloud.stream.bindings.input.destination=messageEvents_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.input.destination=messageEvents${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.input.contentType=application/json
 spring.cloud.stream.bindings.input.group=messages
 
-spring.cloud.stream.bindings.output.destination=commandConsumer_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.output.destination=commandConsumer${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.output.contentType=application/json
 
 activiti.cloud.services.messages.input-headers-to-remove=kafka_consumer

--- a/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
+++ b/activiti-cloud-messages-service/services/core/src/main/resources/config/activiti-cloud-services-messages-core.properties
@@ -1,10 +1,9 @@
-spring.cloud.stream.bindings.input.destination=messageEvents_${spring.application.name}
+spring.cloud.stream.bindings.input.destination=messageEvents_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.input.contentType=application/json
-spring.cloud.stream.bindings.input.group=messageConnector
+spring.cloud.stream.bindings.input.group=messages
 
-spring.cloud.stream.bindings.output.destination=commandConsumer_${spring.application.name}
+spring.cloud.stream.bindings.output.destination=commandConsumer_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.output.contentType=application/json
-spring.cloud.stream.bindings.output.producer.required-groups=messageConnector
 
 activiti.cloud.services.messages.input-headers-to-remove=kafka_consumer
 activiti.cloud.services.messages.header-channels-time-to-live-expression=headers['headerChannelsTTL']?:60000

--- a/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapperTest.java
+++ b/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/core/router/CommandConsumerDestinationMapperTest.java
@@ -16,13 +16,13 @@
 
 package org.activiti.cloud.services.messages.core.router;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommandConsumerDestinationMapperTest {
 
-    private CommandConsumerDestinationMapper destinationMapper = new CommandConsumerDestinationMapper();
+    private CommandConsumerDestinationMapper destinationMapper = new CommandConsumerDestinationMapper(".");
 
     @Test
     public void should_appendServiceNameToCommandConsumerDestinationName() {
@@ -33,6 +33,6 @@ public class CommandConsumerDestinationMapperTest {
         final String destination = destinationMapper.apply(serviceFullName);
 
         //then
-        assertThat(destination).isEqualTo("commandConsumer_myService");
+        assertThat(destination).isEqualTo("commandConsumer.myService");
     }
 }

--- a/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/core/router/CommandConsumerMessageRouterTest.java
+++ b/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/core/router/CommandConsumerMessageRouterTest.java
@@ -16,13 +16,6 @@
 
 package org.activiti.cloud.services.messages.core.router;
 
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.SERVICE_FULL_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
-import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,6 +26,14 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.DestinationResolver;
+
+import java.util.Collection;
+
+import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.APP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CommandConsumerMessageRouterTest {
@@ -46,13 +47,13 @@ public class CommandConsumerMessageRouterTest {
     @Test
     public void should_returnResultOfDestinationResolver_when_headerHasServiceFullName() {
         //given
-        final String serviceName = "myService";
+        final String appName = "myApp";
         final Message<String> message = MessageBuilder.withPayload("any")
-            .setHeader(SERVICE_FULL_NAME, serviceName)
+            .setHeader(APP_NAME, appName)
             .build();
 
         final MessageChannel messageChannel = mock(MessageChannel.class);
-        given(destinationResolver.resolveDestination(serviceName)).willReturn(
+        given(destinationResolver.resolveDestination(appName)).willReturn(
             messageChannel);
 
         //when
@@ -80,12 +81,12 @@ public class CommandConsumerMessageRouterTest {
     @Test
     public void should_throwException_when_destinationResolverDoesNotFindADestination() {
         //given
-        final String serviceName = "myService";
+        final String appName = "myApp";
         final Message<String> message = MessageBuilder.withPayload("any")
-            .setHeader(SERVICE_FULL_NAME, serviceName)
+            .setHeader(APP_NAME, appName)
             .build();
 
-        given(destinationResolver.resolveDestination(serviceName)).willReturn(null);
+        given(destinationResolver.resolveDestination(appName)).willReturn(null);
 
         //then
         assertThatExceptionOfType(MessageMappingException.class)

--- a/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/test/core/MessageCoreAutoConfigurationTest.java
+++ b/activiti-cloud-messages-service/services/core/src/test/java/org/activiti/cloud/services/messages/test/core/MessageCoreAutoConfigurationTest.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.services.messages.test.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.activiti.cloud.services.messages.core.channels.MessageConnectorProcessor;
 import org.assertj.core.api.AbstractStringAssert;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.dsl.IntegrationFlow;
 
-@SpringBootTest(properties = "spring.application.name=my-activiti-rb-app")
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "activiti.cloud.application.name=my-activiti-rb-app")
 public class MessageCoreAutoConfigurationTest {
 
     @Autowired

--- a/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/main/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -16,15 +16,6 @@
 package org.activiti.cloud.services.messages.tests;
 
 
-import static java.util.Collections.singletonMap;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_CORRELATION_KEY;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_ID;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_NAME;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.MESSAGE_EVENT_TYPE;
-import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.SERVICE_FULL_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.springframework.messaging.MessageHeaders.CONTENT_TYPE;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,6 +35,7 @@ import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
@@ -67,12 +59,14 @@ import org.springframework.transaction.PlatformTransactionManager;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.stream.IntStream;
+
+import static java.util.Collections.singletonMap;
+import static org.activiti.cloud.services.messages.core.integration.MessageEventHeaders.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.springframework.messaging.MessageHeaders.CONTENT_TYPE;
 
 
 /**
@@ -83,6 +77,7 @@ import java.util.stream.IntStream;
         webEnvironment = SpringBootTest.WebEnvironment.NONE,
         properties = {
                 "spring.application.name=rb",
+                "activiti.cloud.application.name=default-app",
                 "spring.cloud.stream.bindings.input.content-type=application/json",
                 "spring.cloud.stream.bindings.output.content-type=application/json"
         }
@@ -127,6 +122,12 @@ public abstract class AbstractMessagesCoreIntegrationTests {
 
     @Autowired
     protected AbstractMessageChannel output;
+
+    @Value("${activiti.cloud.application.name}")
+    protected String activitiCloudApplicationName;
+
+    @Value("${spring.application.name}")
+    protected String springApplicationName;
 
     @TestConfiguration
     static class TestConfigurationContext {
@@ -741,7 +742,8 @@ public abstract class AbstractMessagesCoreIntegrationTests {
                              .setHeader(MESSAGE_EVENT_NAME, messageName)
                              .setHeader(MESSAGE_EVENT_CORRELATION_KEY, correlationKey)
                              .setHeader(MESSAGE_EVENT_ID, UUID.randomUUID())
-                             .setHeader(SERVICE_FULL_NAME, "rb");
+                             .setHeader(APP_NAME, activitiCloudApplicationName)
+                             .setHeader(SERVICE_FULL_NAME, springApplicationName);
 
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
@@ -47,9 +47,8 @@
       <artifactId>spring-cloud-stream</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-      <optional>true</optional>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-config</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>
@@ -109,6 +108,12 @@
       <artifactId>activiti-spring-security-policies</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
@@ -1,5 +1,5 @@
 # Activiti engine subscriber (receive integration result)
-activiti.cloud.mq.destination.separator=_
+activiti.cloud.mq.destination.separator=${activiti.cloud.messaging.destination-separator}
 spring.cloud.stream.bindings.integrationResultsConsumer.destination=${ACT_INT_RES_CONSUMER:integrationResult${activiti.cloud.mq.destination.separator}${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
@@ -1,9 +1,9 @@
 # Activiti engine subscriber (receive integration result)
 activiti.cloud.mq.destination.separator=_
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=${ACT_INT_RES_CONSUMER:integrationResult${activiti.cloud.mq.destination.separator}${spring.application.name}}
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=${ACT_INT_RES_CONSUMER:integrationResult${activiti.cloud.mq.destination.separator}${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}
 
-spring.cloud.stream.bindings.integrationErrorsConsumer.destination=${ACT_INT_ERR_CONSUMER:integrationError${activiti.cloud.mq.destination.separator}${spring.application.name}}
+spring.cloud.stream.bindings.integrationErrorsConsumer.destination=${ACT_INT_ERR_CONSUMER:integrationError${activiti.cloud.mq.destination.separator}${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.integrationErrorsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationErrorsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>activiti-cloud-services-events</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-config</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.activiti</groupId>
       <artifactId>activiti-api-model-shared</artifactId>
     </dependency>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/resources/config/command-endpoint-channels.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/resources/config/command-endpoint-channels.properties
@@ -1,7 +1,7 @@
 # configures dynamic destination routing using spring.application.name
-spring.cloud.stream.bindings.commandConsumer.destination=${ACT_RB_COMMAND_CONSUMER_DEST:commandConsumer_${activiti.cloud.application.name}}
+spring.cloud.stream.bindings.commandConsumer.destination=${ACT_RB_COMMAND_CONSUMER_DEST:commandConsumer${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.commandConsumer.contentType=${ACT_RB_COMMAND_CONSUMER_CONTENT_TYPE:application/json}
 spring.cloud.stream.bindings.commandConsumer.group=${ACT_RB_COMMAND_CONSUMER_GROUP:${spring.application.name}}
 
-spring.cloud.stream.bindings.commandResults.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandResults_${activiti.cloud.application.name}}
+spring.cloud.stream.bindings.commandResults.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandResults${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.commandResults.contentType=${ACT_RB_COMMAND_RESULTS_CONTENT_TYPE:application/json}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/resources/config/command-endpoint-channels.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/resources/config/command-endpoint-channels.properties
@@ -1,7 +1,7 @@
 # configures dynamic destination routing using spring.application.name
-spring.cloud.stream.bindings.commandConsumer.destination=${ACT_RB_COMMAND_CONSUMER_DEST:commandConsumer_${spring.application.name}}
+spring.cloud.stream.bindings.commandConsumer.destination=${ACT_RB_COMMAND_CONSUMER_DEST:commandConsumer_${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.commandConsumer.contentType=${ACT_RB_COMMAND_CONSUMER_CONTENT_TYPE:application/json}
-spring.cloud.stream.bindings.commandConsumer.group=${ACT_RB_COMMAND_CONSUMER_GROUP:messageConnector}
+spring.cloud.stream.bindings.commandConsumer.group=${ACT_RB_COMMAND_CONSUMER_GROUP:${spring.application.name}}
 
-spring.cloud.stream.bindings.commandResults.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandResults_${spring.application.name}}
+spring.cloud.stream.bindings.commandResults.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandResults_${activiti.cloud.application.name}}
 spring.cloud.stream.bindings.commandResults.contentType=${ACT_RB_COMMAND_RESULTS_CONTENT_TYPE:application/json}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/DefaultMessageBasedJobManagerFactory.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/DefaultMessageBasedJobManagerFactory.java
@@ -15,24 +15,24 @@
  */
 package org.activiti.cloud.services.job.executor;
 
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.springframework.cloud.stream.config.BindingProperties;
 
 public class DefaultMessageBasedJobManagerFactory implements MessageBasedJobManagerFactory {
-    
-    private final RuntimeBundleProperties runtimeBundleProperties;
+
+    private final BindingProperties bindingProperties;
     private final JobMessageProducer jobMessageProducer;
-    
-    public DefaultMessageBasedJobManagerFactory(RuntimeBundleProperties runtimeBundleProperties,
+
+    public DefaultMessageBasedJobManagerFactory(BindingProperties bindingProperties,
                                                 JobMessageProducer jobMessageProducer) {
-        this.runtimeBundleProperties = runtimeBundleProperties;
+        this.bindingProperties = bindingProperties;
         this.jobMessageProducer = jobMessageProducer;
     }
 
     @Override
     public MessageBasedJobManager create(ProcessEngineConfigurationImpl processEngineConfiguration) {
         return new MessageBasedJobManager(processEngineConfiguration,
-                                          runtimeBundleProperties,
+                                          bindingProperties,
                                           jobMessageProducer);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManager.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManager.java
@@ -15,8 +15,6 @@
  */
 package org.activiti.cloud.services.job.executor;
 
-import java.util.Date;
-
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.engine.impl.asyncexecutor.DefaultJobManager;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -25,21 +23,23 @@ import org.activiti.engine.runtime.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
+
 public class MessageBasedJobManager extends DefaultJobManager {
     private static final Logger logger = LoggerFactory.getLogger(MessageBasedJobManager.class);
-    
+
     private static final String DEFAULT_INPUT_CHANNEL_NAME = "asyncExecutorJobs";
-    
+
     private final RuntimeBundleProperties runtimeBundleProperties;
     private final JobMessageProducer jobMessageProducer;
-    
+
     private String inputChannelName = DEFAULT_INPUT_CHANNEL_NAME;
 
     public MessageBasedJobManager(ProcessEngineConfigurationImpl processEngineConfiguration,
                                   RuntimeBundleProperties runtimeBundleProperties,
                                   JobMessageProducer jobMessageProducer) {
         super(processEngineConfiguration);
-        
+
         this.runtimeBundleProperties = runtimeBundleProperties;
         this.jobMessageProducer = jobMessageProducer;
     }
@@ -67,15 +67,18 @@ public class MessageBasedJobManager extends DefaultJobManager {
 
         sendMessage(job);
     }
-    
+
     /**
-     * Scoped destination name by runtime bundle service name   
-     * 
+     * Scoped destination name by activiti cloud application name
+     *
      */
     public String getDestination() {
-        return runtimeBundleProperties.getServiceName() + "." + this.getInputChannelName();
+        return new StringBuilder().append(this.getInputChannelName())
+                                  .append("_")
+                                  .append(runtimeBundleProperties.getAppName())
+                                  .toString();
     }
-   
+
     public String getInputChannelName() {
         return inputChannelName;
     }
@@ -83,10 +86,10 @@ public class MessageBasedJobManager extends DefaultJobManager {
     public void setInputChannelName(String inputChannelName) {
         this.inputChannelName = inputChannelName;
     }
-    
+
     public void sendMessage(final Job job) {
         logger.debug("sendMessage for job: {}", job);
-        
+
         jobMessageProducer.sendMessage(getDestination(), job);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManager.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManager.java
@@ -15,13 +15,13 @@
  */
 package org.activiti.cloud.services.job.executor;
 
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.engine.impl.asyncexecutor.DefaultJobManager;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.persistence.entity.JobEntity;
 import org.activiti.engine.runtime.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.config.BindingProperties;
 
 import java.util.Date;
 
@@ -30,17 +30,17 @@ public class MessageBasedJobManager extends DefaultJobManager {
 
     private static final String DEFAULT_INPUT_CHANNEL_NAME = "asyncExecutorJobs";
 
-    private final RuntimeBundleProperties runtimeBundleProperties;
+    private final BindingProperties bindingProperties;
     private final JobMessageProducer jobMessageProducer;
 
     private String inputChannelName = DEFAULT_INPUT_CHANNEL_NAME;
 
     public MessageBasedJobManager(ProcessEngineConfigurationImpl processEngineConfiguration,
-                                  RuntimeBundleProperties runtimeBundleProperties,
+                                  BindingProperties bindingProperties,
                                   JobMessageProducer jobMessageProducer) {
         super(processEngineConfiguration);
 
-        this.runtimeBundleProperties = runtimeBundleProperties;
+        this.bindingProperties = bindingProperties;
         this.jobMessageProducer = jobMessageProducer;
     }
 
@@ -68,15 +68,12 @@ public class MessageBasedJobManager extends DefaultJobManager {
         sendMessage(job);
     }
 
-    /**
-     * Scoped destination name by activiti cloud application name
-     *
-     */
+    public BindingProperties getBindingProperties() {
+        return bindingProperties;
+    }
+
     public String getDestination() {
-        return new StringBuilder().append(this.getInputChannelName())
-                                  .append("_")
-                                  .append(runtimeBundleProperties.getAppName())
-                                  .toString();
+        return bindingProperties.getDestination();
     }
 
     public String getInputChannelName() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
@@ -84,13 +84,15 @@ public class MessageBasedJobManagerAutoConfiguration {
                                                                                  JobMessageInputChannelFactory jobMessageInputChannelFactory,
                                                                                  MessageBasedJobManagerFactory messageBasedJobManagerFactory,
                                                                                  JobMessageHandlerFactory jobMessageHandlerFactory,
-                                                                                 ConsumerProperties messageJobConsumerProperties) {
+                                                                                 ConsumerProperties messageJobConsumerProperties,
+                                                                                 RuntimeBundleProperties runtimeBundleProperties) {
         return new MessageBasedJobManagerConfigurator(beanFactory,
                                                       bindingService,
                                                       jobMessageInputChannelFactory,
                                                       messageBasedJobManagerFactory,
                                                       jobMessageHandlerFactory,
-                                                      messageJobConsumerProperties);
+                                                      messageJobConsumerProperties,
+                                                      runtimeBundleProperties);
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
@@ -16,51 +16,54 @@
 package org.activiti.cloud.services.job.executor;
 
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.binding.SubscribableChannelBindingTargetFactory;
+import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @ConditionalOnProperty(name = "spring.activiti.asyncExecutorActivate", havingValue = "true", matchIfMissing = true)
+@PropertySource("classpath:config/job-executor-channel.properties")
 public class MessageBasedJobManagerAutoConfiguration {
-    
+
     @Bean
-    @ConditionalOnMissingBean(name = "messageJobConsumerProperties")
-    @ConfigurationProperties(prefix = "spring.activiti.cloud.rb.job-executor.message-job-consumer")
-    public ConsumerProperties messageJobConsumerProperties() {
-        return new ConsumerProperties();
+    @ConditionalOnMissingBean(name = "jobExecutorBindingProperties")
+    @ConfigurationProperties(prefix = "activiti.cloud.rb.job-executor")
+    public BindingProperties jobExecutorBindingProperties() {
+        return new BindingProperties();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public JobMessageBuilderFactory jobMessageBuilderFactory(RuntimeBundleProperties properties) {
         return new JobMessageBuilderFactory(properties);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public JobMessageInputChannelFactory jobMessageInputChannelFactory(SubscribableChannelBindingTargetFactory bindingTargetFactory,
                                                                        BindingServiceProperties bindingServiceProperties,
                                                                        ConfigurableListableBeanFactory beanFactory) {
         return new JobMessageInputChannelFactory(bindingTargetFactory, bindingServiceProperties, beanFactory);
-    }    
-    
+    }
+
     @Bean
     @ConditionalOnMissingBean
-    public MessageBasedJobManagerFactory messageBasedJobManagerFactory(RuntimeBundleProperties runtimeBundleProperties,
+    public MessageBasedJobManagerFactory messageBasedJobManagerFactory(@Qualifier("jobExecutorBindingProperties") BindingProperties bindingProperties,
                                                                        JobMessageProducer jobMessageProducer) {
-        return new DefaultMessageBasedJobManagerFactory(runtimeBundleProperties, jobMessageProducer);
+        return new DefaultMessageBasedJobManagerFactory(bindingProperties, jobMessageProducer);
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public JobMessageProducer jobMessageProducer(BinderAwareChannelResolver resolver,
@@ -76,7 +79,7 @@ public class MessageBasedJobManagerAutoConfiguration {
     public JobMessageHandlerFactory jobMessageHandlerFactory() {
         return new DefaultJobMessageHandlerFactory();
     }
-    
+
     @Bean
     @ConditionalOnMissingBean
     public MessageBasedJobManagerConfigurator messageBasedJobManagerConfigurator(ConfigurableListableBeanFactory beanFactory,
@@ -84,14 +87,12 @@ public class MessageBasedJobManagerAutoConfiguration {
                                                                                  JobMessageInputChannelFactory jobMessageInputChannelFactory,
                                                                                  MessageBasedJobManagerFactory messageBasedJobManagerFactory,
                                                                                  JobMessageHandlerFactory jobMessageHandlerFactory,
-                                                                                 ConsumerProperties messageJobConsumerProperties,
                                                                                  RuntimeBundleProperties runtimeBundleProperties) {
         return new MessageBasedJobManagerConfigurator(beanFactory,
                                                       bindingService,
                                                       jobMessageInputChannelFactory,
                                                       messageBasedJobManagerFactory,
                                                       jobMessageHandlerFactory,
-                                                      messageJobConsumerProperties,
                                                       runtimeBundleProperties);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerAutoConfiguration.java
@@ -86,14 +86,13 @@ public class MessageBasedJobManagerAutoConfiguration {
                                                                                  BindingService bindingService,
                                                                                  JobMessageInputChannelFactory jobMessageInputChannelFactory,
                                                                                  MessageBasedJobManagerFactory messageBasedJobManagerFactory,
-                                                                                 JobMessageHandlerFactory jobMessageHandlerFactory,
-                                                                                 RuntimeBundleProperties runtimeBundleProperties) {
+                                                                                 JobMessageHandlerFactory jobMessageHandlerFactory) {
+
         return new MessageBasedJobManagerConfigurator(beanFactory,
                                                       bindingService,
                                                       jobMessageInputChannelFactory,
                                                       messageBasedJobManagerFactory,
-                                                      jobMessageHandlerFactory,
-                                                      runtimeBundleProperties);
+                                                      jobMessageHandlerFactory);
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.services.job.executor;
 
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.engine.cfg.ProcessEngineConfigurator;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.slf4j.Logger;
@@ -38,7 +37,6 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     private final MessageBasedJobManagerFactory messageBasedJobManagerFactory;
     private final JobMessageHandlerFactory jobMessageHandlerFactory;
     private final ConfigurableListableBeanFactory beanFactory;
-    private final RuntimeBundleProperties runtimeBundleProperties;
 
     private MessageBasedJobManager messageBasedJobManager;
     private MessageHandler jobMessageHandler;
@@ -51,14 +49,12 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
                                               BindingService bindingService,
                                               JobMessageInputChannelFactory inputChannelFactory,
                                               MessageBasedJobManagerFactory messageBasedJobManagerFactory,
-                                              JobMessageHandlerFactory jobMessageHandlerFactory,
-                                              RuntimeBundleProperties runtimeBundleProperties) {
+                                              JobMessageHandlerFactory jobMessageHandlerFactory) {
         this.bindingService = bindingService;
         this.inputChannelFactory = inputChannelFactory;
         this.messageBasedJobManagerFactory = messageBasedJobManagerFactory;
         this.jobMessageHandlerFactory = jobMessageHandlerFactory;
         this.beanFactory = beanFactory;
-        this.runtimeBundleProperties = runtimeBundleProperties;
     }
 
     protected MessageHandler createJobMessageHandler(ProcessEngineConfigurationImpl configuration) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.job.executor;
 
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.engine.cfg.ProcessEngineConfigurator;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.slf4j.Logger;
@@ -29,7 +30,7 @@ import org.springframework.messaging.SubscribableChannel;
 
 public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigurator, SmartLifecycle {
     private static final Logger logger = LoggerFactory.getLogger(MessageBasedJobManagerConfigurator.class);
-    
+
     private static final String MESSAGE_BASED_JOB_MANAGER = "messageBasedJobManager";
     public static final String JOB_MESSAGE_HANDLER = "jobMessageHandler";
 
@@ -41,78 +42,82 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     private final MessageBasedJobManagerFactory messageBasedJobManagerFactory;
     private final JobMessageHandlerFactory jobMessageHandlerFactory;
     private final ConfigurableListableBeanFactory beanFactory;
-    
+    private final RuntimeBundleProperties runtimeBundleProperties;
+
     private MessageBasedJobManager messageBasedJobManager;
     private MessageHandler jobMessageHandler;
     private SubscribableChannel inputChannel;
     private ProcessEngineConfigurationImpl configuration;
-    
-    private boolean running = false;    
-    
+
+    private boolean running = false;
+
     public MessageBasedJobManagerConfigurator(ConfigurableListableBeanFactory beanFactory,
                                               BindingService bindingService,
                                               JobMessageInputChannelFactory inputChannelFactory,
                                               MessageBasedJobManagerFactory messageBasedJobManagerFactory,
                                               JobMessageHandlerFactory jobMessageHandlerFactory,
-                                              ConsumerProperties consumerProperties) {
+                                              ConsumerProperties consumerProperties,
+                                              RuntimeBundleProperties runtimeBundleProperties) {
         this.bindingService = bindingService;
         this.inputChannelFactory = inputChannelFactory;
         this.consumerProperties = consumerProperties;
         this.messageBasedJobManagerFactory = messageBasedJobManagerFactory;
         this.jobMessageHandlerFactory = jobMessageHandlerFactory;
         this.beanFactory = beanFactory;
+        this.runtimeBundleProperties = runtimeBundleProperties;
     }
-    
+
     protected MessageHandler createJobMessageHandler(ProcessEngineConfigurationImpl configuration) {
         MessageHandler messageHandler = jobMessageHandlerFactory.create(configuration);
-        
+
         return registerBean(JOB_MESSAGE_HANDLER, messageHandler);
     }
 
     protected MessageBasedJobManager createMessageBasedJobManager(ProcessEngineConfigurationImpl configuration) {
         MessageBasedJobManager instance = messageBasedJobManagerFactory.create(configuration);
-        
+
         return registerBean(MESSAGE_BASED_JOB_MANAGER, instance);
     }
-    
+
     /**
-     * Configures MessageBasedJobManager 
+     * Configures MessageBasedJobManager
      */
     @Override
     public void beforeInit(ProcessEngineConfigurationImpl configuration) {
         this.messageBasedJobManager = createMessageBasedJobManager(configuration);
-        
+
         // Let's manage async executor lifecycle manually on start/stop
         configuration.setAsyncExecutorActivate(false);
         configuration.setAsyncExecutorMessageQueueMode(true);
         configuration.setJobManager(messageBasedJobManager);
-        
+
         logger.info("Configured message based job manager class: {}", this.messageBasedJobManager.getClass());
-        
+
     }
 
     /**
-     * Configures input channel 
+     * Configures input channel
      */
     @Override
     public void configure(ProcessEngineConfigurationImpl configuration) {
         this.configuration = configuration;
-        
+
         String channelName = messageBasedJobManager.getInputChannelName();
         String destination = messageBasedJobManager.getDestination();
+        String group = runtimeBundleProperties.getServiceFullName();
 
         BindingProperties bindingProperties = new BindingProperties();
         bindingProperties.setConsumer(consumerProperties);
         bindingProperties.setContentType(contentType);
-        bindingProperties.setGroup(JOB_MESSAGE_HANDLER);
+        bindingProperties.setGroup(group);
         // Let's use message job producer destination scope
         bindingProperties.setDestination(destination);
 
-        // Let's create input channel 
+        // Let's create input channel
         inputChannel = inputChannelFactory.createInputChannel(channelName, bindingProperties);
 
         logger.info("Configured message job input channel '{}' with bindings: {}", channelName, bindingProperties);
-        
+
     }
 
     @Override
@@ -125,24 +130,24 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
         logger.info("Subscribing job message handler to input channel {}", messageBasedJobManager.getInputChannelName());
 
         jobMessageHandler = createJobMessageHandler(configuration);
-        
-        // Let's subscribe and bind consumer channel   
+
+        // Let's subscribe and bind consumer channel
         inputChannel.subscribe(jobMessageHandler);
         bindingService.bindConsumer(inputChannel, messageBasedJobManager.getInputChannelName());
 
         // Now start async executor
         if (!configuration.getAsyncExecutor().isActive()) {
             configuration.getAsyncExecutor()
-                         .start();            
+                         .start();
         }
-        
+
         running = true;
     }
 
     @Override
     public void stop() {
         logger.info("Unsubscribing job message handler to input channel {}", messageBasedJobManager.getInputChannelName());
-        
+
         try {
             // Let's unbind consumer from input channel
             bindingService.unbindConsumers(messageBasedJobManager.getInputChannelName());
@@ -151,9 +156,9 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
             // Let's gracefully shutdown executor
             if (configuration.getAsyncExecutor().isActive()) {
                 configuration.getAsyncExecutor()
-                             .shutdown();            
+                             .shutdown();
             }
-            
+
         } finally {
             running = false;
         }
@@ -164,11 +169,11 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
         return running;
     }
 
-    
+
     public void setContentType(String contentType) {
         this.contentType = contentType;
     }
-    
+
     @SuppressWarnings("unchecked")
     protected <T> T registerBean(String name, T bean) {
         beanFactory.registerSingleton(name, bean);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
@@ -21,7 +21,6 @@ import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.context.SmartLifecycle;
@@ -34,11 +33,8 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     private static final String MESSAGE_BASED_JOB_MANAGER = "messageBasedJobManager";
     public static final String JOB_MESSAGE_HANDLER = "jobMessageHandler";
 
-    private String contentType = "application/json";
-
     private final BindingService bindingService;
     private final JobMessageInputChannelFactory inputChannelFactory;
-    private final ConsumerProperties consumerProperties;
     private final MessageBasedJobManagerFactory messageBasedJobManagerFactory;
     private final JobMessageHandlerFactory jobMessageHandlerFactory;
     private final ConfigurableListableBeanFactory beanFactory;
@@ -56,11 +52,9 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
                                               JobMessageInputChannelFactory inputChannelFactory,
                                               MessageBasedJobManagerFactory messageBasedJobManagerFactory,
                                               JobMessageHandlerFactory jobMessageHandlerFactory,
-                                              ConsumerProperties consumerProperties,
                                               RuntimeBundleProperties runtimeBundleProperties) {
         this.bindingService = bindingService;
         this.inputChannelFactory = inputChannelFactory;
-        this.consumerProperties = consumerProperties;
         this.messageBasedJobManagerFactory = messageBasedJobManagerFactory;
         this.jobMessageHandlerFactory = jobMessageHandlerFactory;
         this.beanFactory = beanFactory;
@@ -103,15 +97,7 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
         this.configuration = configuration;
 
         String channelName = messageBasedJobManager.getInputChannelName();
-        String destination = messageBasedJobManager.getDestination();
-        String group = runtimeBundleProperties.getServiceFullName();
-
-        BindingProperties bindingProperties = new BindingProperties();
-        bindingProperties.setConsumer(consumerProperties);
-        bindingProperties.setContentType(contentType);
-        bindingProperties.setGroup(group);
-        // Let's use message job producer destination scope
-        bindingProperties.setDestination(destination);
+        BindingProperties bindingProperties = messageBasedJobManager.getBindingProperties();
 
         // Let's create input channel
         inputChannel = inputChannelFactory.createInputChannel(channelName, bindingProperties);
@@ -167,11 +153,6 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     @Override
     public boolean isRunning() {
         return running;
-    }
-
-
-    public void setContentType(String contentType) {
-        this.contentType = contentType;
     }
 
     @SuppressWarnings("unchecked")

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/resources/config/job-executor-channel.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/resources/config/job-executor-channel.properties
@@ -1,0 +1,2 @@
+activiti.cloud.rb.job-executor.destination=${ACT_RB_JOB_EXECUTOR_DEST:asyncExecutorJobs${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}}
+activiti.cloud.rb.job-executor.group=${spring.application.name}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/pom.xml
@@ -19,6 +19,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-config</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.activiti</groupId>
       <artifactId>activiti-engine</artifactId>
       <scope>provided</scope>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/src/main/resources/config/messages-events-channels.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/src/main/resources/config/messages-events-channels.properties
@@ -1,3 +1,3 @@
-spring.cloud.stream.bindings.messageEvents.destination=messageEvents_${spring.application.name}
+spring.cloud.stream.bindings.messageEvents.destination=messageEvents_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.messageEvents.contentType=application/json
-spring.cloud.stream.bindings.messageEvents.producer.required-groups=messageConnector
+spring.cloud.stream.bindings.messageEvents.producer.required-groups=messages

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/src/main/resources/config/messages-events-channels.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/messages-events/src/main/resources/config/messages-events-channels.properties
@@ -1,3 +1,3 @@
-spring.cloud.stream.bindings.messageEvents.destination=messageEvents_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.messageEvents.destination=messageEvents${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.messageEvents.contentType=application/json
 spring.cloud.stream.bindings.messageEvents.producer.required-groups=messages

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.starter.tests.conf;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
@@ -28,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
@@ -66,16 +67,16 @@ public class EngineConfigurationIT {
     @Test
     public void shouldHaveChannelBindingsSetForMessageEvents() {
         //when
-        assertProperty("spring.cloud.stream.bindings.messageEvents.destination").isEqualTo("messageEvents_my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.messageEvents.producer.required-groups").isEqualTo("messageConnector");
+        assertProperty("spring.cloud.stream.bindings.messageEvents.destination").isEqualTo("messageEvents_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.messageEvents.producer.required-groups").isEqualTo("messages");
     }
 
     @Test
     public void shouldHaveChannelBindingsSetForCommandEndpoint() {
         //when
-        assertProperty("spring.cloud.stream.bindings.commandConsumer.destination").isEqualTo("commandConsumer_my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.commandConsumer.group").isEqualTo("messageConnector");
-        assertProperty("spring.cloud.stream.bindings.commandResults.destination").isEqualTo("commandResults_my-activiti-rb-app");
+        assertProperty("spring.cloud.stream.bindings.commandConsumer.destination").isEqualTo("commandConsumer_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.commandConsumer.group").isEqualTo("my-activiti-rb-app");
+        assertProperty("spring.cloud.stream.bindings.commandResults.destination").isEqualTo("commandResults_activiti-app");
 
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -91,9 +91,9 @@ public class EngineConfigurationIT {
     @Test
     public void shouldHaveChannelBindingsSetForCloudConnectors() {
         //when
-        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult_my-activiti-rb-app");
+        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult_activiti-app");
         assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.group").isEqualTo("my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError_my-activiti-rb-app");
+        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError_activiti-app");
         assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.group").isEqualTo("my-activiti-rb-app");
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -30,7 +30,8 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+                properties = {"activiti.cloud.messaging.destination-separator=."})
 @DirtiesContext
 @ContextConfiguration(initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
 public class EngineConfigurationIT {
@@ -67,16 +68,16 @@ public class EngineConfigurationIT {
     @Test
     public void shouldHaveChannelBindingsSetForMessageEvents() {
         //when
-        assertProperty("spring.cloud.stream.bindings.messageEvents.destination").isEqualTo("messageEvents_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.messageEvents.destination").isEqualTo("messageEvents.activiti-app");
         assertProperty("spring.cloud.stream.bindings.messageEvents.producer.required-groups").isEqualTo("messages");
     }
 
     @Test
     public void shouldHaveChannelBindingsSetForCommandEndpoint() {
         //when
-        assertProperty("spring.cloud.stream.bindings.commandConsumer.destination").isEqualTo("commandConsumer_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.commandConsumer.destination").isEqualTo("commandConsumer.activiti-app");
         assertProperty("spring.cloud.stream.bindings.commandConsumer.group").isEqualTo("my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.commandResults.destination").isEqualTo("commandResults_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.commandResults.destination").isEqualTo("commandResults.activiti-app");
 
     }
 
@@ -92,9 +93,9 @@ public class EngineConfigurationIT {
     @Test
     public void shouldHaveChannelBindingsSetForCloudConnectors() {
         //when
-        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult.activiti-app");
         assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.group").isEqualTo("my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError_activiti-app");
+        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError.activiti-app");
         assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.group").isEqualTo("my-activiti-rb-app");
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -44,7 +44,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.*;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
     "spring.activiti.asyncExecutorActivate=true",
-    "spring.activiti.cloud.rb.job-executor.message-job-consumer.max-attempts=4" // customized
+    "activiti.cloud.rb.job-executor.consumer.max-attempts=4" // customized
 })
 @DirtiesContext
 @ContextConfiguration(classes = {RuntimeITConfiguration.class,
@@ -106,7 +106,7 @@ public class JobExecutorIT {
     private RepositoryService repositoryService;
 
     @Autowired
-    private ConsumerProperties messageJobConsumerProperties;
+    private BindingProperties jobExecutorBindingProperties;
 
     @Autowired
     private MessageBasedJobManager messageBasedJobManager;
@@ -175,7 +175,7 @@ public class JobExecutorIT {
 
     @Test
     public void shouldConfigureConsumerProperties() {
-        assertThat(messageJobConsumerProperties.getMaxAttempts())
+        assertThat(jobExecutorBindingProperties.getConsumer().getMaxAttempts())
             .as("should configure consumer properties")
             .isEqualTo(4);
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -15,28 +15,12 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.message.RuntimeBundleInfoMessageHeaders;
-import org.activiti.cloud.services.job.executor.JobMessageFailedEvent;
-import org.activiti.cloud.services.job.executor.JobMessageHandler;
-import org.activiti.cloud.services.job.executor.JobMessageHandlerFactory;
-import org.activiti.cloud.services.job.executor.JobMessageHeaders;
-import org.activiti.cloud.services.job.executor.JobMessageProducer;
-import org.activiti.cloud.services.job.executor.JobMessageSentEvent;
-import org.activiti.cloud.services.job.executor.MessageBasedJobManager;
+import org.activiti.cloud.services.job.executor.*;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.ManagementService;
-import org.activiti.engine.ProcessEngineConfiguration;
-import org.activiti.engine.ProcessEngines;
-import org.activiti.engine.RepositoryService;
-import org.activiti.engine.RuntimeService;
+import org.activiti.engine.*;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.JavaDelegate;
 import org.activiti.engine.delegate.event.ActivitiEvent;
@@ -77,17 +61,18 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
 @TestPropertySource("classpath:application-test.properties")
@@ -208,7 +193,7 @@ public class JobExecutorIT {
 
         assertThat(messageBasedJobManager.getDestination())
             .as("should configure rb scoped destination")
-            .startsWith(runtimeBundleProperties.getServiceName());
+            .endsWith(runtimeBundleProperties.getAppName());
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -17,11 +17,6 @@ package org.activiti.cloud.starter.tests.runtime;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
@@ -35,6 +30,13 @@ import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -111,7 +113,7 @@ public class ServiceTaskConsumerHandler {
         Message<IntegrationResultImpl> message = MessageBuilder.withPayload(integrationResult)
             .build();
         resolver
-            .resolveDestination("integrationResult_" + runtimeBundleProperties.getServiceFullName())
+            .resolveDestination("integrationResult_" + runtimeBundleProperties.getAppName())
             .send(message);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.starter.tests.services.audit;
 
-import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
-import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
-import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
-import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED;
-import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED;
-import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED;
-import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.BPMNError;
@@ -33,12 +23,7 @@ import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
-import org.activiti.cloud.api.process.model.events.CloudBPMNActivityCompletedEvent;
-import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
-import org.activiti.cloud.api.process.model.events.CloudBPMNErrorReceivedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
-import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
+import org.activiti.cloud.api.process.model.events.*;
 import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
@@ -66,6 +51,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
+import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
+import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
+import static org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents.*;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 @ActiveProfiles(ConnectorAuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -100,10 +94,10 @@ public class ConnectorAuditProducerIT {
     @Autowired
     private BinderAwareChannelResolver channelResolver;
 
-    @Value("integrationResult_${spring.application.name}")
+    @Value("integrationResult_${activiti.cloud.application.name}")
     private String integrationResultDestination;
 
-    @Value("integrationError_${spring.application.name}")
+    @Value("integrationError_${activiti.cloud.application.name}")
     private String integrationErrorDestination;
 
     @BeforeEach

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -10,12 +10,12 @@ spring.activiti.asyncExecutorActivate=false
 spring.cloud.stream.default.contentType=application/json
 
 # test command results bindings
-spring.cloud.stream.bindings.myCmdResults.destination=commandResults_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.myCmdResults.destination=commandResults${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdResults.group=${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdResults.contentType=application/json
 
 # test command producer bindings
-spring.cloud.stream.bindings.myCmdProducer.destination=commandConsumer_${activiti.cloud.application.name}
+spring.cloud.stream.bindings.myCmdProducer.destination=commandConsumer${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdProducer.contentType=application/json
 
 # test audit consumer binding

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -10,12 +10,12 @@ spring.activiti.asyncExecutorActivate=false
 spring.cloud.stream.default.contentType=application/json
 
 # test command results bindings
-spring.cloud.stream.bindings.myCmdResults.destination=commandResults_${spring.application.name}
+spring.cloud.stream.bindings.myCmdResults.destination=commandResults_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdResults.group=${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdResults.contentType=application/json
 
 # test command producer bindings
-spring.cloud.stream.bindings.myCmdProducer.destination=commandConsumer_${spring.application.name}
+spring.cloud.stream.bindings.myCmdProducer.destination=commandConsumer_${activiti.cloud.application.name}
 spring.cloud.stream.bindings.myCmdProducer.contentType=application/json
 
 # test audit consumer binding

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 spring.main.banner-mode=off
 #spring.main.allow-bean-definition-overriding=true
+activiti.cloud.application.name=activiti-app
 spring.application.name=my-activiti-rb-app
 spring.cloud.stream.default.contentType=application/json
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/pom.xml
@@ -27,5 +27,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -19,9 +19,7 @@ package org.activiti.cloud.common.messaging;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import javax.validation.constraints.*;
 import java.util.Objects;
 
 @ConfigurationProperties(prefix = ActivitiCloudMessagingProperties.ACTIVITI_CLOUD_MESSAGING_PREFIX)
@@ -47,6 +45,10 @@ public class ActivitiCloudMessagingProperties {
     @Min(0)
     private Integer instanceIndex = 0;
 
+    @NotEmpty
+    @Size(min = 1, max = 1)
+    private String destinationSeparator;
+
     ActivitiCloudMessagingProperties() { }
 
     public Boolean isPartitioned() {
@@ -71,6 +73,14 @@ public class ActivitiCloudMessagingProperties {
 
     public void setInstanceIndex(Integer instanceIndex) {
         this.instanceIndex = instanceIndex;
+    }
+
+    public String getDestinationSeparator() {
+        return destinationSeparator;
+    }
+
+    public void setDestinationSeparator(String destinationSeparator) {
+        this.destinationSeparator = destinationSeparator;
     }
 
     @Override

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/activiti-cloud-messaging.properties
@@ -2,3 +2,4 @@ activiti.cloud.messaging.broker=${ACT_MESSAGING_BROKER:rabbitmq}
 activiti.cloud.messaging.partitioned=${ACT_MESSAGING_PARTITIONED:false}
 activiti.cloud.messaging.partition-count=${ACT_MESSAGING_PARTITION_COUNT:1}
 activiti.cloud.messaging.instance-index=${ACT_MESSAGING_INSTANCE_INDEX:0}
+activiti.cloud.messaging.destination-separator=${ACT_MESSAGING_DEST_SEPARATOR:_}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.cloud.common.messaging.config.test;
 
 import org.junit.jupiter.api.Test;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -1,0 +1,15 @@
+package org.activiti.cloud.common.messaging.config.test;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@SpringBootApplication
+public class ActivitiCloudMessagingAutoConfigurationTests {
+
+    @Test
+    public void contextLoads() {
+        // noop
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-metadata/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-metadata/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
This PR fixes Rb channel destinations to use `activiti.cloud.application.name` property for the channel bindings in order for all services to share the same `activiti.cloud.application.name` and to be able to communicate correctly via Spring Cloud Stream messaging broker, i.e.

- [x] New common `activiti.cloud.messaging.destination-separator` configuration property has been added to enable customization of the destination separator character, i.e. `.` or `_` for Rb destinations. The default separator value is set to `_`.
- [x] Connector Integration Result Destination, i.e. `integrationResult_${activiti.cloud.application.name}`
- [x] Connector Integration Error Destination, i.e. `integrationError_${activiti.cloud.application.name}`
- [x] Command Consumer Destination, i.e. `commandConsumer_${activiti.cloud.application.name}`
- [x] Async Job Executor Destination, i.e. `asyncJobExecutor_${activiti.cloud.application.name}`
- [x] Message Events Destination, i.e. `messageEvents_${activiti.cloud.application.name}`
- [x] Message Events Input Destination, i.e. `messageEvents_${activiti.cloud.application.name}`
- [x] Message Events Output Destination, i.e. `commandConsumer_${activiti.cloud.application.name}`


Part of https://github.com/Activiti/Activiti/issues/3702