### PR TITLE
Add possibility to define path prefix to swagger spec

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/AuditSwaggerConfig.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/AuditSwaggerConfig.java
@@ -31,14 +31,10 @@ public class AuditSwaggerConfig {
 
     @Bean(name = "auditApiDocket")
     @ConditionalOnMissingBean(name = "auditApiDocket")
-    public Docket auditApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
-        List<DocketCustomizer> docketCustomizers,
+    public Docket auditApiDocket(SwaggerDocketBuilder docketBuilder,
         @Value("${activiti.cloud.swagger.audit-base-path:}") String auditSwaggerBasePath) {
-        return new SwaggerDocketBuilder("org.activiti.cloud.services.audit",
-            typeResolver, docketCustomizers)
-            .buildApiDocket("Audit", auditSwaggerBasePath)
-            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Audit Service ReST API")
-                .build());
+        return docketBuilder.buildApiDocket("Audit Service ReST API", "Audit",
+            auditSwaggerBasePath, "org.activiti.cloud.services.audit");
     }
 
     @Bean

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/AuditSwaggerConfig.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/main/java/org/activiti/cloud/starter/audit/configuration/AuditSwaggerConfig.java
@@ -15,43 +15,34 @@
  */
 package org.activiti.cloud.starter.audit.configuration;
 
