### PR TITLE
AAE-5950 migrate to OAS3

### DIFF
--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-shared/src/main/java/org/activiti/cloud/acc/shared/service/SwaggerService.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-shared/src/main/java/org/activiti/cloud/acc/shared/service/SwaggerService.java
@@ -19,7 +19,7 @@ import feign.RequestLine;
 
 public interface SwaggerService {
 
-    @RequestLine("GET /v2/api-docs")
+    @RequestLine("GET /v3/api-docs")
     String getSwaggerSpecification();
 
 }

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/PayloadsDocketCustomizer.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/PayloadsDocketCustomizer.java
@@ -40,8 +40,7 @@ public class PayloadsDocketCustomizer implements DocketCustomizer {
                                                                      WildcardType.class,
                                                                      CloudRuntimeEventType.class);
         
-        return docket.forCodeGeneration(true)
-                     .alternateTypeRules(AlternateTypeRules.newRule(resourceTypeWithWildCard,
+        return docket.alternateTypeRules(AlternateTypeRules.newRule(resourceTypeWithWildCard,
                                                                     CloudRuntimeEventModel.class)
                                          );            
    }

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
@@ -43,15 +43,15 @@ public class AuditSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("ListResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey("CloudRuntimeEventModel")))
+            .andExpect(jsonPath("$.components.schemas").isNotEmpty())
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey("CloudRuntimeEventModel")))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Audit :: Starter :: Audit ReST API"));
 
     }

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
@@ -49,7 +49,7 @@ public class AuditSwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/pom.xml
@@ -40,7 +40,7 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
+      <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
   </dependencies>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ModelImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ModelImpl.java
@@ -22,8 +22,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.process.ModelScope;
 import org.activiti.cloud.services.auditable.AbstractAuditable;
@@ -31,40 +30,40 @@ import org.activiti.cloud.services.auditable.AbstractAuditable;
 /**
  * Implementation for {@link Model}
  */
