### PR TITLE
fix: make sure validation also checks inner element containers

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/no-assignee-subprocess.bpmn20.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/no-assignee-subprocess.bpmn20.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-380a27f5-677c-4bad-9125-236cc687c0b3" name="test" targetNamespace="" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_dhrgGjT-O" name="test" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="StartEvent_1fw4d3c">
+      <bpmn2:outgoing>SequenceFlow_0732qsn</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:subProcess id="SubProcess_0ga17u4">
+      <bpmn2:incoming>SequenceFlow_0732qsn</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1c1xkg9</bpmn2:outgoing>
+      <bpmn2:startEvent id="StartEvent_1aysmcj">
+        <bpmn2:outgoing>SequenceFlow_01dn0uz</bpmn2:outgoing>
+      </bpmn2:startEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_01dn0uz" sourceRef="StartEvent_1aysmcj" targetRef="Task_06l44lk" />
+      <bpmn2:userTask id="Task_06l44lk" name="My task">
+        <bpmn2:incoming>SequenceFlow_01dn0uz</bpmn2:incoming>
+        <bpmn2:outgoing>SequenceFlow_0l6m74z</bpmn2:outgoing>
+      </bpmn2:userTask>
+      <bpmn2:endEvent id="EndEvent_060pwu8">
+        <bpmn2:incoming>SequenceFlow_0l6m74z</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_0l6m74z" sourceRef="Task_06l44lk" targetRef="EndEvent_060pwu8" />
+    </bpmn2:subProcess>
+    <bpmn2:sequenceFlow id="SequenceFlow_0732qsn" sourceRef="StartEvent_1fw4d3c" targetRef="SubProcess_0ga17u4" />
+    <bpmn2:endEvent id="EndEvent_1j5lksr">
+      <bpmn2:incoming>SequenceFlow_1c1xkg9</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1c1xkg9" sourceRef="SubProcess_0ga17u4" targetRef="EndEvent_1j5lksr" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_dhrgGjT-O">
+      <bpmndi:BPMNShape id="StartEvent_1fw4d3c_di" bpmnElement="StartEvent_1fw4d3c">
+        <dc:Bounds x="92.33333333333331" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_0ga17u4_di" bpmnElement="SubProcess_0ga17u4" isExpanded="true">
+        <dc:Bounds x="210" y="120" width="440" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0732qsn_di" bpmnElement="SequenceFlow_0732qsn">
+        <di:waypoint x="128" y="210" />
+        <di:waypoint x="169" y="210" />
+        <di:waypoint x="169" y="220" />
+        <di:waypoint x="210" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1aysmcj_di" bpmnElement="StartEvent_1aysmcj">
+        <dc:Bounds x="272" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_01dn0uz_di" bpmnElement="SequenceFlow_01dn0uz">
+        <di:waypoint x="308" y="210" />
+        <di:waypoint x="360" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0tzkpvq_di" bpmnElement="Task_06l44lk">
+        <dc:Bounds x="360" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_060pwu8_di" bpmnElement="EndEvent_060pwu8">
+        <dc:Bounds x="512" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0l6m74z_di" bpmnElement="SequenceFlow_0l6m74z">
+        <di:waypoint x="460" y="210" />
+        <di:waypoint x="490" y="210" />
+        <di:waypoint x="490" y="220" />
+        <di:waypoint x="512" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1j5lksr_di" bpmnElement="EndEvent_1j5lksr">
+        <dc:Bounds x="902" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1c1xkg9_di" bpmnElement="SequenceFlow_1c1xkg9">
+        <di:waypoint x="650" y="220" />
+        <di:waypoint x="776" y="220" />
+        <di:waypoint x="776" y="260" />
+        <di:waypoint x="902" y="260" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
@@ -65,5 +65,10 @@
       <artifactId>activiti-cloud-services-modeling-api-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -41,6 +41,7 @@ import org.activiti.cloud.services.modeling.validation.process.BpmnModelUserTask
 import org.activiti.cloud.services.modeling.validation.process.BpmnCommonModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.EndEventIncomingOutgoingFlowValidator;
