### PR TITLE
fix(GH-3702): regression for integration result/error destinations scope

### DIFF
--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorDestinationBuilderImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationErrorDestinationBuilderImpl.java
@@ -33,7 +33,7 @@ public class IntegrationErrorDestinationBuilderImpl implements IntegrationErrorD
 
         String destination = ObjectUtils.isEmpty(errorDestinationOverride)
             ? new StringBuilder("integrationError").append(connectorProperties.getMqDestinationSeparator())
-                                                   .append(event.getAppName())
+                                                   .append(event.getServiceFullName())
                                                    .toString()
             : errorDestinationOverride;
 

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/main/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderImpl.java
@@ -33,7 +33,7 @@ public class IntegrationResultDestinationBuilderImpl implements IntegrationResul
 
         String destination = ObjectUtils.isEmpty(resultDestinationOverride)
                 ? new StringBuilder("integrationResult").append(connectorProperties.getMqDestinationSeparator())
-                                                        .append(event.getAppName())
+                                                        .append(event.getServiceFullName())
                                                         .toString()
                 : resultDestinationOverride;
 

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderTest.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/channels/IntegrationResultDestinationBuilderTest.java
@@ -47,7 +47,7 @@ public class IntegrationResultDestinationBuilderTest {
         // given
         IntegrationContextImpl integrationContext = new IntegrationContextImpl();
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
-        integrationRequest.setServiceFullName("myApp");
+        integrationRequest.setServiceFullName("myServiceName");
         integrationRequest.setAppName("myAppName");
         integrationRequest.setAppVersion("1.0");
         integrationRequest.setServiceType("RUNTIME_BUNDLE");
@@ -57,7 +57,7 @@ public class IntegrationResultDestinationBuilderTest {
         String result = subject.buildDestination(integrationRequest);
 
         // then
-        assertThat(result).isEqualTo("integrationResult.myAppName");
+        assertThat(result).isEqualTo("integrationResult.myServiceName");
 
     }
 

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -63,6 +63,9 @@ public class ActivitiCloudConnectorServiceIT {
     @Value("${activiti.cloud.application.name}")
     private String appName;
 
+    @Value("${spring.application.name}")
+    private String serviceFullName;
+
     private final static String PROCESS_INSTANCE_ID = "processInstanceId-" + UUID.randomUUID().toString();
     private final static String PROCESS_DEFINITION_ID = "myProcessDefinitionId";
     private final static String INTEGRATION_ID = "integrationId-" + UUID.randomUUID().toString();
@@ -92,7 +95,7 @@ public class ActivitiCloudConnectorServiceIT {
         integrationContext.addInBoundVariables(variables);
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
         integrationRequest.setAppName(appName);
-        integrationRequest.setServiceFullName("mock-rb");
+        integrationRequest.setServiceFullName(serviceFullName);
         integrationRequest.setServiceType("runtime-bundle");
         integrationRequest.setServiceVersion("1");
         integrationRequest.setAppVersion("1");
@@ -262,7 +265,7 @@ public class ActivitiCloudConnectorServiceIT {
 
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
         integrationRequest.setAppName(appName);
-        integrationRequest.setServiceFullName("mock-rb");
+        integrationRequest.setServiceFullName(serviceFullName);
         integrationRequest.setServiceType("runtime-bundle");
         integrationRequest.setServiceVersion("1");
         integrationRequest.setAppVersion("1");

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=test-streams
 activiti.cloud.application.name=test-rb-app
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult${activiti.cloud.messaging.destination-separator}${spring.application.name}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsProducer.destination=messages
 spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
 
-spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError${activiti.cloud.messaging.destination-separator}${activiti.cloud.application.name}
+spring.cloud.stream.bindings.integrationErrorConsumer.destination=integrationError${activiti.cloud.messaging.destination-separator}${spring.application.name}
 spring.cloud.stream.bindings.integrationErrorConsumer.contentType=application/json
 
 spring.cloud.stream.bindings.integrationEventsConsumer.destination=messages

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
@@ -1,9 +1,9 @@
 # Activiti engine subscriber (receive integration result)
 activiti.cloud.mq.destination.separator=${activiti.cloud.messaging.destination-separator}
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=${ACT_INT_RES_CONSUMER:integrationResult${activiti.cloud.mq.destination.separator}${activiti.cloud.application.name}}
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=${ACT_INT_RES_CONSUMER:integrationResult${activiti.cloud.mq.destination.separator}${spring.application.name}}
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}
 
-spring.cloud.stream.bindings.integrationErrorsConsumer.destination=${ACT_INT_ERR_CONSUMER:integrationError${activiti.cloud.mq.destination.separator}${activiti.cloud.application.name}}
+spring.cloud.stream.bindings.integrationErrorsConsumer.destination=${ACT_INT_ERR_CONSUMER:integrationError${activiti.cloud.mq.destination.separator}${spring.application.name}}
 spring.cloud.stream.bindings.integrationErrorsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationErrorsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -93,9 +93,9 @@ public class EngineConfigurationIT {
     @Test
     public void shouldHaveChannelBindingsSetForCloudConnectors() {
         //when
-        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult.activiti-app");
+        assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.destination").isEqualTo("integrationResult.my-activiti-rb-app");
         assertProperty("spring.cloud.stream.bindings.integrationResultsConsumer.group").isEqualTo("my-activiti-rb-app");
-        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError.activiti-app");
+        assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.destination").isEqualTo("integrationError.my-activiti-rb-app");
         assertProperty("spring.cloud.stream.bindings.integrationErrorsConsumer.group").isEqualTo("my-activiti-rb-app");
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -118,7 +118,7 @@ public class ServiceTaskConsumerHandler {
             .build();
 
         String destination = new StringBuilder("integrationResult").append(destinationSeparator)
-                                                                   .append(runtimeBundleProperties.getAppName())
+                                                                   .append(runtimeBundleProperties.getServiceFullName())
                                                                    .toString();
         resolver
             .resolveDestination(destination)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -94,10 +94,10 @@ public class ConnectorAuditProducerIT {
     @Autowired
     private BinderAwareChannelResolver channelResolver;
 
-    @Value("integrationResult_${activiti.cloud.application.name}")
+    @Value("integrationResult_${spring.application.name}")
     private String integrationResultDestination;
 
-    @Value("integrationError_${activiti.cloud.application.name}")
+    @Value("integrationError_${spring.application.name}")
     private String integrationErrorDestination;
 
     @BeforeEach


### PR DESCRIPTION
This PR fixes regression with integration result/error destination scope to use original service full name mapped from spring.application.name configuration.

- [x] Connector Integration Result Destination, i.e. `integrationResult_${spring.application.name}`
- [x] Connector Integration Error Destination, i.e. `integrationError_${spring.application.name}`

Part of https://github.com/Activiti/Activiti/issues/3702