### PR TITLE
fix: add missing slash to Oracle query Liquibase DDL for variable sequences

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/10-alter.oracle.schema.7.1.0-m17.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/10-alter.oracle.schema.7.1.0-m17.sql
@@ -6,9 +6,11 @@ begin
     select nvl(max(id), 0) + 1 into max_process_variable from process_variable;
     execute immediate 'create sequence process_variable_sequence start with ' || max_process_variable || ' increment by 50';
 end;
+/
 
 declare max_task_variable number;
 begin
     select nvl(max(id), 0) + 1 into max_task_variable from task_variable;
     execute immediate 'create sequence task_variable_sequence start with ' || max_task_variable || ' increment by 50';
 end;
+/


### PR DESCRIPTION
This PR fixes Query Liquibase migration script for Oractle, i.e.

```
liquibase/ActivitiCloudQueryLiquibaseAutoConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.LiquibaseException: liquibase.exception.MigrationFailedException: Migration failed for change set config/query/liquibase/master.xml::alter10-oracle-schema-m17::activiti-query:
     Reason: liquibase.exception.DatabaseException: ORA-06550: line 1, column 35:
PLS-00103: Encountered the symbol "end-of-file" when expecting one of the following:

   := . ( @ % ; not null range default character
 [Failed SQL: (6550) declare max_process_variable number]
```