+import org.activiti.cloud.services.modeling.validation.process.FlowElementsExtractor;
 import org.activiti.cloud.services.modeling.validation.process.FlowNodeFlowsValidator;
 import org.activiti.cloud.services.modeling.validation.process.IntermediateFlowNodeIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.ProcessModelValidator;
@@ -60,6 +61,12 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class ProcessModelValidatorConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public FlowElementsExtractor flowElementsExtractor() {
+        return new FlowElementsExtractor();
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -153,15 +160,15 @@ public class ProcessModelValidatorConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public BpmnModelServiceTaskImplementationValidator bpmnModelServiceTaskImplementationValidator(ConnectorModelType connectorModelType,
-                                                                                                   ConnectorModelContentConverter connectorModelContentConverter) {
+        ConnectorModelContentConverter connectorModelContentConverter, FlowElementsExtractor flowElementsExtractor) {
         return new BpmnModelServiceTaskImplementationValidator(connectorModelType,
-                                                               connectorModelContentConverter);
+                                                               connectorModelContentConverter, flowElementsExtractor);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public BpmnModelUserTaskAssigneeValidator bpmnModelUserTaskAssigneeValidator() {
-        return new BpmnModelUserTaskAssigneeValidator();
+    public BpmnModelUserTaskAssigneeValidator bpmnModelUserTaskAssigneeValidator(FlowElementsExtractor flowElementsExtractor) {
+        return new BpmnModelUserTaskAssigneeValidator(flowElementsExtractor);
     }
 
     @Bean
@@ -183,14 +190,15 @@ public class ProcessModelValidatorConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BpmnModelSequenceFlowValidator bpmnModelSequenceFlowValidator() {
-        return new BpmnModelSequenceFlowValidator();
+    public BpmnModelSequenceFlowValidator bpmnModelSequenceFlowValidator(FlowElementsExtractor flowElementsExtractor) {
+        return new BpmnModelSequenceFlowValidator(flowElementsExtractor);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public BpmnModelIncomingOutgoingFlowValidator bpmnModelIncomingOutgoingFlowValidator(List<FlowNodeFlowsValidator> flowNodeFlowsValidators) {
-        return new BpmnModelIncomingOutgoingFlowValidator(flowNodeFlowsValidators);
+    public BpmnModelIncomingOutgoingFlowValidator bpmnModelIncomingOutgoingFlowValidator(List<FlowNodeFlowsValidator> flowNodeFlowsValidators,
+        FlowElementsExtractor flowElementsExtractor) {
+        return new BpmnModelIncomingOutgoingFlowValidator(flowNodeFlowsValidators, flowElementsExtractor);
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnCommonModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnCommonModelValidator.java
@@ -16,9 +16,7 @@
 package org.activiti.cloud.services.modeling.validation.process;
 
 import java.util.stream.Stream;
-
 import org.activiti.bpmn.model.BpmnModel;
-import org.activiti.bpmn.model.FlowElement;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ModelValidationErrorProducer;
 import org.activiti.cloud.modeling.api.ValidationContext;
@@ -28,15 +26,6 @@ import org.activiti.cloud.modeling.api.ValidationContext;
  */
 public interface BpmnCommonModelValidator extends ModelValidationErrorProducer {
 
-    Stream<ModelValidationError> validate(BpmnModel bpmnModel,
-                                          ValidationContext validationContext);
+    Stream<ModelValidationError> validate(BpmnModel bpmnModel, ValidationContext validationContext);
 
-    default <T extends FlowElement> Stream<T> getFlowElements(BpmnModel bpmnModel,
-                                                       Class<T> taskType) {
-        return bpmnModel.getProcesses()
-                .stream()
-                .flatMap(process -> process.getFlowElements().stream())
-                .filter(element -> taskType.isAssignableFrom(element.getClass()))
-                .map(taskType::cast);
-    }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelIncomingOutgoingFlowValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelIncomingOutgoingFlowValidator.java
@@ -30,19 +30,20 @@ import java.util.stream.Stream;
 public class BpmnModelIncomingOutgoingFlowValidator implements BpmnCommonModelValidator {
 
     private final List<FlowNodeFlowsValidator> flowNodeFlowsValidators;
+    private final FlowElementsExtractor flowElementsExtractor;
 
-    public BpmnModelIncomingOutgoingFlowValidator(List<FlowNodeFlowsValidator> flowNodeFlowsValidators) {
+    public BpmnModelIncomingOutgoingFlowValidator(
+        List<FlowNodeFlowsValidator> flowNodeFlowsValidators,
+        FlowElementsExtractor flowElementsExtractor) {
         this.flowNodeFlowsValidators = flowNodeFlowsValidators;
+        this.flowElementsExtractor = flowElementsExtractor;
     }
 
     @Override
     public Stream<ModelValidationError> validate(BpmnModel bpmnModel, ValidationContext validationContext) {
         List<ModelValidationError> errors = new ArrayList<>();
-        getFlowElements(bpmnModel,
-            FlowNode.class).forEach(flowNode -> {
-            errors.addAll(validateFlowNode(flowNode));
-        });
-
+        flowElementsExtractor.extractFlowElements(bpmnModel, FlowNode.class)
+            .forEach(flowNode -> errors.addAll(validateFlowNode(flowNode)));
         return errors.stream();
     }
 
@@ -51,7 +52,7 @@ public class BpmnModelIncomingOutgoingFlowValidator implements BpmnCommonModelVa
         List<ModelValidationError> errors = new ArrayList<>();
 
         for (FlowNodeFlowsValidator validator: flowNodeFlowsValidators) {
-            if (validator.canValidate(flowNode)){
+            if (validator.canValidate(flowNode)) {
                 errors.addAll(validator.validate(flowNode));
             }
         }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelSequenceFlowValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelSequenceFlowValidator.java
@@ -38,18 +38,21 @@ public class BpmnModelSequenceFlowValidator implements BpmnCommonModelValidator 
     public static final String NO_TARGET_REF_PROBLEM_DESCRIPTION = "Sequence flow [name: '%s', id: '%s'] has to have a target reference";
     public static final String SEQUENCE_FLOW_VALIDATOR_NAME = "BPMN sequence flow validator";
 
+    private final FlowElementsExtractor flowElementsExtractor;
+
+    public BpmnModelSequenceFlowValidator(FlowElementsExtractor flowElementsExtractor) {
+        this.flowElementsExtractor = flowElementsExtractor;
+    }
+
     @Override
     public Stream<ModelValidationError> validate(BpmnModel bpmnModel, ValidationContext validationContext) {
         List<ModelValidationError> errors = new ArrayList<>();
-        getFlowElements(bpmnModel,
-            SequenceFlow.class).forEach(sequenceFlow -> {
-            errors.addAll(validateSequenceFlow(sequenceFlow));
-        });
-
+        flowElementsExtractor.extractFlowElements(bpmnModel, SequenceFlow.class)
+            .forEach(sequenceFlow -> errors.addAll(validateSequenceFlow(sequenceFlow)));
         return errors.stream();
     }
 
-    private List<ModelValidationError> validateSequenceFlow(SequenceFlow sequenceFlow){
+    private List<ModelValidationError> validateSequenceFlow(SequenceFlow sequenceFlow) {
 
         List<ModelValidationError> errors = new ArrayList<>();
         if (StringUtils.isEmpty(sequenceFlow.getSourceRef())) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskImplementationValidator.java
@@ -44,11 +44,14 @@ public class BpmnModelServiceTaskImplementationValidator implements BpmnCommonMo
     private final ConnectorModelType connectorModelType;
 
     private final ConnectorModelContentConverter connectorModelContentConverter;
+    private final FlowElementsExtractor flowElementsExtractor;
 
     public BpmnModelServiceTaskImplementationValidator(ConnectorModelType connectorModelType,
-            ConnectorModelContentConverter connectorModelContentConverter) {
+        ConnectorModelContentConverter connectorModelContentConverter,
+        FlowElementsExtractor flowElementsExtractor) {
         this.connectorModelType = connectorModelType;
         this.connectorModelContentConverter = connectorModelContentConverter;
+        this.flowElementsExtractor = flowElementsExtractor;
     }
 
     @Override
@@ -56,11 +59,9 @@ public class BpmnModelServiceTaskImplementationValidator implements BpmnCommonMo
                                                  ValidationContext validationContext) {
         List<String> availableImplementations = getAvailableImplementations(validationContext);
 
-        return getFlowElements(bpmnModel,
-                        ServiceTask.class)
+        return flowElementsExtractor.extractFlowElements(bpmnModel, ServiceTask.class).stream()
                 .filter(serviceTask -> serviceTask.getImplementation() != null)
-                .map(serviceTask -> validateServiceTaskImplementation(serviceTask,
-                                                                      availableImplementations))
+                .map(serviceTask -> validateServiceTaskImplementation(serviceTask, availableImplementations))
                 .filter(Optional::isPresent)
                 .map(Optional::get);
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
@@ -32,17 +32,22 @@ import java.util.stream.Stream;
  */
 public class BpmnModelUserTaskAssigneeValidator implements BpmnCommonModelValidator {
 
-    public final String NO_ASSIGNEE_PROBLEM_TITLE = "No assignee for user task";
-    public final String NO_ASSIGNEE_DESCRIPTION = "One of the attributes 'assignee','candidateUsers' or"
+    private static final String NO_ASSIGNEE_PROBLEM_TITLE = "No assignee for user task";
+    private static final String NO_ASSIGNEE_DESCRIPTION = "One of the attributes 'assignee','candidateUsers' or"
             + " 'candidateGroups' are mandatory on user task with id: '%s' %s";
-    public final String NO_ASSIGNEE_DESCRIPTION_NAME = "and name: '%s'";
-    public final String USER_TASK_ASSIGNEE_VALIDATOR_NAME = "BPMN user task assignee validator";
+    private static final String NO_ASSIGNEE_DESCRIPTION_NAME = "and name: '%s'";
+    private static final String USER_TASK_ASSIGNEE_VALIDATOR_NAME = "BPMN user task assignee validator";
+
+    private final FlowElementsExtractor flowElementsExtractor;
+
+    public BpmnModelUserTaskAssigneeValidator(FlowElementsExtractor flowElementsExtractor) {
+        this.flowElementsExtractor = flowElementsExtractor;
+    }
 
     @Override
     public Stream<ModelValidationError> validate(BpmnModel bpmnModel,
                                                  ValidationContext validationContext) {
-        return getFlowElements(bpmnModel,
-                        UserTask.class)
+        return flowElementsExtractor.extractFlowElements(bpmnModel, UserTask.class).stream()
                 .map(this::validateTaskAssignedUser)
                 .filter(Optional::isPresent)
                 .map(Optional::get);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/FlowElementsExtractor.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/FlowElementsExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.validation.process;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.FlowElementsContainer;
+
+public class FlowElementsExtractor {
+
+    public <T extends FlowElement> Set<T> extractFlowElements(BpmnModel bpmnModel,
+        Class<T> flowElementType) {
+        final Set<T> flowElements = new HashSet<>();
+        bpmnModel.getProcesses().forEach(process -> flowElements.addAll(extractFlowElements(process, flowElementType)));
+        return flowElements;
+    }
+
+    private <T extends FlowElement> Set<T> extractFlowElements(FlowElementsContainer container, Class<T> flowElementType) {
+        Set<T> flowElements = container.getFlowElements().stream()
+            .filter(flowElement -> flowElementType.isAssignableFrom(flowElement.getClass()))
+            .map(flowElementType::cast).collect(Collectors.toSet());
+        container.getFlowElements().stream()
+            .filter(flowElement -> FlowElementsContainer.class.isAssignableFrom(flowElement.getClass()))
+            .map(FlowElementsContainer.class::cast)
+            .forEach(childContainer -> flowElements.addAll(extractFlowElements(childContainer, flowElementType)));
+        return flowElements;
+    }
+
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/FlowElementsExtractorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/FlowElementsExtractorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.validation.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.jupiter.api.Test;
+
+public class FlowElementsExtractorTest {
+
+    private final FlowElementsExtractor flowElementsExtractor = new FlowElementsExtractor();
+
+    @Test
+    public void should_extractElements_when_modelHasASimpleProcess() {
+        //given
+        final Process process = new Process();
+        process.addFlowElement(new StartEvent());
+        process.addFlowElement(buildUserTask("Task 1"));
+        process.addFlowElement(buildUserTask("Task 2"));
+        process.addFlowElement(new ServiceTask());
+        final BpmnModel model = new BpmnModel();
+        model.addProcess(process);
+
+        //when
+        final Set<UserTask> userTasks = flowElementsExtractor.extractFlowElements(model, UserTask.class);
+
+        //then
+        assertThat(userTasks)
+            .extracting(UserTask::getName)
+            .containsExactlyInAnyOrder("Task 1", "Task 2");
+    }
+
+    @Test
+    public void should_extractElements_when_modelHasSubProcess() {
+        //given
+        final Process process = new Process();
+        process.addFlowElement(new StartEvent());
+        process.addFlowElement(buildUserTask("Task from main process"));
+        final SubProcess subProcess = new SubProcess();
+        process.addFlowElement(subProcess);
+        subProcess.addFlowElement(buildUserTask("Task from sub-process"));
+        process.addFlowElement(new ServiceTask());
+        final BpmnModel model = new BpmnModel();
+        model.addProcess(process);
+
+        //when
+        final Set<UserTask> userTasks = flowElementsExtractor.extractFlowElements(model, UserTask.class);
+
+        //then
+        assertThat(userTasks)
+            .extracting(UserTask::getName)
+            .containsExactlyInAnyOrder("Task from main process", "Task from sub-process");
+    }
+
+    @Test
+    public void should_extractElements_when_modelHasMoreThanOneProcess() {
+        //given
+        final Process process1 = new Process();
+        process1.addFlowElement(new StartEvent());
+        process1.addFlowElement(buildUserTask("Task from process 1"));
+        process1.addFlowElement(new ServiceTask());
+
+        final Process process2 = new Process();
+        process2.addFlowElement(new StartEvent());
+        process2.addFlowElement(buildUserTask("Task from process 2"));
+        process2.addFlowElement(new ServiceTask());
+
+        final BpmnModel model = new BpmnModel();
+        model.addProcess(process1);
+        model.addProcess(process2);
+
+        //when
+        final Set<UserTask> userTasks = flowElementsExtractor.extractFlowElements(model, UserTask.class);
+
+        //then
+        assertThat(userTasks)
+            .extracting(UserTask::getName)
+            .containsExactlyInAnyOrder("Task from process 1", "Task from process 2");
+    }
+
+    private UserTask buildUserTask(String name) {
+        final UserTask userTask = new UserTask();
+        userTask.setName(name);
+        return userTask;
+    }
+}


### PR DESCRIPTION
In addition to direct flow elements, the validation should also check flow elements inside inner containers (subprocesses, event-subprocesses)

Fixes https://github.com/Activiti/Activiti/issues/3794