### PR TITLE
fix: split m17 query liquibase Oracle DDL into separate scripts

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/10-alter.oracle.schema.7.1.0-m17.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/10-alter.oracle.schema.7.1.0-m17.sql
@@ -1,16 +1,2 @@
 alter table process_definition
     add category varchar(255);
-
-declare max_process_variable number;
-begin
-    select nvl(max(id), 0) + 1 into max_process_variable from process_variable;
-    execute immediate 'create sequence process_variable_sequence start with ' || max_process_variable || ' increment by 50';
-end;
-/
-
-declare max_task_variable number;
-begin
-    select nvl(max(id), 0) + 1 into max_task_variable from task_variable;
-    execute immediate 'create sequence task_variable_sequence start with ' || max_task_variable || ' increment by 50';
-end;
-/

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/11-alter.oracle.schema.7.1.0-m17.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/11-alter.oracle.schema.7.1.0-m17.sql
@@ -1,0 +1,6 @@
+declare max_process_variable number;
+begin
+    select nvl(max(id), 0) + 1 into max_process_variable from process_variable;
+    execute immediate 'create sequence process_variable_sequence start with ' || max_process_variable || ' increment by 50';
+end;
+/

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/12-alter.oracle.schema.7.1.0-m17.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/12-alter.oracle.schema.7.1.0-m17.sql
@@ -1,0 +1,6 @@
+declare max_task_variable number;
+begin
+    select nvl(max(id), 0) + 1 into max_task_variable from task_variable;
+    execute immediate 'create sequence task_variable_sequence start with ' || max_task_variable || ' increment by 50';
+end;
+/

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
@@ -261,6 +261,26 @@
   </changeSet>
 
   <changeSet author="activiti-query"
+             id="alter11-oracle-schema-m17" dbms="oracle">
+    <sqlFile dbms="oracle"
+             encoding="utf8"
+             path="changelog/11-alter.oracle.schema.7.1.0-m17.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
+             id="alter12-oracle-schema-m17" dbms="oracle">
+    <sqlFile dbms="oracle"
+             encoding="utf8"
+             path="changelog/12-alter.oracle.schema.7.1.0-m17.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
     id="alter13-schema-m17" dbms="postgresql">
     <sqlFile dbms="postgresql"
       encoding="utf8"


### PR DESCRIPTION
This PR fixes query liquibase script errors for Oracle when creating sequences for process and task variables. I have split scripts into separate files to be able to specify statement execution policy per each script.