### PR TITLE
fix(GH-3734): refactor connector messaging destinations initialization dependency

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfiguration.java
@@ -20,7 +20,6 @@ import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
 import org.activiti.engine.ManagementService;
-import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.bpmn.parser.factory.DefaultActivityBehaviorFactory;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
@@ -136,25 +135,4 @@ public class CloudConnectorsAutoConfiguration {
         taskBehavior.setVariablesCalculator(variablesMappingProvider);
         return taskBehavior;
     }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public ConnectorImplementationsProvider connectorDestinationsProvider(RepositoryService repositoryService) {
-        return new RepositoryConnectorImplementationsProvider(repositoryService);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public ConnectorDestinationMappingStrategy destinationMappingStrategy() {
-        return new ConnectorDestinationMappingStrategy() {};
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public ConnectorDestinationsBeanPostProcessor connectorDestinationsBeanPostProcessor(ConnectorImplementationsProvider destinationsProvider,
-                                                                                         ConnectorDestinationMappingStrategy destinationMappingStrategy) {
-        return new ConnectorDestinationsBeanPostProcessor(destinationsProvider,
-                                                          destinationMappingStrategy);
-    }
-
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsMessagingAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsMessagingAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.services.connectors.conf;
+
+import org.activiti.engine.RepositoryService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CloudConnectorsMessagingAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConnectorImplementationsProvider connectorDestinationsProvider(RepositoryService repositoryService) {
+        return new RepositoryConnectorImplementationsProvider(repositoryService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConnectorDestinationMappingStrategy destinationMappingStrategy() {
+        return new ConnectorDestinationMappingStrategy() {};
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConnectorMessagingDestinationsConfigurer connectorMessagingDestinationsConfigurer(BindingServiceProperties bindingServiceProperties,
+                                                                                             ConnectorImplementationsProvider destinationsProvider,
+                                                                                             ConnectorDestinationMappingStrategy destinationMappingStrategy) {
+        return new ConnectorMessagingDestinationsConfigurer(destinationsProvider,
+                                                            destinationMappingStrategy,
+                                                            bindingServiceProperties);
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsMessagingAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsMessagingAutoConfiguration.java
@@ -17,12 +17,15 @@
 package org.activiti.services.connectors.conf;
 
 import org.activiti.engine.RepositoryService;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@AutoConfigureAfter(BinderFactoryAutoConfiguration.class)
 public class CloudConnectorsMessagingAutoConfiguration {
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorDestinationsBeanPostProcessor.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorDestinationsBeanPostProcessor.java
@@ -73,7 +73,7 @@ public class ConnectorDestinationsBeanPostProcessor implements BeanPostProcessor
 
 
     protected void log(Map.Entry<String, BindingProperties> entry) {
-        logger.info("Configured Connector '{}' implementation to '{}' destination",
+        logger.warn("Configured Connector '{}' implementation to '{}' destination",
                     entry.getKey(),
                     entry.getValue()
                          .getDestination());

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorDestinationsBeanPostProcessor.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorDestinationsBeanPostProcessor.java
@@ -22,11 +22,12 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.core.Ordered;
 
 import java.util.AbstractMap;
 import java.util.Map;
 
-public class ConnectorDestinationsBeanPostProcessor implements BeanPostProcessor {
+public class ConnectorDestinationsBeanPostProcessor implements BeanPostProcessor, Ordered {
 
     private static final Logger logger = LoggerFactory.getLogger(ConnectorImplementationsProvider.class);
 
@@ -78,4 +79,8 @@ public class ConnectorDestinationsBeanPostProcessor implements BeanPostProcessor
                          .getDestination());
     }
 
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorMessagingDestinationsConfigurer.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/ConnectorMessagingDestinationsConfigurer.java
@@ -23,7 +23,6 @@ import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.core.Ordered;
 
-import java.util.AbstractMap;
 import java.util.Map;
 
 public class ConnectorMessagingDestinationsConfigurer implements InitializingBean, Ordered {
@@ -46,26 +45,25 @@ public class ConnectorMessagingDestinationsConfigurer implements InitializingBea
     public void afterPropertiesSet() throws Exception {
         destinationsProvider.getImplementations()
                             .stream()
-                            .map(this::getDestination)
-                            .map(entry -> applyDestination(bindingServiceProperties, entry))
+                            .map(this::resolveBindingDestination)
+                            .map(this::applyBindingDestination)
                             .forEach(this::log);
     }
 
-    protected Map.Entry<String, String> getDestination(String implementation) {
+    protected Map.Entry<String, String> resolveBindingDestination(String implementation) {
         String destination = destinationMappingStrategy.apply(implementation);
 
-        return new AbstractMap.SimpleEntry<>(implementation,
-                                             destination);
+        return Map.entry(implementation,
+                         destination);
     }
 
-    protected Map.Entry<String, BindingProperties> applyDestination(BindingServiceProperties bindingServiceProperties,
-                                                                    Map.Entry<String, String> entry) {
+    protected Map.Entry<String, BindingProperties> applyBindingDestination(Map.Entry<String, String> entry) {
         BindingProperties bindingProperties = bindingServiceProperties.getBindingProperties(entry.getKey());
 
         bindingProperties.setDestination(entry.getValue());
 
-        return new AbstractMap.SimpleEntry<String, BindingProperties>(entry.getKey(),
-                                                                      bindingProperties);
+        return Map.entry(entry.getKey(),
+                         bindingProperties);
     }
 
 
@@ -78,6 +76,6 @@ public class ConnectorMessagingDestinationsConfigurer implements InitializingBea
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
+        return Ordered.HIGHEST_PRECEDENCE;
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.services.connectors.conf.CloudConnectorsAutoConfiguration
+    org.activiti.services.connectors.conf.CloudConnectorsAutoConfiguration,\
+    org.activiti.services.connectors.conf.CloudConnectorsMessagingAutoConfiguration

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/SignalSender.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/SignalSender.java
@@ -17,27 +17,27 @@ package org.activiti.services.subscription;
 
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.runtime.api.signal.SignalPayloadEventListener;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * Overrides default SignalPayloadEventListener implementation to 
+ * Overrides default SignalPayloadEventListener implementation to
  * broadcast signals into Runtime Bundle instances via Cloud Stream
  */
 public class SignalSender implements SignalPayloadEventListener {
 
-    private final BinderAwareChannelResolver resolver;
+    private final MessageChannel messageChannel;
 
-    public SignalSender(BinderAwareChannelResolver resolver) {
-        this.resolver = resolver;
+    public SignalSender(MessageChannel messageChannel) {
+        this.messageChannel = messageChannel;
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendSignal(SignalPayload signalPayload) {
         Message<SignalPayload> message = MessageBuilder.withPayload(signalPayload).build();
-        resolver.resolveDestination("signalEvent").send(message);
+        messageChannel.send(message);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/channel/BroadcastSignalEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/channel/BroadcastSignalEventHandler.java
@@ -18,14 +18,12 @@ package org.activiti.services.subscription.channel;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.engine.RuntimeService;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 
 public class BroadcastSignalEventHandler {
 
     private final RuntimeService runtimeService;
 
-    public BroadcastSignalEventHandler(BinderAwareChannelResolver resolver,
-                                      RuntimeService runtimeService) {
+    public BroadcastSignalEventHandler(RuntimeService runtimeService) {
         this.runtimeService = runtimeService;
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/config/ActivitiCloudSubscriptionsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/config/ActivitiCloudSubscriptionsAutoConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.services.subscription.config;
 
-import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
 import org.activiti.bpmn.model.Signal;
 import org.activiti.bpmn.model.SignalEventDefinition;
 import org.activiti.engine.RuntimeService;
@@ -30,12 +29,13 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.Scope;
+
+import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
 
 @Configuration
 @PropertySource("classpath:config/signal-events-channels.properties")
@@ -45,24 +45,22 @@ public class ActivitiCloudSubscriptionsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BroadcastSignalEventHandler broadcastSignalEventHandler(BinderAwareChannelResolver resolver,
-                                                                  RuntimeService runtimeService) {
-        return new BroadcastSignalEventHandler(resolver,
-                                              runtimeService);
+    public BroadcastSignalEventHandler broadcastSignalEventHandler(RuntimeService runtimeService) {
+        return new BroadcastSignalEventHandler(runtimeService);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public SignalPayloadEventListener signalSender(BinderAwareChannelResolver resolver) {
-        return new SignalSender(resolver);
+    public SignalPayloadEventListener signalSender(ProcessEngineSignalChannels processEngineSignalChannels) {
+        return new SignalSender(processEngineSignalChannels.signalProducer());
     }
 
     @Bean(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME)
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     @ConditionalOnMissingBean
     public IntermediateThrowSignalEventActivityBehavior broadcastSignalEventActivityBehavior(ApplicationEventPublisher eventPublisher,
-                                                                                     SignalEventDefinition signalEventDefinition,
-                                                                                     Signal signal) {
+                                                                                             SignalEventDefinition signalEventDefinition,
+                                                                                             Signal signal) {
         return new BroadcastSignalEventActivityBehavior(eventPublisher,
                                                         signalEventDefinition,
                                                         signal);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.common.messaging;
 import org.activiti.cloud.common.messaging.config.InputConverterFunction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.*;
@@ -95,7 +96,7 @@ public class ActivitiCloudMessagingProperties {
     /**
      * Configure destination properties to apply customization to producers and consumer channel bindings with matching destination key.
      */
-    private Map<String, DestinationProperties> destinations = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private Map<String, DestinationProperties> destinations = new LinkedCaseInsensitiveMap<>();
 
     private Map<String, InputConverterFunction> inputConverters;
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsAutoConfiguration.java
@@ -17,13 +17,16 @@
 package org.activiti.cloud.common.messaging.config;
 
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@AutoConfigureBefore(BinderFactoryAutoConfiguration.class)
 @ConditionalOnClass(BindingServiceProperties.class)
 public class ActivitiMessagingDestinationsAutoConfiguration {
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -16,16 +16,25 @@
 
 package org.activiti.cloud.common.messaging.config.test;
 
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @SpringBootApplication
 public class ActivitiCloudMessagingAutoConfigurationTests {
 
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
     @Test
     public void contextLoads() {
-        // noop
+        assertThat(messagingProperties.getDestinations()).isInstanceOf(LinkedCaseInsensitiveMap.class);
+
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiMessagingDestinationsEnvironmentPostProcessorIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiMessagingDestinationsEnvironmentPostProcessorIT.java
@@ -17,17 +17,12 @@
 package org.activiti.cloud.common.messaging.config.test;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(ActivitiMessagingDestinationsEnvironmentPostProcessorIT.PropertyExtension.class)
 @SpringBootTest(properties = {
     "activiti.cloud.application.name=foo",
     "spring.application.name=bar",
@@ -47,7 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
     "spring.cloud.stream.bindings.auditProducer.destination=engineEvents",
     "spring.cloud.stream.bindings.auditConsumer.destination=engineEvents",
     "spring.cloud.stream.bindings.queryConsumer.destination=engineEvents",
+
     // override destination name
+    "activiti.cloud.messaging.destinations.engineEvents.name=engine-events",
 
     "spring.cloud.stream.bindings.[camel-connector.INVOKE].destination=camel-connector.INVOKE",
     "spring.cloud.stream.bindings.camelConnectorConsumer.destination=camel-connector.INVOKE",
@@ -65,21 +62,6 @@ import static org.assertj.core.api.Assertions.assertThat;
     "activiti.cloud.messaging.destinations.commandResults.prefix=bar",
     "activiti.cloud.messaging.destinations.commandResults.separator=_"})
 public class ActivitiMessagingDestinationsEnvironmentPostProcessorIT {
-
-    // override destination name via case in-sensitive environment variable key map, i.e.
-    // activiti.cloud.messaging.destinations.engineEvents.name=engine-events
-    public static class PropertyExtension implements BeforeAllCallback, AfterAllCallback {
-
-        @Override
-        public void beforeAll(ExtensionContext context) {
-            System.setProperty("ACTIVITI_CLOUD_MESSAGING_DESTINATIONS_ENGINEEVENTS_NAME", "engine-events");
-        }
-
-        @Override
-        public void afterAll(ExtensionContext context) throws Exception {
-            System.clearProperty("ACTIVITI_CLOUD_MESSAGING_DESTINATIONS_ENGINEEVENTS_NAME");
-        }
-    }
 
     @Autowired
     private BindingServiceProperties bindingServiceProperties;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiMessagingDestinationsEnvironmentPostProcessorIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiMessagingDestinationsEnvironmentPostProcessorIT.java
@@ -17,12 +17,17 @@
 package org.activiti.cloud.common.messaging.config.test;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(ActivitiMessagingDestinationsEnvironmentPostProcessorIT.PropertyExtension.class)
 @SpringBootTest(properties = {
     "activiti.cloud.application.name=foo",
     "spring.application.name=bar",
@@ -43,7 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
     "spring.cloud.stream.bindings.auditConsumer.destination=engineEvents",
     "spring.cloud.stream.bindings.queryConsumer.destination=engineEvents",
     // override destination name
-    "activiti.cloud.messaging.destinations.engineEvents.name=engine-events",
 
     "spring.cloud.stream.bindings.[camel-connector.INVOKE].destination=camel-connector.INVOKE",
     "spring.cloud.stream.bindings.camelConnectorConsumer.destination=camel-connector.INVOKE",
@@ -61,6 +65,21 @@ import static org.assertj.core.api.Assertions.assertThat;
     "activiti.cloud.messaging.destinations.commandResults.prefix=bar",
     "activiti.cloud.messaging.destinations.commandResults.separator=_"})
 public class ActivitiMessagingDestinationsEnvironmentPostProcessorIT {
+
+    // override destination name via case in-sensitive environment variable key map, i.e.
+    // activiti.cloud.messaging.destinations.engineEvents.name=engine-events
+    public static class PropertyExtension implements BeforeAllCallback, AfterAllCallback {
+
+        @Override
+        public void beforeAll(ExtensionContext context) {
+            System.setProperty("ACTIVITI_CLOUD_MESSAGING_DESTINATIONS_ENGINEEVENTS_NAME", "engine-events");
+        }
+
+        @Override
+        public void afterAll(ExtensionContext context) throws Exception {
+            System.clearProperty("ACTIVITI_CLOUD_MESSAGING_DESTINATIONS_ENGINEEVENTS_NAME");
+        }
+    }
 
     @Autowired
     private BindingServiceProperties bindingServiceProperties;


### PR DESCRIPTION
This PR fixes the following problems discovered during acceptance testing in Activiti Cloud Application PR: https://github.com/Activiti/activiti-cloud-application/pull/449

- [x] Use Spring InitializingBean to configure connector messaging destinations due to Spring bean postprocessor initialization race conditions between binder factory and process engine factory bean
- [x] Refactor signal event sender to use producer message channel to fire signal events
- [x] Use highest priority to configure connector channel binding destinations during context initialization
- [x] Resolve messaging destination config properties from environment variables

Part of https://github.com/Activiti/activiti-cloud/pull/485