-@ApiModel("Model")
+@Schema(name = "Model")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 public class ModelImpl extends AbstractAuditable<String> implements Model<ProjectImpl, String> {
 
-    @ApiModelProperty(readOnly = true)
+    @Schema(readOnly = true)
     private String id;
 
-    @ApiModelProperty("The name of the model")
+    @Schema(description = "The name of the model")
     private String name;
 
-    @ApiModelProperty(value = "The type of the model", readOnly = true)
+    @Schema(description = "The type of the model", readOnly = true)
     private String type;
 
-    @ApiModelProperty(value = "The version of the model", readOnly = true)
+    @Schema(description = "The version of the model", readOnly = true)
     private String version;
 
-    @ApiModelProperty(value = "The content type of the model", readOnly = true, hidden = true)
+    @Schema(description = "The content type of the model", readOnly = true, hidden = true)
     private String contentType;
 
-    @ApiModelProperty(value = "The content of the model", readOnly = true, hidden = true)
+    @Schema(description = "The content of the model", readOnly = true, hidden = true)
     private byte[] content;
 
-    @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
     @JsonIgnore
     private Set<ProjectImpl> projects = new HashSet<>();
 
-    @ApiModelProperty(value = "The extensions of the model", readOnly = true)
+    @Schema(description = "The extensions of the model", readOnly = true)
     private Map<String,Object> extensions;
 
-    @ApiModelProperty(value = "The template of the model", readOnly = true)
+    @Schema(description = "The template of the model", readOnly = true)
     private String template;
 
-    @ApiModelProperty(value = "The scope of the model. They can be shared between projects if it's scope is GLOBAL", readOnly = true)
+    @Schema(description = "The scope of the model. They can be shared between projects if it's scope is GLOBAL", readOnly = true)
     private ModelScope scope;
 
     public ModelImpl() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ProjectImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api-impl/src/main/java/org/activiti/cloud/modeling/api/impl/ProjectImpl.java
@@ -17,8 +17,7 @@ package org.activiti.cloud.modeling.api.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.services.auditable.AbstractAuditable;
 
@@ -27,21 +26,21 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 /**
  * Implementation for {@link Project}
  */
-@ApiModel("Project")
+@Schema(name = "Project")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 public class ProjectImpl extends AbstractAuditable<String> implements Project<String> {
 
-    @ApiModelProperty(value = "The unique identifier of the project", readOnly = true)
+    @Schema(description = "The unique identifier of the project", readOnly = true)
     private String id;
 
-    @ApiModelProperty(value = "The name of the project")
+    @Schema(description = "The name of the project")
     private String name;
 
-    @ApiModelProperty(value = "The description of the project")
+    @Schema(description = "The description of the project")
     private String description;
 
-    @ApiModelProperty(value = "The version of the project")
+    @Schema(description = "The version of the project")
     private String version;
 
     public ProjectImpl() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/pom.xml
@@ -76,7 +76,7 @@
       <artifactId>spring-data-rest-webmvc</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
+      <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ModelRestApi.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ModelRestApi.java
@@ -27,9 +27,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelType;
 import org.springframework.data.domain.Pageable;
@@ -52,7 +52,7 @@ import org.springframework.web.multipart.MultipartFile;
  * Controller for process resources.
  */
 @RestController
-@Api(tags = MODELS, description = "Retrieve and manage models")
+@Tag(name = MODELS, description = "Retrieve and manage models")
 @RequestMapping(path = "/v1", produces = {HAL_JSON_VALUE, APPLICATION_JSON_VALUE})
 public interface ModelRestApi {
 
@@ -121,77 +121,77 @@ public interface ModelRestApi {
     String DELETE_RELATIONSHIP_MODEL_PROJECT_MODEL_ID_PARAM_DESCR = "The id of the model of the relationship to delete";
 
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "List models for an project",
-            notes = "Get the models associated with an project. " +
+            summary = "List models for an project",
+            description = "Get the models associated with an project. " +
                     "Minimal information for each model is returned."
             //response = AlfrescoModelPage.class
     )
     @GetMapping(path = "/projects/{projectId}/models")
     PagedModel<EntityModel<Model>> getModels(
-            @ApiParam(value = GET_MODELS_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = GET_MODELS_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(GET_MODELS_TYPE_PARAM_DESCR)
+            @Parameter(description = GET_MODELS_TYPE_PARAM_DESCR)
             @RequestParam(MODEL_TYPE_PARAM_NAME) String type,
             Pageable pageable);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Get metadata information for a model")
+            summary = "Get metadata information for a model")
     @GetMapping(path = "/models/{modelId}")
     EntityModel<Model> getModel(
-            @ApiParam(value = GET_MODEL_ID_PARAM_DESCR, required = true)
+            @Parameter(description = GET_MODEL_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Create new model belonging to an project",
-            notes = "Create a new model related to an existing project")
+            summary = "Create new model belonging to an project",
+            description = "Create a new model related to an existing project")
     @PostMapping(path = "/projects/{projectId}/models")
     @ResponseStatus(CREATED)
     EntityModel<Model> createModel(
-            @ApiParam(value = CREATE_MODEL_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = CREATE_MODEL_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(CREATE_MODEL_PARAM_DESCR)
+            @Parameter(description = CREATE_MODEL_PARAM_DESCR)
             @RequestBody Model model);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Update model metadata",
-            notes = "Update the details of a model.")
+            summary = "Update model metadata",
+            description = "Update the details of a model.")
     @PutMapping(path = "/models/{modelId}")
     EntityModel<Model> updateModel(
-            @ApiParam(value = UPDATE_MODEL_ID_PARAM_DESCR, required = true)
+            @Parameter(description = UPDATE_MODEL_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId,
-            @ApiParam(UPDATE_MODEL_PARAM_DESCR)
+            @Parameter(description = UPDATE_MODEL_PARAM_DESCR)
             @RequestBody Model model);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Update model content",
-            notes = "Update the content of the model from file.")
+            summary = "Update model content",
+            description = "Update the content of the model from file.")
     @PutMapping(path = "/models/{modelId}/content")
     @ResponseStatus(NO_CONTENT)
     void updateModelContent(
-            @ApiParam(value = UPDATE_MODEL_ID_PARAM_DESCR,required = true)
+            @Parameter(description = UPDATE_MODEL_ID_PARAM_DESCR,required = true)
             @PathVariable String modelId,
-            @ApiParam(UPDATE_MODEL_FILE_PARAM_DESCR)
+            @Parameter(description = UPDATE_MODEL_FILE_PARAM_DESCR)
             @RequestPart(UPLOAD_FILE_PARAM_NAME) MultipartFile file) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Delete model")
+            summary = "Delete model")
     @DeleteMapping(path = "/models/{modelId}")
     @ResponseStatus(NO_CONTENT)
     void deleteModel(
-            @ApiParam(value = DELETE_MODEL_ID_PARAM_DESCR, required = true)
+            @Parameter(description = DELETE_MODEL_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Get the model content",
-            notes = "Retrieve the content of the model for the identifier <b>modelId</b> " +
+            summary = "Get the model content",
+            description = "Retrieve the content of the model for the identifier <b>modelId</b> " +
                     "with the content type corresponding to the model type " +
                     "(xml for process models and json for the others).<br>" +
                     "For <b>Accept: image/svg+xml</b> request header, " +
@@ -199,134 +199,134 @@ public interface ModelRestApi {
     @GetMapping(path = "/models/{modelId}/content")
     void getModelContent(
             HttpServletResponse response,
-            @ApiParam(value = GET_MODEL_CONTENT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = GET_MODEL_CONTENT_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId) throws IOException;
 
     @GetMapping(path = "/models/{modelId}/content", produces = CONTENT_TYPE_SVG)
     void getModelDiagram(
             HttpServletResponse response,
-            @ApiParam(value = GET_MODEL_CONTENT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = GET_MODEL_CONTENT_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Import a model from file",
-            notes = "Allows a file to be uploaded containing a model definition.")
+            summary = "Import a model from file",
+            description = "Allows a file to be uploaded containing a model definition.")
     @PostMapping(path = "/projects/{projectId}/models/import", consumes = MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(CREATED)
     EntityModel<Model> importModel(
-            @ApiParam(value = CREATE_MODEL_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = CREATE_MODEL_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(IMPORT_MODEL_TYPE_PARAM_DESCR)
+            @Parameter(description = IMPORT_MODEL_TYPE_PARAM_DESCR)
             @RequestParam(MODEL_TYPE_PARAM_NAME) String type,
-            @ApiParam(IMPORT_MODEL_FILE_PARAM_DESCR)
+            @Parameter(description = IMPORT_MODEL_FILE_PARAM_DESCR)
             @RequestPart(UPLOAD_FILE_PARAM_NAME) MultipartFile file) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Export a model definition as file",
-            notes = "Allows to download a file containing a model metadata along with the model content.")
+            summary = "Export a model definition as file",
+            description = "Allows to download a file containing a model metadata along with the model content.")
     @GetMapping(path = "/models/{modelId}/export")
     void exportModel(
             HttpServletResponse response,
-            @ApiParam(value = EXPORT_MODEL_ID_PARAM_DESCR, required = true)
+            @Parameter(description = EXPORT_MODEL_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId,
-            @ApiParam(ATTACHMENT_API_PARAM_DESCR)
+            @Parameter(description = ATTACHMENT_API_PARAM_DESCR)
             @RequestParam(name = EXPORT_AS_ATTACHMENT_PARAM_NAME,
                     required = false,
                     defaultValue = "true") boolean attachment) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "List model types",
-            notes = "Get the list of available model types.")
+            summary = "List model types",
+            description = "Get the list of available model types.")
     @GetMapping(path = "/model-types")
     PagedModel<EntityModel<ModelType>> getModelTypes(Pageable pageable);
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Validate a model content",
-            notes = "Allows to validate the model content without save it.")
+            summary = "Validate a model content",
+            description = "Allows to validate the model content without save it.")
     @PostMapping("/models/{modelId}/validate")
     @ResponseStatus(NO_CONTENT)
     void validateModel(
-            @ApiParam(value = VALIDATE_MODEL_ID_PARAM_DESCR, required = true)
+            @Parameter(description = VALIDATE_MODEL_ID_PARAM_DESCR, required = true)
             @PathVariable String modelId,
-            @ApiParam(VALIDATE_MODEL_FILE_PARAM_DESCR)
+            @Parameter(description = VALIDATE_MODEL_FILE_PARAM_DESCR)
             @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
-            @ApiParam(value=VALIDATE_PROJECT_ID_PARAM_DESCR, required = false)
+            @Parameter(description = VALIDATE_PROJECT_ID_PARAM_DESCR, required = false)
             @RequestParam(value=PROJECT_ID_PARAM_NAME,required = false) String projectId,
-            @ApiParam(value= MODEL_USED_PARAM_DESCR, required = false)
+            @Parameter(description = MODEL_USED_PARAM_DESCR, required = false)
             @RequestParam(value= MODEL_USED_PARAM_DESCR,required = false) boolean isUsed) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = MODELS,
-            value = "Validate model extensions",
-            notes = "Allows to validate the model extensions without save them.")
+            summary = "Validate model extensions",
+            description = "Allows to validate the model extensions without save them.")
     @PostMapping("/models/{modelId}/validate/extensions")
     @ResponseStatus(NO_CONTENT)
     void validateModelExtensions(
-            @ApiParam(VALIDATE_MODEL_ID_PARAM_DESCR)
+            @Parameter(description = VALIDATE_MODEL_ID_PARAM_DESCR)
             @PathVariable String modelId,
-            @ApiParam(VALIDATE_EXTENSIONS_FILE_PARAM_DESCR)
+            @Parameter(description = VALIDATE_EXTENSIONS_FILE_PARAM_DESCR)
             @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
-            @ApiParam(value=VALIDATE_PROJECT_ID_PARAM_DESCR, required = false)
+            @Parameter(description = VALIDATE_PROJECT_ID_PARAM_DESCR, required = false)
             @RequestParam(value=PROJECT_ID_PARAM_NAME,required = false) String projectId) throws IOException;
 
