### PR TITLE
fix(GH-3457): remove common security keycloak dependency from connectors

### DIFF
--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
@@ -37,10 +37,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-common-security-keycloak</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-tracing</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR removes the activiti-cloud-services-common-security-keycloak dependency from connector starter pom. This should resolved leaking activiti.keycloak.client properties and Keycloak client  beans into Connector applications.