### PR TITLE
#3765 Add new Category field to process extensions

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.modeling.validation.process.BpmnModelSequence
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelServiceTaskImplementationValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelUserTaskAssigneeValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnCommonModelValidator;
+import org.activiti.cloud.services.modeling.validation.process.BpmnModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.EndEventIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.FlowNodeFlowsValidator;
 import org.activiti.cloud.services.modeling.validation.process.IntermediateFlowNodeIncomingOutgoingFlowValidator;
@@ -161,6 +162,12 @@ public class ProcessModelValidatorConfiguration {
     @ConditionalOnMissingBean
     public BpmnModelUserTaskAssigneeValidator bpmnModelUserTaskAssigneeValidator() {
         return new BpmnModelUserTaskAssigneeValidator();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BpmnModelValidator bpmnModelValidator() {
+        return new BpmnModelValidator();
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -38,7 +38,7 @@ import org.activiti.cloud.services.modeling.validation.process.BpmnModelNameVali
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelSequenceFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelServiceTaskImplementationValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelUserTaskAssigneeValidator;
-import org.activiti.cloud.services.modeling.validation.process.BpmnModelValidator;
+import org.activiti.cloud.services.modeling.validation.process.BpmnCommonModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.EndEventIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.FlowNodeFlowsValidator;
 import org.activiti.cloud.services.modeling.validation.process.IntermediateFlowNodeIncomingOutgoingFlowValidator;
@@ -166,7 +166,7 @@ public class ProcessModelValidatorConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ProcessModelValidator processModelValidator(ProcessModelType processModelType,
-                                                       Set<BpmnModelValidator> mpmnModelValidators,
+                                                       Set<BpmnCommonModelValidator> mpmnModelValidators,
                                                        ProcessModelContentConverter processModelContentConverter) {
         return new ProcessModelValidator(processModelType,
                                          mpmnModelValidators,

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnCommonModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnCommonModelValidator.java
@@ -26,7 +26,7 @@ import org.activiti.cloud.modeling.api.ValidationContext;
 /**
  * Interface for validating {@link BpmnModel} objects
  */
-public interface BpmnModelValidator extends ModelValidationErrorProducer {
+public interface BpmnCommonModelValidator extends ModelValidationErrorProducer {
 
     Stream<ModelValidationError> validate(BpmnModel bpmnModel,
                                           ValidationContext validationContext);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelCallActivityValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelCallActivityValidator.java
@@ -35,7 +35,7 @@ import org.activiti.cloud.modeling.api.ValidationContext;
 import org.activiti.cloud.services.modeling.converter.BpmnProcessModelContent;
 import org.activiti.cloud.services.modeling.converter.ProcessModelContentConverter;
 
-public class BpmnModelCallActivityValidator implements BpmnModelValidator {
+public class BpmnModelCallActivityValidator implements BpmnCommonModelValidator {
 
     private ProcessModelType processModelType;
     private ProcessModelContentConverter processModelContentConverter;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelEngineValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelEngineValidator.java
@@ -24,9 +24,9 @@ import org.activiti.validation.ValidationError;
 import java.util.stream.Stream;
 
 /**
- * Implementation of {@link BpmnModelValidator} based on the default BPMN activiti engine validator
+ * Implementation of {@link BpmnCommonModelValidator} based on the default BPMN activiti engine validator
  */
-public class BpmnModelEngineValidator implements BpmnModelValidator {
+public class BpmnModelEngineValidator implements BpmnCommonModelValidator {
 
     private final ProcessValidator processValidator;
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelIncomingOutgoingFlowValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelIncomingOutgoingFlowValidator.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * Implementation of {@link BpmnModelValidator} for validating Incoming and Outgoing flows
+ * Implementation of {@link BpmnCommonModelValidator} for validating Incoming and Outgoing flows
  */
-public class BpmnModelIncomingOutgoingFlowValidator implements BpmnModelValidator{
+public class BpmnModelIncomingOutgoingFlowValidator implements BpmnCommonModelValidator {
 
     private final List<FlowNodeFlowsValidator> flowNodeFlowsValidators;
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelNameValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelNameValidator.java
@@ -25,9 +25,9 @@ import java.util.stream.Stream;
 import org.activiti.cloud.services.modeling.validation.NameValidator;
 
 /**
- * Implementation of {@link BpmnModelValidator} for validating process name
+ * Implementation of {@link BpmnCommonModelValidator} for validating process name
  */
-public class BpmnModelNameValidator implements BpmnModelValidator,
+public class BpmnModelNameValidator implements BpmnCommonModelValidator,
                                                NameValidator {
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelSequenceFlowValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelSequenceFlowValidator.java
@@ -28,9 +28,9 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 
 /**
- * Implementation of {@link BpmnModelValidator} for validating Sequence flow when empty source or target references are provided
+ * Implementation of {@link BpmnCommonModelValidator} for validating Sequence flow when empty source or target references are provided
  */
-public class BpmnModelSequenceFlowValidator implements BpmnModelValidator {
+public class BpmnModelSequenceFlowValidator implements BpmnCommonModelValidator {
 
     public static final String NO_SOURCE_REF_PROBLEM = "Sequence flow has no source reference";
     public static final String NO_SOURCE_REF_PROBLEM_DESCRIPTION = "Sequence flow [name: '%s', id: '%s'] has to have a source reference";

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
@@ -33,9 +33,9 @@ import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConve
 import org.activiti.cloud.services.modeling.converter.ConnectorModelFeature;
 
 /**
- * Implementation of {@link BpmnModelValidator} vor validating service task implementation
+ * Implementation of {@link BpmnCommonModelValidator} vor validating service task implementation
  */
-public class BpmnModelServiceTaskImplementationValidator implements BpmnModelValidator {
+public class BpmnModelServiceTaskImplementationValidator implements BpmnCommonModelValidator {
 
     public static final String INVALID_SERVICE_IMPLEMENTATION_PROBLEM = "Invalid service implementation";
     public static final String INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION = "Invalid service implementation on service '%s'";

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
@@ -28,9 +28,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * Implementation of {@link BpmnModelValidator} for validating assignee attribute for user tasks
+ * Implementation of {@link BpmnCommonModelValidator} for validating assignee attribute for user tasks
  */
-public class BpmnModelUserTaskAssigneeValidator implements BpmnModelValidator {
+public class BpmnModelUserTaskAssigneeValidator implements BpmnCommonModelValidator {
 
     public final String NO_ASSIGNEE_PROBLEM_TITLE = "No assignee for user task";
     public final String NO_ASSIGNEE_DESCRIPTION = "One of the attributes 'assignee','candidateUsers' or"

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
@@ -56,9 +56,9 @@ public class BpmnModelUserTaskAssigneeValidator implements BpmnCommonModelValida
             return Optional.empty();
         }
 
-        return Optional.of(
-                new ModelValidationError(NO_ASSIGNEE_PROBLEM_TITLE, getNoAssigneeErrorDescription(userTask),
-                        USER_TASK_ASSIGNEE_VALIDATOR_NAME));
+        return Optional.of(new ModelValidationError(NO_ASSIGNEE_PROBLEM_TITLE,
+            getNoAssigneeErrorDescription(userTask),
+            USER_TASK_ASSIGNEE_VALIDATOR_NAME));
     }
 
     private String getNoAssigneeErrorDescription(UserTask userTask) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.services.modeling.validation.process;
 
 import java.util.ArrayList;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
@@ -9,9 +9,9 @@ import org.activiti.cloud.modeling.api.ValidationContext;
 
 public class BpmnModelValidator implements BpmnCommonModelValidator {
 
-    public final String ERROR_TYPE = "Invalid process category";
+    public final String ERROR_TYPE = "Missing process category";
 
-    public final String ERROR_DESCRIPTION = "The process category needs to be a string";
+    public final String ERROR_DESCRIPTION = "The process category needs to be set";
 
     @Override
     public Stream<ModelValidationError> validate(BpmnModel bpmnModel,
@@ -21,7 +21,7 @@ public class BpmnModelValidator implements BpmnCommonModelValidator {
 
     public Stream<ModelValidationError> validateTargetNamespace(BpmnModel bpmnModel) {
         List<ModelValidationError> aggregatedErrors = new ArrayList();
-        if(!(bpmnModel.getTargetNamespace() instanceof String)){
+        if(bpmnModel.getTargetNamespace() == null){
             aggregatedErrors.add(new ModelValidationError(ERROR_TYPE,
                 ERROR_DESCRIPTION));
         }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelValidator.java
@@ -1,0 +1,31 @@
+package org.activiti.cloud.services.modeling.validation.process;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.cloud.modeling.api.ModelValidationError;
+import org.activiti.cloud.modeling.api.ValidationContext;
+
+public class BpmnModelValidator implements BpmnCommonModelValidator {
+
+    public final String ERROR_TYPE = "Invalid process category";
+
+    public final String ERROR_DESCRIPTION = "The process category needs to be a string";
+
+    @Override
+    public Stream<ModelValidationError> validate(BpmnModel bpmnModel,
+        ValidationContext validationContext) {
+        return validateTargetNamespace(bpmnModel);
+    }
+
+    public Stream<ModelValidationError> validateTargetNamespace(BpmnModel bpmnModel) {
+        List<ModelValidationError> aggregatedErrors = new ArrayList();
+        if(!(bpmnModel.getTargetNamespace() instanceof String)){
+            aggregatedErrors.add(new ModelValidationError(ERROR_TYPE,
+                ERROR_DESCRIPTION));
+        }
+        return aggregatedErrors.stream();
+    }
+
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.modeling.validation.process;
 
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_XML;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -59,14 +60,15 @@ public class ProcessModelValidator implements ModelContentValidator {
 
     @Override
     public void validate(byte[] bytes,
-                                     ValidationContext validationContext) {
+        ValidationContext validationContext) {
+
         BpmnModel bpmnModel = processContentToBpmnModel(bytes);
-        List<ModelValidationError> validationErrors =
-                bpmnCommonModelValidators
-                        .stream()
-                        .flatMap(mpmnModelValidator -> mpmnModelValidator.validate(bpmnModel,
-                                                                                   validationContext))
-                        .collect(Collectors.toList());
+
+        List<ModelValidationError> validationErrors = bpmnCommonModelValidators
+            .stream()
+            .flatMap(bpmnCommonModelValidator -> bpmnCommonModelValidator.validate(bpmnModel,
+                validationContext))
+            .collect(Collectors.toList());
 
         if (!validationErrors.isEmpty()) {
             String messageError = "Semantic process model validation errors encountered: " + validationErrors;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
@@ -45,15 +45,15 @@ public class ProcessModelValidator implements ModelContentValidator {
 
     private final ProcessModelType processModelType;
 
-    private final Set<BpmnCommonModelValidator> mpmnModelValidators;
+    private final Set<BpmnCommonModelValidator> bpmnCommonModelValidators;
 
     private final ProcessModelContentConverter processModelContentConverter;
 
     public ProcessModelValidator(ProcessModelType processModelType,
-                                 Set<BpmnCommonModelValidator> mpmnModelValidators,
+                                 Set<BpmnCommonModelValidator> bpmnCommonModelValidators,
                                  ProcessModelContentConverter processModelContentConverter) {
         this.processModelType = processModelType;
-        this.mpmnModelValidators = mpmnModelValidators;
+        this.bpmnCommonModelValidators = bpmnCommonModelValidators;
         this.processModelContentConverter = processModelContentConverter;
     }
 
@@ -62,7 +62,7 @@ public class ProcessModelValidator implements ModelContentValidator {
                                      ValidationContext validationContext) {
         BpmnModel bpmnModel = processContentToBpmnModel(bytes);
         List<ModelValidationError> validationErrors =
-                mpmnModelValidators
+                bpmnCommonModelValidators
                         .stream()
                         .flatMap(mpmnModelValidator -> mpmnModelValidator.validate(bpmnModel,
                                                                                    validationContext))

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidator.java
@@ -45,12 +45,12 @@ public class ProcessModelValidator implements ModelContentValidator {
 
     private final ProcessModelType processModelType;
 
-    private final Set<BpmnModelValidator> mpmnModelValidators;
+    private final Set<BpmnCommonModelValidator> mpmnModelValidators;
 
     private final ProcessModelContentConverter processModelContentConverter;
 
     public ProcessModelValidator(ProcessModelType processModelType,
-                                 Set<BpmnModelValidator> mpmnModelValidators,
+                                 Set<BpmnCommonModelValidator> mpmnModelValidators,
                                  ProcessModelContentConverter processModelContentConverter) {
         this.processModelType = processModelType;
         this.mpmnModelValidators = mpmnModelValidators;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidatorTest.java
@@ -1,0 +1,85 @@
+package org.activiti.cloud.services.modeling.validation.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.cloud.modeling.core.error.SemanticModelValidationException;
+import org.activiti.cloud.services.modeling.converter.ProcessModelContentConverter;
+import org.activiti.cloud.services.modeling.validation.ProjectValidationContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProcessModelValidatorTest {
+
+    @InjectMocks
+    private ProcessModelValidator processModelValidator;
+
+    @Spy
+    private Set<BpmnCommonModelValidator> bpmnCommonModelValidators = new HashSet<>(Arrays.asList(new BpmnModelValidator()));
+
+    @Mock
+    private ProcessModelValidator ProcessModelType;
+
+    @Mock
+    private ProcessModelContentConverter processModelContentConverter;
+
+    @Test
+    void should_validateWithNoErrors_when_categoryIsSet() throws Exception {
+        BpmnModel bpmnModel = new BpmnModel();
+        byte[] bytesFromModel = bpmnModel.toString().getBytes();
+        bpmnModel.setTargetNamespace("test-category");
+
+        given(processModelContentConverter.convertToBpmnModel(bytesFromModel))
+            .willReturn(bpmnModel);
+
+        Throwable exception = catchThrowable( () ->
+        processModelValidator.validate(bytesFromModel,
+            new ProjectValidationContext()));
+
+        assertThat(exception).isNull();
+    }
+
+    @Test
+    void should_validateWithNoErrors_when_categoryIsEmpty() throws Exception {
+        BpmnModel bpmnModel = new BpmnModel();
+        byte[] bytesFromModel = bpmnModel.toString().getBytes();
+        bpmnModel.setTargetNamespace("");
+
+        given(processModelContentConverter.convertToBpmnModel(bytesFromModel))
+            .willReturn(bpmnModel);
+
+        Throwable exception = catchThrowable( () ->
+            processModelValidator.validate(bytesFromModel,
+                new ProjectValidationContext()));
+
+        assertThat(exception).isNull();
+    }
+
+    @Test
+    void should_validateWithErrors_when_categoryIsNotSet() throws Exception {
+        BpmnModel bpmnModel = new BpmnModel();
+        byte[] bytesFromModel = bpmnModel.toString().getBytes();
+
+        given(processModelContentConverter.convertToBpmnModel(bytesFromModel))
+            .willReturn(bpmnModel);
+
+        Throwable exception = catchThrowable( () ->
+            processModelValidator.validate(bytesFromModel,
+                new ProjectValidationContext()));
+
+        assertThat(exception)
+            .isInstanceOf(SemanticModelValidationException.class)
+            .hasMessage("Semantic process model validation errors encountered: [The process category needs to be set]");
+
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/ProcessModelValidatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.services.modeling.validation.process;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Ref: https://github.com/Activiti/Activiti/issues/3765
Since from the Activiti engine we will leverage `targetNamespace` of definitions as process categories, we need to make sure that no model is without its category.
The default from modeling app (FE) can be an empty string, instead of the current broken link: `"http://bpmn.io/schema/bpmn"` 