-    @ApiOperation(
-        tags = MODELS,
-        value = "List all the models that are not coupled to a project",
-        notes = "Get the models that has GLOBAL as scope. " +
+    @Operation(
+            tags = MODELS, 
+            summary = "List all the models that are not coupled to a project",
+            description = "Get the models that has GLOBAL as scope. " +
             "Minimal information for each model is returned."
         //response = AlfrescoModelPage.class
     )
     @GetMapping(path = "/models")
     PagedModel<EntityModel<Model>> getGlobalModels(
-        @ApiParam(GET_MODELS_TYPE_PARAM_DESCR)
+        @Parameter(description = GET_MODELS_TYPE_PARAM_DESCR)
         @RequestParam(MODEL_TYPE_PARAM_NAME) String type,
-        @ApiParam(value = INCLUDE_ORPHANS_PARAM_DESCR, required = false)
+        @Parameter(description = INCLUDE_ORPHANS_PARAM_DESCR, required = false)
         @RequestParam(value = INCLUDE_ORPHANS_PARAM_NAME, required = false, defaultValue = "false") boolean includeOrphans,
         Pageable pageable);
 
-    @ApiOperation(
-        tags = MODELS,
-        value = "Add or update the relationship between an existing model, and the project",
-        notes = "Get the model associated with the project updated. " +
-            "Minimal information for the model is returned."
+    @Operation(
+            tags = MODELS, 
+            summary = "Add or update the relationship between an existing model, and the project",
+            description = "Get the model associated with the project updated. " +
+                "Minimal information for the model is returned."
     )
     @PutMapping(path = "/projects/{projectId}/models/{modelId}")
     EntityModel<Model> putProjectModelRelationship(
-        @ApiParam(value = RELATE_MODEL_PROJECT_PROJECT_ID_PARAM_DESCR, required = true)
+        @Parameter(description = RELATE_MODEL_PROJECT_PROJECT_ID_PARAM_DESCR, required = true)
         @PathVariable String projectId,
-        @ApiParam(value = RELATE_MODEL_PROJECT_MODEL_ID_PARAM_DESCR, required = true)
+        @Parameter(description = RELATE_MODEL_PROJECT_MODEL_ID_PARAM_DESCR, required = true)
         @PathVariable String modelId,
-        @ApiParam(value = SCOPE_PARAM_DESCR, required = false)
+        @Parameter(description = SCOPE_PARAM_DESCR, required = false)
         @RequestParam(value = SCOPE_PARAM_NAME, required = false) String scope,
-        @ApiParam(value = FORCE_PARAM_DESCR, required = false)
+        @Parameter(description = FORCE_PARAM_DESCR, required = false)
         @RequestParam(value = FORCE_PARAM_NAME, required = false, defaultValue = "false") boolean force);
 
-    @ApiOperation(
-        tags = MODELS,
-        value = "Delete the relationship between an existing model, and the project",
-        notes = "Get the model associated with the project updated. " +
-            "Minimal information for the model is returned."
+    @Operation(
+            tags = MODELS,
+            summary = "Delete the relationship between an existing model, and the project",
+            description = "Get the model associated with the project updated. " +
+                "Minimal information for the model is returned."
     )
     @DeleteMapping(path = "/projects/{projectId}/models/{modelId}")
     EntityModel<Model> deleteProjectModelRelationship(
-        @ApiParam(value = DELETE_RELATIONSHIP_MODEL_PROJECT_PROJECT_ID_PARAM_DESCR, required = true)
+        @Parameter(description = DELETE_RELATIONSHIP_MODEL_PROJECT_PROJECT_ID_PARAM_DESCR, required = true)
         @PathVariable String projectId,
-        @ApiParam(value = DELETE_RELATIONSHIP_MODEL_PROJECT_MODEL_ID_PARAM_DESCR, required = true)
+        @Parameter(description = DELETE_RELATIONSHIP_MODEL_PROJECT_MODEL_ID_PARAM_DESCR, required = true)
         @PathVariable String modelId);
 
-    @ApiOperation(
+    @Operation(
         tags = MODELS,
-        value = "Create new model that does note belong to a project",
-        notes = "Create a new model with no relationship to other projects"
+        summary = "Create new model that does note belong to a project",
+        description = "Create a new model with no relationship to other projects"
     )
     @PostMapping(path = "/models")
     @ResponseStatus(CREATED)
     EntityModel<Model> createModelWithoutProject(
-        @ApiParam(CREATE_MODEL_PARAM_DESCR)
+        @Parameter(description = CREATE_MODEL_PARAM_DESCR)
         @RequestBody Model model);
 
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ModelsSchemaRestApi.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ModelsSchemaRestApi.java
@@ -16,8 +16,8 @@
 package org.activiti.cloud.services.modeling.rest.api;
 
 import static org.activiti.cloud.services.modeling.rest.api.ModelRestApi.MODELS;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,14 +29,14 @@ import org.springframework.web.bind.annotation.RestController;
  * Controller for Schema resources.
  */
 @RestController
-@Api(tags = MODELS)
+@Tag(name = MODELS)
 @RequestMapping(value = "/v1/schemas")
 public interface ModelsSchemaRestApi {
 
-    @ApiOperation(
+    @Operation(
         tags = MODELS,
-        value = "Get validation schema for model type",
-        notes = "Get the content of the schema used to validate the given model type."
+        summary = "Get validation schema for model type",
+        description = "Get the content of the schema used to validate the given model type."
     )
     @GetMapping(value = "/{modelType}", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<String> getSchema(@PathVariable String modelType);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ProjectRestApi.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ProjectRestApi.java
@@ -18,9 +18,9 @@ package org.activiti.cloud.services.modeling.rest.api;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.modeling.api.Project;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.PagedModel;
@@ -48,7 +48,7 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
  * Controller for {@link Project} resources.
  */
 @RestController
-@Api(tags = PROJECTS, description = "Retrieve and manage project definitions")
+@Tag(name = PROJECTS, description = "Retrieve and manage project definitions")
 @RequestMapping(path = "/v1", produces = {HAL_JSON_VALUE, APPLICATION_JSON_VALUE})
 public interface ProjectRestApi {
 
@@ -89,101 +89,100 @@ public interface ProjectRestApi {
 
     String PROJECT_NAME_PARAM_NAME = "name";
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "List projects",
-            notes = "Get the list of available projects. " +
-                    "Minimal information for each project is returned.",
-            produces = APPLICATION_JSON_VALUE)
+            summary = "List projects",
+            description = "Get the list of available projects. " +
+                    "Minimal information for each project is returned.")
     @GetMapping(path = "/projects")
     PagedModel<EntityModel<Project>> getProjects(Pageable pageable,
-                                                  @ApiParam(PROJECT_NAME_PARAM_DESCR)
+                                                  @Parameter(description = PROJECT_NAME_PARAM_DESCR)
                                                   @RequestParam(
                                                           name = PROJECT_NAME_PARAM_NAME,
                                                           required = false) String name);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Create new project")
+            summary = "Create new project")
     @PostMapping(path = "/projects")
     @ResponseStatus(CREATED)
     EntityModel<Project> createProject(
-            @ApiParam(CREATE_PROJECT_PARAM_DESCR)
+            @Parameter(description = CREATE_PROJECT_PARAM_DESCR)
             @RequestBody Project project);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Get project")
+            summary = "Get project")
     @GetMapping(path = "/projects/{projectId}")
     EntityModel<Project> getProject(
-            @ApiParam(value = GET_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = GET_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Update project details")
+            summary = "Update project details")
     @PutMapping(path = "/projects/{projectId}")
     EntityModel<Project> updateProject(
-            @ApiParam(value = UPDATE_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = UPDATE_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(UPDATE_PROJECT_PARAM_DESCR)
+            @Parameter(description = UPDATE_PROJECT_PARAM_DESCR)
             @RequestBody Project project);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Delete project")
+            summary = "Delete project")
     @DeleteMapping(path = "/projects/{projectId}")
     @ResponseStatus(NO_CONTENT)
     void deleteProject(
-            @ApiParam(value = DELETE_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = DELETE_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Import an project as zip file",
-            notes = "Allows a zip file to be uploaded containing an project definition and any number of included models.")
+            summary = "Import an project as zip file",
+            description = "Allows a zip file to be uploaded containing an project definition and any number of included models.")
     @PostMapping(path = "/projects/import", consumes = MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(CREATED)
     EntityModel<Project> importProject(
-            @ApiParam(IMPORT_PROJECT_FILE_PARAM_DESCR)
+            @Parameter(description = IMPORT_PROJECT_FILE_PARAM_DESCR)
             @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
-            @ApiParam(PROJECT_NAME_OVERRIDE_DESCR)
+            @Parameter(description = PROJECT_NAME_OVERRIDE_DESCR)
             @RequestParam(
                     name = PROJECT_NAME_PARAM_NAME,
                     required = false) String name) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Export an project as zip file",
-            notes = "This will create and download the zip " +
+            summary = "Export an project as zip file",
+            description = "This will create and download the zip " +
                     "containing the project folder and all related models.<br>")
     @GetMapping(path = "/projects/{projectId}/export")
     void exportProject(
             HttpServletResponse response,
-            @ApiParam(value = EXPORT_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = EXPORT_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(ATTACHMENT_API_PARAM_DESCR)
+            @Parameter(description = ATTACHMENT_API_PARAM_DESCR)
             @RequestParam(name = EXPORT_AS_ATTACHMENT_PARAM_NAME,
                     required = false,
                     defaultValue = "true") boolean attachment) throws IOException;
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Copy an project as a new project with chosen name",
-            notes = "This will create a new project with chosen name " +
+            summary = "Copy an project as a new project with chosen name",
+            description = "This will create a new project with chosen name " +
                     "containing the project folder and all related models.<br>")
     @PostMapping(path = "/projects/{projectId}/copy")
     EntityModel<Project> copyProject(
-            @ApiParam(value = COPY_PROJECT_ID_PARAM_DESCR, required = true)
+            @Parameter(description = COPY_PROJECT_ID_PARAM_DESCR, required = true)
             @PathVariable String projectId,
-            @ApiParam(value = PROJECT_NAME_COPY_DESCR)
+            @Parameter(description = PROJECT_NAME_COPY_DESCR)
             @RequestParam(name = PROJECT_NAME_PARAM_NAME) String name);
 
-    @ApiOperation(
+    @Operation(
             tags = PROJECTS,
-            value = "Validate an project by id")
+            summary = "Validate an project by id")
     @GetMapping(path = "/projects/{projectId}/validate")
     void validateProject(
-            @ApiParam(VALIDATE_PROJECT_ID_PARAM_DESCR)
+            @Parameter(description = VALIDATE_PROJECT_ID_PARAM_DESCR)
             @PathVariable String projectId) throws IOException;
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelType;
@@ -222,9 +222,9 @@ public class ModelController implements ModelRestApi {
 
     @Override
     public void validateModelExtensions(
-        @ApiParam(VALIDATE_MODEL_ID_PARAM_DESCR)
+        @Parameter(description = VALIDATE_MODEL_ID_PARAM_DESCR)
         @PathVariable String modelId,
-        @ApiParam(VALIDATE_EXTENSIONS_FILE_PARAM_DESCR)
+        @Parameter(description = VALIDATE_EXTENSIONS_FILE_PARAM_DESCR)
         @RequestParam(UPLOAD_FILE_PARAM_NAME) MultipartFile file,
         @RequestParam(value = PROJECT_ID_PARAM_NAME, required = false) String projectId) throws IOException {
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.services.common.file.FileContent;
@@ -132,7 +132,7 @@ public class ProjectController implements ProjectRestApi {
 
     @Override
     public void validateProject(
-            @ApiParam(VALIDATE_PROJECT_ID_PARAM_DESCR)
+            @Parameter(description = VALIDATE_PROJECT_ID_PARAM_DESCR)
             @PathVariable String projectId) throws IOException {
         Project project = findProjectById(projectId);
         projectService.validateProject(project);

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
@@ -40,14 +40,14 @@ public class ModelingSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("ListResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").isNotEmpty())
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Starter :: Modeling ReST API"))
             .andExpect(jsonPath("$['paths']['/v1/projects/{projectId}/models']['get']['parameters'][*]['name']",
                 containsInAnyOrder("projectId", "type", "skipCount", "maxItems", "sort")));

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerITSupport.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerITSupport.java
@@ -45,7 +45,7 @@ public class ModelingSwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -18,6 +18,10 @@ package org.activiti.cloud.starter.tests.swagger;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -52,10 +56,20 @@ public class QuerySwaggerIT {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
-            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
-            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContentOf"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContentOf"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContentOf"))))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Query :: Starter :: Query ReST API"))
+            .andExpect(content().string(
+                        both(notNullValue(String.class))
+                                .and(not(containsString("ListResponseContent«")))
+                                .and(not(containsString("EntriesResponseContent«")))
+                                .and(not(containsString("EntryResponseContent«")))
+                                .and(not(containsString("PagedResources«")))
+                                .and(not(containsString("PagedResources«")))
+                                .and(not(containsString("Resources«Resource«")))
+                                .and(not(containsString("Resource«")))
+            ))
             .andReturn();
 
         assertThatJson(result.getResponse().getContentAsString())

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -47,14 +47,14 @@ public class QuerySwaggerIT {
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
         MvcResult result = mockMvc
-            .perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+            .perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("ListResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").isNotEmpty())
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
             .andExpect(jsonPath("$.info.title").value("Activiti Cloud Query :: Starter :: Query ReST API"))
             .andReturn();
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
@@ -48,7 +48,7 @@ public class QuerySwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/pom.xml
@@ -71,7 +71,7 @@
       <artifactId>activiti-cloud-api-process-model-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
+      <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
   </dependencies>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
@@ -15,7 +15,7 @@
  */
 package org.activiti.cloud.services.rest.api;
 
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
@@ -41,18 +41,18 @@ public interface ProcessDefinitionController {
     @GetMapping(value = "/{id}/model",
             produces = "application/xml")
     @ResponseBody
-    @ApiOperation("getProcessModel")
+    @Operation(summary = "getProcessModel")
     String getProcessModel(@PathVariable(value = "id") String id);
 
     @GetMapping(value = "/{id}/model",
             produces = "application/json")
     @ResponseBody
-    @ApiOperation("getProcessModel")
+    @Operation(summary = "getProcessModel")
     String getBpmnModel(@PathVariable(value = "id") String id);
 
     @GetMapping(value = "/{id}/model",
             produces = "image/svg+xml")
     @ResponseBody
-    @ApiOperation("getProcessModel")
+    @Operation(summary = "getProcessModel")
     String getProcessDiagram(@PathVariable(value = "id") String id);
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -48,16 +48,16 @@ public class RuntimeBundleSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.paths").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").isNotEmpty())
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("ListResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").isNotEmpty())
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
             .andExpect(
-                jsonPath("$.definitions").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.definitions").value(hasKey(startsWith("EntryResponseContent"))))
-            .andExpect(jsonPath("$.definitions[\"SaveTaskPayload\"].properties")
+                jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas[\"SaveTaskPayload\"].properties")
                 .value(hasKey("payloadType")))
             .andExpect(jsonPath("$.info.title")
                 .value("Activiti Cloud Starter :: Runtime Bundle ReST API"));

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -53,10 +53,9 @@ public class RuntimeBundleSwaggerIT {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
-            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
-            .andExpect(
-                jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
-            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContentOf"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContentOf"))))
+            .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContentOf"))))
             .andExpect(jsonPath("$.components.schemas[\"SaveTaskPayload\"].properties")
                 .value(hasKey("payloadType")))
             .andExpect(jsonPath("$.info.title")

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
@@ -52,7 +52,7 @@ class RuntimeBundleSwaggerITSupport {
      */
     @Test
     void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper
                     .readTree(result.getResponse().getContentAsByteArray());

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
@@ -65,6 +65,8 @@ public class SwaggerDocketBuilder {
         if (apiInfo != null) {
             baseDocket.apiInfo(apiInfo);
         }
+     
+        baseDocket.forCodeGeneration(true);
         return applyCustomizations(baseDocket);
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
@@ -57,7 +57,7 @@ public class SwaggerDocketBuilder {
     }
 
     private Docket baseDocket() {
-        Docket baseDocket = new Docket(DocumentationType.SWAGGER_2)
+        Docket baseDocket = new Docket(DocumentationType.OAS_30)
             .select()
             .apis(apiSelector::test)
             .paths(PathSelectors.any())

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -22,14 +22,12 @@ import org.activiti.cloud.common.swagger.DocketCustomizer;
 import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.RequestHandler;
-import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.oas.annotations.EnableOpenApi;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /**
  * Provides base springfox configuration for swagger auto-generated specification file. It provides two
@@ -49,7 +47,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
  *
  */
 @Configuration
-@EnableSwagger2
+@EnableOpenApi
 public class SwaggerAutoConfiguration {
 
     @Bean

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -44,7 +44,7 @@
     <resteasy.version>4.7.1.Final</resteasy.version>
     <logstash.version>6.6</logstash.version>
     <springfox.version>3.0.0</springfox.version>
-    <swagger.version>1.5.20</swagger.version>
+    <swagger.version>2.1.11</swagger.version>
     <xstream.version>1.4.18</xstream.version>
     <json-unit.version>2.25.0</json-unit.version>
   </properties>
@@ -121,7 +121,7 @@
         <version>${springfox.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.swagger</groupId>
+        <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${swagger.version}</version>
       </dependency>


### PR DESCRIPTION
Ref: [3743](https://github.com/Activiti/Activiti/issues/3743) Update of the Springfox configuration and  swagger-core annotation to support OAS3

OAS3 doesn't support  '<< ' in the module names so  replacing them using "Of"
OAS3.0.3 doesn't support request body  for DELETE method ( eg. rb specifications will show an error  generates an error if trying to validate it on swagger-editor) but the support will be back with OAS3.1 (see [PR]( https://github.com/OAI/OpenAPI-Specification/pull/2117))