-import java.util.function.Predicate;
+import com.fasterxml.classmate.TypeResolver;
+import java.util.List;
+import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
 import org.activiti.cloud.common.swagger.DocketCustomizer;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.RequestHandler;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class AuditSwaggerConfig {
 
-    @Bean
-    @ConditionalOnMissingBean
-    public ApiInfo apiInfo(BuildProperties buildProperties) {
-        return new ApiInfoBuilder()
-            .title(String.format("%s ReST API", buildProperties.getName()))
-            .description(buildProperties.get("description"))
-            .version(buildProperties.getVersion())
-            .license(String.format("© %s-%s %s. All rights reserved",
-                buildProperties.get("inceptionYear"),
-                buildProperties.get("year"),
-                buildProperties.get("organization.name")))
-            .termsOfServiceUrl(buildProperties.get("organization.url"))
-            .build();
+    @Bean(name = "auditApiDocket")
+    @ConditionalOnMissingBean(name = "auditApiDocket")
+    public Docket auditApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
+        List<DocketCustomizer> docketCustomizers,
+        @Value("${activiti.cloud.swagger.audit-base-path:}") String auditSwaggerBasePath) {
+        return new SwaggerDocketBuilder("org.activiti.cloud.services.audit",
+            typeResolver, docketCustomizers)
+            .buildApiDocket("Audit", auditSwaggerBasePath)
+            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Audit Service ReST API")
+                .build());
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public Predicate<RequestHandler> apiSelector() {
-        return RequestHandlerSelectors.basePackage("org.activiti.cloud.services.audit");
-    }
-
-    @Bean
-    public DocketCustomizer PayloadsDocketCustomizer() {
+    public DocketCustomizer payloadsDocketCustomizer() {
         return new PayloadsDocketCustomizer();
     }
 

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
@@ -43,7 +43,7 @@ public class AuditSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Audit").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
@@ -52,7 +52,7 @@ public class AuditSwaggerIT {
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey("CloudRuntimeEventModel")))
-            .andExpect(jsonPath("$.info.title").value("Activiti Cloud Audit :: Starter :: Audit ReST API"));
+            .andExpect(jsonPath("$.info.title").value("Audit Service ReST API"));
 
     }
 

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
@@ -25,6 +25,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -46,6 +48,8 @@ public class AuditSwaggerIT {
         mockMvc.perform(get("/v3/api-docs?group=Audit").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.servers").isNotEmpty())
+            .andExpect(jsonPath("$.servers[0].url").value(equalTo("/")))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
@@ -49,7 +49,7 @@ public class AuditSwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Audit").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/main/java/org/activiti/cloud/starter/modeling/configuration/ModelingSwaggerConfig.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/main/java/org/activiti/cloud/starter/modeling/configuration/ModelingSwaggerConfig.java
@@ -15,38 +15,30 @@
  */
 package org.activiti.cloud.starter.modeling.configuration;
 
-import java.util.function.Predicate;
+import com.fasterxml.classmate.TypeResolver;
+import java.util.List;
+import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
+import org.activiti.cloud.common.swagger.DocketCustomizer;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.RequestHandler;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class ModelingSwaggerConfig {
 
-    @Bean
-    @ConditionalOnMissingBean
-    public ApiInfo apiInfo(BuildProperties buildProperties) {
-        return new ApiInfoBuilder()
-            .title(String.format("%s ReST API", buildProperties.getName()))
-            .description(buildProperties.get("description"))
-            .version(buildProperties.getVersion())
-            .license(String.format("© %s-%s %s. All rights reserved",
-                buildProperties.get("inceptionYear"),
-                buildProperties.get("year"),
-                buildProperties.get("organization.name")))
-            .termsOfServiceUrl(buildProperties.get("organization.url"))
-            .build();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public Predicate<RequestHandler> apiSelector() {
-        return RequestHandlerSelectors.basePackage("org.activiti.cloud.services.modeling.rest");
+    @Bean(name = "modelingApiDocket")
+    @ConditionalOnMissingBean(name = "modelingApiDocket")
+    public Docket modelingApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
+        List<DocketCustomizer> docketCustomizers,
+        @Value("${activiti.cloud.swagger.modeling-base-path:}") String swaggerBasePath) {
+        return new SwaggerDocketBuilder("org.activiti.cloud.services.modeling.rest",
+            typeResolver, docketCustomizers)
+            .buildApiDocket("Modeling", swaggerBasePath)
+            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Modeling ReST API")
+                .build());
     }
 
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/main/java/org/activiti/cloud/starter/modeling/configuration/ModelingSwaggerConfig.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/main/java/org/activiti/cloud/starter/modeling/configuration/ModelingSwaggerConfig.java
@@ -15,10 +15,6 @@
  */
 package org.activiti.cloud.starter.modeling.configuration;
 
-import com.fasterxml.classmate.TypeResolver;
-import java.util.List;
-import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
-import org.activiti.cloud.common.swagger.DocketCustomizer;
 import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -31,14 +27,10 @@ public class ModelingSwaggerConfig {
 
     @Bean(name = "modelingApiDocket")
     @ConditionalOnMissingBean(name = "modelingApiDocket")
-    public Docket modelingApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
-        List<DocketCustomizer> docketCustomizers,
+    public Docket modelingApiDocket(SwaggerDocketBuilder swaggerDocketBuilder,
         @Value("${activiti.cloud.swagger.modeling-base-path:}") String swaggerBasePath) {
-        return new SwaggerDocketBuilder("org.activiti.cloud.services.modeling.rest",
-            typeResolver, docketCustomizers)
-            .buildApiDocket("Modeling", swaggerBasePath)
-            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Modeling ReST API")
-                .build());
+        return swaggerDocketBuilder.buildApiDocket("Modeling ReST API", "Modeling", swaggerBasePath,
+            "org.activiti.cloud.services.modeling.rest");
     }
 
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
@@ -43,6 +43,8 @@ public class ModelingSwaggerIT {
         mockMvc.perform(get("/v3/api-docs?group=Modeling").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.servers").isNotEmpty())
+            .andExpect(jsonPath("$.servers[0].url").value(equalTo("/")))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
@@ -40,7 +40,7 @@ public class ModelingSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Modeling").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
@@ -48,7 +48,7 @@ public class ModelingSwaggerIT {
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContent"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContent"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContent"))))
-            .andExpect(jsonPath("$.info.title").value("Activiti Cloud Starter :: Modeling ReST API"))
+            .andExpect(jsonPath("$.info.title").value("Modeling ReST API"))
             .andExpect(jsonPath("$['paths']['/v1/projects/{projectId}/models']['get']['parameters'][*]['name']",
                 containsInAnyOrder("projectId", "type", "skipCount", "maxItems", "sort")));
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerITSupport.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerITSupport.java
@@ -45,7 +45,7 @@ public class ModelingSwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Modeling").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/java/org/activiti/cloud/starter/query/configuration/QuerySwaggerConfig.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/java/org/activiti/cloud/starter/query/configuration/QuerySwaggerConfig.java
@@ -16,39 +16,31 @@
 package org.activiti.cloud.starter.query.configuration;
 
 import com.fasterxml.classmate.TypeResolver;
-import java.util.function.Predicate;
+import java.util.List;
+import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
+import org.activiti.cloud.common.swagger.DocketCustomizer;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.RequestHandler;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class QuerySwaggerConfig {
 
-    @Bean
-    @ConditionalOnMissingBean
-    public ApiInfo apiInfo(BuildProperties buildProperties) {
-        return new ApiInfoBuilder()
-            .title(String.format("%s ReST API", buildProperties.getName()))
-            .description(buildProperties.get("description"))
-            .version(buildProperties.getVersion())
-            .license(String.format("© %s-%s %s. All rights reserved",
-                buildProperties.get("inceptionYear"),
-                buildProperties.get("year"),
-                buildProperties.get("organization.name")))
-            .termsOfServiceUrl(buildProperties.get("organization.url"))
-            .build();
+    @Bean(name = "queryApiDocket")
+    @ConditionalOnMissingBean(name = "queryApiDocket")
+    public Docket queryApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
+        List<DocketCustomizer> docketCustomizers,
+        @Value("${activiti.cloud.swagger.query-base-path:}") String querySwaggerBasePath) {
+        return new SwaggerDocketBuilder("org.activiti.cloud.services.query.rest",
+            typeResolver, docketCustomizers)
+            .buildApiDocket("Query", querySwaggerBasePath)
+            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Query Service ReST API")
+                .build());
     }
 
-    @Bean
-    @ConditionalOnMissingBean
-    public Predicate<RequestHandler> apiSelector() {
-        return RequestHandlerSelectors.basePackage("org.activiti.cloud.services.query.rest");
-    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/java/org/activiti/cloud/starter/query/configuration/QuerySwaggerConfig.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/java/org/activiti/cloud/starter/query/configuration/QuerySwaggerConfig.java
@@ -31,16 +31,11 @@ public class QuerySwaggerConfig {
 
     @Bean(name = "queryApiDocket")
     @ConditionalOnMissingBean(name = "queryApiDocket")
-    public Docket queryApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
-        List<DocketCustomizer> docketCustomizers,
+    public Docket queryApiDocket(SwaggerDocketBuilder docketBuilder,
         @Value("${activiti.cloud.swagger.query-base-path:}") String querySwaggerBasePath) {
-        return new SwaggerDocketBuilder("org.activiti.cloud.services.query.rest",
-            typeResolver, docketCustomizers)
-            .buildApiDocket("Query", querySwaggerBasePath)
-            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Query Service ReST API")
-                .build());
+        return docketBuilder.buildApiDocket("Query Service ReST API", "Query",
+            querySwaggerBasePath, "org.activiti.cloud.services.query.rest");
     }
-
 
     @Bean
     @ConditionalOnMissingBean

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -51,7 +51,7 @@ public class QuerySwaggerIT {
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
         MvcResult result = mockMvc
-            .perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+            .perform(get("/v3/api-docs?group=Query").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.paths").isNotEmpty())
@@ -59,7 +59,7 @@ public class QuerySwaggerIT {
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContentOf"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntriesResponseContentOf"))))
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("EntryResponseContentOf"))))
-            .andExpect(jsonPath("$.info.title").value("Activiti Cloud Query :: Starter :: Query ReST API"))
+            .andExpect(jsonPath("$.info.title").value("Query Service ReST API"))
             .andExpect(content().string(
                         both(notNullValue(String.class))
                                 .and(not(containsString("ListResponseContent«")))

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.starter.tests.swagger;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.both;
@@ -54,6 +55,8 @@ public class QuerySwaggerIT {
             .perform(get("/v3/api-docs?group=Query").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.servers").isNotEmpty())
+            .andExpect(jsonPath("$.servers[0].url").value(equalTo("/")))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContentOf"))))

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
@@ -48,7 +48,7 @@ public class QuerySwaggerITSupport {
      */
     @Test
     public void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Query").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper.readTree(result.getResponse().getContentAsByteArray());
                 Files.write(new File("target/swagger.json").toPath(),

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/RuntimeBundleSwaggerConfig.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/RuntimeBundleSwaggerConfig.java
@@ -15,43 +15,35 @@
  */
 package org.activiti.cloud.starter.rb.configuration;
 
-import java.util.function.Predicate;
+import com.fasterxml.classmate.TypeResolver;
+import java.util.List;
+import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
+import org.activiti.cloud.common.swagger.DocketCustomizer;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.RequestHandler;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class RuntimeBundleSwaggerConfig {
 
-    @Bean
-    @ConditionalOnMissingBean
-    public ApiInfo apiInfo(BuildProperties buildProperties) {
-        return new ApiInfoBuilder()
-            .title(String.format("%s ReST API", buildProperties.getName()))
-            .description(buildProperties.get("description"))
-            .version(buildProperties.getVersion())
-            .license(String.format("© %s-%s %s. All rights reserved",
-                buildProperties.get("inceptionYear"),
-                buildProperties.get("year"),
-                buildProperties.get("organization.name")))
-            .termsOfServiceUrl(buildProperties.get("organization.url"))
-            .build();
+    @Bean(name = "rbApiDocket")
+    @ConditionalOnMissingBean(name = "rbApiDocket")
+    public Docket rbApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
+       List<DocketCustomizer> docketCustomizers,
+        @Value("${activiti.cloud.swagger.rb-base-path:}") String rbSwaggerBasePath) {
+        return new SwaggerDocketBuilder("org.activiti.cloud.services.rest",
+            typeResolver, docketCustomizers)
+            .buildApiDocket("Runtime Bundle", rbSwaggerBasePath)
+            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Runtime Bundle ReST API")
+                .build());
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public Predicate<RequestHandler> apiSelector() {
-        return RequestHandlerSelectors.basePackage("org.activiti.cloud.services.rest");
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public PayloadsDocketCustomizer payloadsDocketCustomizer(){
+    public PayloadsDocketCustomizer payloadsDocketCustomizer() {
         return new PayloadsDocketCustomizer();
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/RuntimeBundleSwaggerConfig.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/RuntimeBundleSwaggerConfig.java
@@ -31,14 +31,10 @@ public class RuntimeBundleSwaggerConfig {
 
     @Bean(name = "rbApiDocket")
     @ConditionalOnMissingBean(name = "rbApiDocket")
-    public Docket rbApiDocket(BaseAPIInfoBuilder baseAPIInfoBuilder, TypeResolver typeResolver,
-       List<DocketCustomizer> docketCustomizers,
+    public Docket rbApiDocket(SwaggerDocketBuilder docketBuilder,
         @Value("${activiti.cloud.swagger.rb-base-path:}") String rbSwaggerBasePath) {
-        return new SwaggerDocketBuilder("org.activiti.cloud.services.rest",
-            typeResolver, docketCustomizers)
-            .buildApiDocket("Runtime Bundle", rbSwaggerBasePath)
-            .apiInfo(baseAPIInfoBuilder.baseApiInfoBuilder("Runtime Bundle ReST API")
-                .build());
+        return docketBuilder.buildApiDocket("Runtime Bundle ReST API", "Runtime Bundle",
+            rbSwaggerBasePath, "org.activiti.cloud.services.rest");
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -27,6 +27,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,6 +53,8 @@ public class RuntimeBundleSwaggerIT {
         mockMvc.perform(get("/v3/api-docs?group=Runtime Bundle").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.servers").isNotEmpty())
+            .andExpect(jsonPath("$.servers[0].url").value(equalTo("/")))
             .andExpect(jsonPath("$.paths").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").isNotEmpty())
             .andExpect(jsonPath("$.components.schemas").value(hasKey(startsWith("ListResponseContentOf"))))

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -48,7 +48,7 @@ public class RuntimeBundleSwaggerIT {
 
     @Test
     public void should_swaggerDefinitionHavePathsAndDefinitionsAndInfo() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Runtime Bundle").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(jsonPath("$.paths").isNotEmpty())
@@ -59,7 +59,7 @@ public class RuntimeBundleSwaggerIT {
             .andExpect(jsonPath("$.components.schemas[\"SaveTaskPayload\"].properties")
                 .value(hasKey("payloadType")))
             .andExpect(jsonPath("$.info.title")
-                .value("Activiti Cloud Starter :: Runtime Bundle ReST API"));
+                .value("Runtime Bundle ReST API"));
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
@@ -52,7 +52,7 @@ class RuntimeBundleSwaggerITSupport {
      */
     @Test
     void generateSwagger() throws Exception {
-        mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/v3/api-docs?group=Runtime Bundle").accept(MediaType.APPLICATION_JSON))
             .andDo((result) -> {
                 JsonNode jsonNodeTree = objectMapper
                     .readTree(result.getResponse().getContentAsByteArray());

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
@@ -31,5 +31,25 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/pom.xml
@@ -27,5 +27,9 @@
       <groupId>io.springfox</groupId>
       <artifactId>springfox-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/BaseAPIInfoBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/BaseAPIInfoBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger;
+
+import org.springframework.boot.info.BuildProperties;
+import springfox.documentation.builders.ApiInfoBuilder;
+
+public class BaseAPIInfoBuilder {
+
+    private BuildProperties buildProperties;
+
+    public BaseAPIInfoBuilder(BuildProperties buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    public ApiInfoBuilder baseApiInfoBuilder(String title) {
+        return new ApiInfoBuilder()
+            .title(title)
+            .version(buildProperties.getVersion())
+            .license(String.format("© %s-%s %s. All rights reserved",
+                buildProperties.get("inceptionYear"),
+                buildProperties.get("year"),
+                buildProperties.get("organization.name")))
+            .termsOfServiceUrl(buildProperties.get("organization.url"));
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/PathPrefixTransformationFilter.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/PathPrefixTransformationFilter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.ArrayList;
+import javax.servlet.http.HttpServletRequest;
+import springfox.documentation.oas.web.OpenApiTransformationContext;
+import springfox.documentation.oas.web.WebMvcOpenApiTransformationFilter;
+import springfox.documentation.spi.DocumentationType;
+
+public class PathPrefixTransformationFilter implements WebMvcOpenApiTransformationFilter {
+
+    private final String swaggerBasePath;
+
+    public PathPrefixTransformationFilter(String swaggerBasePath) {
+        this.swaggerBasePath = swaggerBasePath;
+    }
+
+    @Override
+    public OpenAPI transform(OpenApiTransformationContext<HttpServletRequest> context) {
+        final OpenAPI openApi = context.getSpecification();
+        String servicePrefix = getServicePrefix(openApi);
+        final String url = (swaggerBasePath + servicePrefix).replaceAll("//", "/");
+        replaceServer(openApi, url);
+        return openApi;
+    }
+
+    private void replaceServer(OpenAPI openApi, String url) {
+        final ArrayList<Server> servers = new ArrayList<>();
+        final Server server = new Server();
+        server.setUrl(url);
+        servers.add(server);
+        openApi.setServers(servers);
+    }
+
+    private String getServicePrefix(OpenAPI openApi) {
+        String servicePrefix = "";
+        final String configuredPrefix = (String) openApi.getExtensions().get(SwaggerDocketBuilder.SERVICE_URL_PREFIX);
+        if (configuredPrefix != null) {
+            servicePrefix = configuredPrefix;
+        }
+        return servicePrefix;
+    }
+
+    @Override
+    public boolean supports(DocumentationType documentationType) {
+        return DocumentationType.OAS_30.equals(documentationType);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -15,18 +15,16 @@
  */
 package org.activiti.cloud.common.swagger.conf;
 
-import com.fasterxml.classmate.TypeResolver;
-import java.util.List;
 import java.util.function.Predicate;
-import org.activiti.cloud.common.swagger.DocketCustomizer;
-import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
+import org.activiti.cloud.common.swagger.PathPrefixTransformationFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.RequestHandler;
 import springfox.documentation.oas.annotations.EnableOpenApi;
-import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spring.web.plugins.Docket;
 
 /**
@@ -51,17 +49,15 @@ import springfox.documentation.spring.web.plugins.Docket;
 public class SwaggerAutoConfiguration {
 
     @Bean
-    public SwaggerDocketBuilder swaggerDocketBuilder(Predicate<RequestHandler> apiSelector,
-        TypeResolver typeResolver,
-        @Autowired(required = false) List<DocketCustomizer> docketCustomizers,
-        @Autowired(required = false) ApiInfo apiInfo) {
-        return new SwaggerDocketBuilder(apiSelector, typeResolver, docketCustomizers, apiInfo);
+    @ConditionalOnMissingBean
+    public BaseAPIInfoBuilder baseAPIInfoBuilder(BuildProperties buildProperties) {
+        return new BaseAPIInfoBuilder(buildProperties);
     }
 
-    @Bean(name = "alfrescoAPIDocket")
-    @ConditionalOnMissingBean(name = "alfrescoAPIDocket")
-    public Docket alfrescoAPIDocket(SwaggerDocketBuilder swaggerDocketBuilder) {
-        return swaggerDocketBuilder.buildAlfrescoAPIDocket();
+    @Bean
+    @ConditionalOnMissingBean
+    public PathPrefixTransformationFilter pathPrefixTransformationFilter(@Value("${activiti.cloud.swagger.base-path:/}") String swaggerBasePath) {
+        return new PathPrefixTransformationFilter(swaggerBasePath);
     }
 
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -15,9 +15,13 @@
  */
 package org.activiti.cloud.common.swagger.conf;
 
+import com.fasterxml.classmate.TypeResolver;
+import java.util.List;
 import java.util.function.Predicate;
 import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
+import org.activiti.cloud.common.swagger.DocketCustomizer;
 import org.activiti.cloud.common.swagger.PathPrefixTransformationFilter;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.info.BuildProperties;
@@ -50,8 +54,9 @@ public class SwaggerAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BaseAPIInfoBuilder baseAPIInfoBuilder(BuildProperties buildProperties) {
-        return new BaseAPIInfoBuilder(buildProperties);
+    public SwaggerDocketBuilder swaggerDocketBuilder(BuildProperties buildProperties, TypeResolver typeResolver,
+        List<DocketCustomizer> docketCustomizers) {
+        return new SwaggerDocketBuilder(new BaseAPIInfoBuilder(buildProperties), typeResolver, docketCustomizers);
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/test/java/org/activiti/cloud/common/swagger/PathPrefixTransformationFilterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/test/java/org/activiti/cloud/common/swagger/PathPrefixTransformationFilterTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.Collections;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import springfox.documentation.oas.web.OpenApiTransformationContext;
+import springfox.documentation.spi.DocumentationType;
+
+@ExtendWith(MockitoExtension.class)
+public class PathPrefixTransformationFilterTest {
+
+    private PathPrefixTransformationFilter transformationFilter = new PathPrefixTransformationFilter("/base");
+
+    @Mock
+    private OpenApiTransformationContext<HttpServletRequest> context;
+
+    @Test
+    public void transform_should_createServerWithBasePathAndServicePrefix() {
+        //given
+        final OpenAPI openAPI = buildOpenAPI("/service");
+
+        //when
+        transformationFilter.transform(context);
+
+        //then
+        assertThat(openAPI.getServers()).extracting(Server::getUrl).containsExactly("/base/service");
+    }
+
+    @Test
+    public void transform_should_createServerWithBasePathOnly_when_servicePrefixIsNotSet() {
+        //given
+        final OpenAPI openAPI = buildOpenAPI(null);
+
+        //when
+        transformationFilter.transform(context);
+
+        //then
+        assertThat(openAPI.getServers()).extracting(Server::getUrl).containsExactly("/base");
+    }
+
+    private OpenAPI buildOpenAPI(String servicePrefix) {
+        final OpenAPI openAPI = new OpenAPI();
+        openAPI.setExtensions(Collections.singletonMap(SwaggerDocketBuilder.SERVICE_URL_PREFIX,
+            servicePrefix));
+        given(context.getSpecification()).willReturn(openAPI);
+        return openAPI;
+    }
+
+    @Test
+    public void transform_should_convertDoubleSlashToSingleSlash_when_concatenationResultsInDoubleSlash() {
+        //given
+        PathPrefixTransformationFilter transformationFilter = new PathPrefixTransformationFilter("/");
+        final OpenAPI openAPI = buildOpenAPI("/service");
+
+        //when
+        transformationFilter.transform(context);
+
+        //then
+        assertThat(openAPI.getServers()).extracting(Server::getUrl).containsExactly("/service");
+    }
+
+    @Test
+    public void should_supportOAS3() {
+        assertThat(transformationFilter.supports(DocumentationType.OAS_30)).isTrue();
+    }
+
+    @Test
+    public void shouldNot_supportSwagger2() {
+        assertThat(transformationFilter.supports(DocumentationType.SWAGGER_2)).isFalse();
+    }
+}


### PR DESCRIPTION
- `activiti.cloud.swagger.base-path`: defines the base path to be used as relative server URL in the generated Open API specification
The base path will be appended as a prefix to each service URL, resulting in the final relative server URL.
- `activiti.cloud.swagger.audit-base-path`: defines the base path for Audit endpoints
- `activiti.cloud.swagger.query-base-path`: defines the base path for Query endpoints
- `activiti.cloud.swagger.rb-base-path`: defines the base path for Runtime Bundle endpoints
- `activiti.cloud.swagger.modeling-base-path`: defines the base path for Modeling endpoints

Example:
 - `activiti.cloud.swagger.rb-base-path=/sample-application`
 - `activiti.cloud.swagger.rb-base-path=/rb` 
 will generate a specification with the following server: `/sample-application/rb`

Fixes https://github.com/Activiti/Activiti/issues/3754