### PR TITLE
fix(GH-3798): update Spring Boot version to 2.6.2 / Spring Cloud version to 2021.0.0

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.356</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>7.1.355</activiti.version>
+    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/assembler/EventRepresentationModelAssembler.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/assembler/EventRepresentationModelAssembler.java
@@ -30,8 +30,8 @@ public class EventRepresentationModelAssembler implements RepresentationModelAss
     @Override
     public EntityModel<CloudRuntimeEvent<?, CloudRuntimeEventType>> toModel(CloudRuntimeEvent<?, CloudRuntimeEventType> event) {
         Link selfRel = linkTo(methodOn(AuditEventsControllerImpl.class).findById(event.getId())).withSelfRel();
-        return new EntityModel<>(event,
-                                 selfRel);
+        return EntityModel.of(event,
+                              selfRel);
     }
 
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/AuditEventsDeleteController.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/AuditEventsDeleteController.java
@@ -74,7 +74,7 @@ public class AuditEventsDeleteController {
 
         eventsRepository.deleteAll(iterable);
 
-        return new CollectionModel<>(result);
+        return CollectionModel.of(result);
     }
 
 

--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -12,34 +12,11 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Dependencies Parent</name>
   <properties>
-    <spring-cloud.version>2020.0.3</spring-cloud.version>
+    <spring-cloud.version>2021.0.0</spring-cloud.version>
     <testcontainers.version>1.16.2</testcontainers.version>
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!-- 26/07/2021
-  After upgrading spring-boot from 2.5.2 to 2.5.3, the
-  build started failing because it was not anymore able
-  to create the ApplicationContext.
-  The error reported was:
-
-Caused by: org.springframework.context.ApplicationContextException: Failed to start bean 'inputBindingLifecycle'; nested exception is java.lang.NoSuchMethodError: org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.<init>(Lorg/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer;)V
-at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:181)
-
-  The issue seems to be caused by this change in spring-integration-amqp:
-
-  https://github.com/spring-projects/spring-integration/commit/76f77ccd2c5f94e000495357e66c4f99fffc6010
-
-  Since the issue happens only due to the dependencies imported for testing it has been fixed rolling
-  back the library spring-integration-amqp the the previous version (5.5.1)
-      -->
-      <dependency>
-        <groupId>org.springframework.integration</groupId>
-        <artifactId>spring-integration-bom</artifactId>
-        <version>5.5.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>

--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -199,7 +199,7 @@
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <spring-boot.version>2.5.3</spring-boot.version>
+    <spring-boot.version>2.6.2</spring-boot.version>
   </properties>
   <modules>
     <module>activiti-cloud-build-dependencies-parent</module>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelVersionEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelVersionEntity.java
@@ -15,24 +15,22 @@
  */
 package org.activiti.cloud.services.modeling.entity;
 
-import java.util.Map;
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
+import org.activiti.cloud.services.modeling.jpa.version.VersionEntity;
+import org.activiti.cloud.services.modeling.jpa.version.VersionIdentifier;
+
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 import javax.persistence.Transient;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.activiti.cloud.modeling.api.process.Extensions;
-import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
-import org.activiti.cloud.services.modeling.jpa.version.VersionEntity;
-import org.activiti.cloud.services.modeling.jpa.version.VersionIdentifier;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -55,12 +53,10 @@ public class ModelVersionEntity extends AuditableEntity<String> implements Versi
 
     private String contentType;
 
-    @Lob
-    @Column
+    @Column(columnDefinition = "TEXT")
     private byte[] content;
 
-    @Lob
-    @Column
+    @Column(columnDefinition = "TEXT")
     @Convert(converter = ExtensionsJsonConverter.class)
     private Map<String,Object> extensions;
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelVersionEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelVersionEntity.java
@@ -15,22 +15,24 @@
  */
 package org.activiti.cloud.services.modeling.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
-import org.activiti.cloud.services.modeling.jpa.version.VersionEntity;
-import org.activiti.cloud.services.modeling.jpa.version.VersionIdentifier;
-
+import java.util.Map;
+import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 import javax.persistence.Transient;
-import java.util.Map;
-import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.activiti.cloud.modeling.api.process.Extensions;
+import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
+import org.activiti.cloud.services.modeling.jpa.version.VersionEntity;
+import org.activiti.cloud.services.modeling.jpa.version.VersionIdentifier;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -53,7 +55,8 @@ public class ModelVersionEntity extends AuditableEntity<String> implements Versi
 
     private String contentType;
 
-    @Column(columnDefinition = "TEXT")
+    @Lob
+    @Column
     private byte[] content;
 
     @Column(columnDefinition = "TEXT")

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
@@ -27,7 +27,7 @@ create table model_version
     creation_date       timestamp,
     last_modified_by    varchar(255),
     last_modified_date  timestamp,
-    content             text,
+    content             blob,
     content_type        varchar(255),
     extensions          text,
     versioned_entity_id varchar(255) not null,

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
@@ -27,9 +27,9 @@ create table model_version
     creation_date       timestamp,
     last_modified_by    varchar(255),
     last_modified_date  timestamp,
-    content             blob,
+    content             text,
     content_type        varchar(255),
-    extensions          clob,
+    extensions          text,
     versioned_entity_id varchar(255) not null,
     primary key (version, versioned_entity_id)
 );

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ModelRepresentationModelAssembler.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ModelRepresentationModelAssembler.java
@@ -15,13 +15,13 @@
  */
 package org.activiti.cloud.services.modeling.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.services.modeling.rest.controller.ModelController;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * Assembler for {@link Model} resource
@@ -30,7 +30,7 @@ public class ModelRepresentationModelAssembler implements RepresentationModelAss
 
     @Override
     public EntityModel<Model> toModel(Model model) {
-        return new EntityModel<>(model,
+        return EntityModel.of(model,
                               linkTo(methodOn(ModelController.class).getModel(model.getId())).withSelfRel());
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ModelTypeRepresentationModelAssembler.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ModelTypeRepresentationModelAssembler.java
@@ -26,6 +26,6 @@ public class ModelTypeRepresentationModelAssembler implements RepresentationMode
 
     @Override
     public EntityModel<ModelType> toModel(ModelType modelType) {
-        return new EntityModel<>(modelType);
+        return EntityModel.of(modelType);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ProjectRepresentationModelAssembler.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ProjectRepresentationModelAssembler.java
@@ -15,22 +15,21 @@
  */
 package org.activiti.cloud.services.modeling.rest.assembler;
 
-import static org.activiti.cloud.modeling.api.ProcessModelType.PROCESS;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.modeling.core.error.ModelingException;
 import org.activiti.cloud.services.modeling.rest.controller.ModelController;
 import org.activiti.cloud.services.modeling.rest.controller.ProjectController;
 import org.springframework.data.domain.Pageable;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletResponse;
+import static org.activiti.cloud.modeling.api.ProcessModelType.PROCESS;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 /**
  * Assembler for {@link Project} resource
@@ -39,7 +38,7 @@ public class ProjectRepresentationModelAssembler implements RepresentationModelA
 
     @Override
     public EntityModel<Project> toModel(Project project) {
-        return new EntityModel<>(
+        return EntityModel.of(
                 project,
                 linkTo(methodOn(ProjectController.class).getProject(project.getId())).withSelfRel(),
                 getExportProjectLink(project.getId()),
@@ -66,7 +65,9 @@ public class ProjectRepresentationModelAssembler implements RepresentationModelA
                                                             HttpServletResponse.class,
                                                             String.class,
                                                             boolean.class),
-                          projectId)
+                          null,
+                          projectId,
+                          true)
                     .withRel("export");
         } catch (NoSuchMethodException e) {
             throw new ModelingException(e);

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>7.1.355</activiti.version>
+    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.356</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
@@ -34,7 +34,7 @@ public class CommonExceptionHandlerQuery {
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiForbiddenException ex, HttpServletResponse response) {
         response.setContentType("application/json");
-        return new EntityModel<>(new ActivitiErrorMessageImpl(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
     }
 }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
@@ -67,7 +67,7 @@ public class ProcessInstanceDeleteController {
 
         processInstanceRepository.deleteAll(iterable);
 
-        return new CollectionModel<>(result);
+        return CollectionModel.of(result);
     }
 
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskDeleteController.java
@@ -67,7 +67,7 @@ public class TaskDeleteController {
 
         taskRepository.deleteAll(iterable);
 
-        return new CollectionModel<>(result);
+        return CollectionModel.of(result);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ApplicationRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ApplicationRepresentationModelAssembler.java
@@ -25,6 +25,6 @@ public class ApplicationRepresentationModelAssembler implements
 
     @Override
     public EntityModel<CloudApplication> toModel(ApplicationEntity entity) {
-        return new EntityModel<>(entity);
+        return EntityModel.of(entity);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/IntegrationContextRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/IntegrationContextRepresentationModelAssembler.java
@@ -15,9 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.rest.ServiceTaskIntegrationContextAdminController;
@@ -25,14 +22,17 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 public class IntegrationContextRepresentationModelAssembler implements RepresentationModelAssembler<IntegrationContextEntity, EntityModel<CloudIntegrationContext>> {
 
     @Override
     public EntityModel<CloudIntegrationContext> toModel(IntegrationContextEntity entity) {
         Link selfRel = linkTo(methodOn(ServiceTaskIntegrationContextAdminController.class).findById(entity.getId())).withSelfRel();
 
-        return new EntityModel<>(entity,
-                                 selfRel);
+        return EntityModel.of(entity,
+                              selfRel);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessDefinitionRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessDefinitionRepresentationModelAssembler.java
@@ -24,6 +24,6 @@ public class ProcessDefinitionRepresentationModelAssembler implements Representa
 
     @Override
     public EntityModel<CloudProcessDefinition> toModel(ProcessDefinitionEntity processDefinitionEntity) {
-        return new EntityModel<>(processDefinitionEntity);
+        return EntityModel.of(processDefinitionEntity);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceRepresentationModelAssembler.java
@@ -15,17 +15,17 @@
  */
 package org.activiti.cloud.services.query.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.rest.ProcessInstanceController;
 import org.activiti.cloud.services.query.rest.ProcessInstanceTasksController;
 import org.activiti.cloud.services.query.rest.ProcessInstanceVariableController;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 public class ProcessInstanceRepresentationModelAssembler implements RepresentationModelAssembler<ProcessInstanceEntity, EntityModel<CloudProcessInstance>> {
 
@@ -34,7 +34,7 @@ public class ProcessInstanceRepresentationModelAssembler implements Representati
         Link selfRel = linkTo(methodOn(ProcessInstanceController.class).findById(entity.getId())).withSelfRel();
         Link tasksRel = linkTo(methodOn(ProcessInstanceTasksController.class).getTasks(entity.getId(), null)).withRel("tasks");
         Link variablesRel = linkTo(methodOn(ProcessInstanceVariableController.class).getVariables(entity.getId(),null,null)).withRel("variables");
-        return new EntityModel<>(entity,
+        return EntityModel.of(entity,
                               selfRel,
                               tasksRel,
                               variablesRel);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceVariableRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceVariableRepresentationModelAssembler.java
@@ -24,7 +24,7 @@ public class ProcessInstanceVariableRepresentationModelAssembler implements Repr
 
     @Override
     public EntityModel<CloudVariableInstance> toModel(ProcessVariableEntity entity) {
-       return new EntityModel<>(entity);
+       return EntityModel.of(entity);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ServiceTaskRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ServiceTaskRepresentationModelAssembler.java
@@ -15,9 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.api.process.model.CloudServiceTask;
 import org.activiti.cloud.services.query.model.ServiceTaskEntity;
 import org.activiti.cloud.services.query.rest.ServiceTaskAdminController;
@@ -25,14 +22,17 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
 public class ServiceTaskRepresentationModelAssembler implements RepresentationModelAssembler<ServiceTaskEntity, EntityModel<CloudServiceTask>> {
 
     @Override
     public EntityModel<CloudServiceTask> toModel(ServiceTaskEntity entity) {
         Link selfRel = linkTo(methodOn(ServiceTaskAdminController.class).findById(entity.getId())).withSelfRel();
 
-        return new EntityModel<>(entity,
-                                 selfRel);
+        return EntityModel.of(entity,
+                              selfRel);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskRepresentationModelAssembler.java
@@ -15,22 +15,22 @@
  */
 package org.activiti.cloud.services.query.rest.assembler;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.api.task.model.QueryCloudTask;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.query.rest.TaskController;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 public class TaskRepresentationModelAssembler implements RepresentationModelAssembler<TaskEntity, EntityModel<QueryCloudTask>> {
 
     @Override
     public EntityModel<QueryCloudTask> toModel(TaskEntity entity) {
         Link selfRel = linkTo(methodOn(TaskController.class).findById(entity.getId())).withSelfRel();
-        return new EntityModel<>(entity,
+        return EntityModel.of(entity,
                               selfRel);
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskVariableRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskVariableRepresentationModelAssembler.java
@@ -24,7 +24,7 @@ public class TaskVariableRepresentationModelAssembler implements RepresentationM
 
     @Override
     public EntityModel<CloudVariableInstance> toModel(TaskVariableEntity entity) {
-       return new EntityModel<>(entity);
+       return EntityModel.of(entity);
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/config/QueryRestWebAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/config/QueryRestWebAutoConfiguration.java
@@ -16,24 +16,26 @@
 
 package org.activiti.cloud.services.query.rest.config;
 
-import java.util.List;
 import org.activiti.cloud.services.query.rest.VariableSearchArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class QueryRestWebAutoConfiguration implements WebMvcConfigurer {
 
     private ConversionService conversionService;
 
-    public QueryRestWebAutoConfiguration(ConversionService mvcConversionService) {
+    public QueryRestWebAutoConfiguration(@Lazy ConversionService mvcConversionService) {
         this.conversionService = mvcConversionService;
     }
 
     @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    public void addArgumentResolvers(@Lazy List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new VariableSearchArgumentResolver(conversionService));
     }
 }

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>7.1.355</activiti.version>
+    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.356</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
@@ -19,38 +19,33 @@ import io.swagger.v3.oas.annotations.Operation;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-@RequestMapping(value = "/v1/process-definitions",
-        produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface ProcessDefinitionController {
 
-    @GetMapping()
+    @GetMapping("/v1/process-definitions")
     PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(Pageable pageable);
 
 
-    @GetMapping(value = "/{id}")
+    @GetMapping(value = "/v1/process-definitions/{id}")
     EntityModel<CloudProcessDefinition> getProcessDefinition(@PathVariable(value = "id") String id);
 
-    @GetMapping(value = "/{id}/model",
+    @GetMapping(value = "/v1/process-definitions/{id}/model",
             produces = "application/xml")
     @ResponseBody
     @Operation(summary = "getProcessModel")
     String getProcessModel(@PathVariable(value = "id") String id);
 
-    @GetMapping(value = "/{id}/model",
+    @GetMapping(value = "/v1/process-definitions/{id}/model",
             produces = "application/json")
     @ResponseBody
     @Operation(summary = "getProcessModel")
     String getBpmnModel(@PathVariable(value = "id") String id);
 
-    @GetMapping(value = "/{id}/model",
+    @GetMapping(value = "/v1/process-definitions/{id}/model",
             produces = "image/svg+xml")
     @ResponseBody
     @Operation(summary = "getProcessModel")

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -23,10 +23,8 @@ import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.springframework.data.domain.Pageable;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.http.MediaType;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,65 +32,62 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-@RequestMapping(value = "/v1/process-instances", produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface ProcessInstanceController {
 
-    @GetMapping()
+    @GetMapping("/v1/process-instances")
     PagedModel<EntityModel<CloudProcessInstance>> getProcessInstances(Pageable pageable);
 
-    @PostMapping(headers = "Content-type=application/json")
+    @PostMapping(path = "/v1/process-instances", headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload cmd);
 
-    @PostMapping(value = "/{processInstanceId}/start",
+    @PostMapping(value = "/v1/process-instances/{processInstanceId}/start",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable(value = "processInstanceId") String processInstanceId,
         @RequestBody(required = false) StartProcessPayload payload);
 
-    @PostMapping(value = "/create",
+    @PostMapping(value = "/v1/process-instances/create",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload cmd);
 
-    @GetMapping(value = "/{processInstanceId}")
+    @GetMapping(value = "/v1/process-instances/{processInstanceId}")
     EntityModel<CloudProcessInstance> getProcessInstanceById(@PathVariable(value = "processInstanceId") String processInstanceId);
 
-    @GetMapping(value = "/{processInstanceId}/model",
+    @GetMapping(value = "/v1/process-instances/{processInstanceId}/model",
         produces = "image/svg+xml")
     @ResponseBody
     String getProcessDiagram(@PathVariable(value = "processInstanceId") String processInstanceId);
 
-    @PostMapping(value = "/signal",
+    @PostMapping(value = "/v1/process-instances/signal",
         headers = "Content-type=application/json")
     ResponseEntity<Void> sendSignal(@RequestBody SignalPayload signalPayload);
 
-    @PostMapping(value = "/message",
+    @PostMapping(value = "/v1/process-instances/message",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> sendStartMessage(@RequestBody StartMessagePayload startMessagePayload);
 
-    @PutMapping(value = "/message",
+    @PutMapping(value = "/v1/process-instances/message",
         headers = "Content-type=application/json")
     ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload);
 
-    @PostMapping(value = "/{processInstanceId}/suspend",
+    @PostMapping(value = "/v1/process-instances/{processInstanceId}/suspend",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> suspend(@PathVariable(value = "processInstanceId") String processInstanceId);
 
-    @PostMapping(value = "/{processInstanceId}/resume",
+    @PostMapping(value = "/v1/process-instances/{processInstanceId}/resume",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> resume(@PathVariable(value = "processInstanceId") String processInstanceId);
 
-    @DeleteMapping(value = "/{processInstanceId}")
+    @DeleteMapping(value = "/v1/process-instances/{processInstanceId}")
     EntityModel<CloudProcessInstance> deleteProcessInstance(@PathVariable(value = "processInstanceId") String processInstanceId);
 
-    @PutMapping(value = "/{processInstanceId}",
+    @PutMapping(value = "/v1/process-instances/{processInstanceId}",
         headers = "Content-type=application/json")
     EntityModel<CloudProcessInstance> updateProcess(@PathVariable(value = "processInstanceId") String processInstanceId,
         @RequestBody UpdateProcessPayload payload);
 
-    @GetMapping(value = "/{processInstanceId}/subprocesses")
+    @GetMapping(value = "/v1/process-instances/{processInstanceId}/subprocesses")
     PagedModel<EntityModel<CloudProcessInstance>> subprocesses(@PathVariable(value = "processInstanceId") String processInstanceId,
         Pageable pageable);
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceTasksController.java
@@ -18,18 +18,13 @@ package org.activiti.cloud.services.rest.api;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping(value = "/v1/process-instances/{processInstanceId}", produces = {MediaTypes.HAL_JSON_VALUE,
-    MediaType.APPLICATION_JSON_VALUE})
 public interface ProcessInstanceTasksController {
 
-    @GetMapping(value = "/tasks")
+    @GetMapping(value = "/v1/process-instances/{processInstanceId}/tasks")
     PagedModel<EntityModel<CloudTask>> getTasks(@PathVariable(value = "processInstanceId") String processInstanceId,
         Pageable pageable);
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
@@ -23,57 +23,53 @@ import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping(value = "/v1/tasks", produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface TaskController {
 
-    @GetMapping()
+    @GetMapping("/v1/tasks")
     PagedModel<EntityModel<CloudTask>> getTasks(Pageable pageable);
 
-    @GetMapping(value = "/{taskId}")
+    @GetMapping(value = "/v1/tasks/{taskId}")
     EntityModel<CloudTask> getTaskById(@PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(value = "/{taskId}/claim")
+    @PostMapping(value = "/v1/tasks/{taskId}/claim")
     EntityModel<CloudTask> claimTask(@PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(value = "/{taskId}/release")
+    @PostMapping(value = "/v1/tasks/{taskId}/release")
     EntityModel<CloudTask> releaseTask(@PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(value = "/{taskId}/complete",
+    @PostMapping(value = "/v1/tasks/{taskId}/complete",
         headers = "Content-type=application/json")
     EntityModel<CloudTask> completeTask(@PathVariable(value = "taskId") String taskId,
         @RequestBody CompleteTaskPayload completeTaskPayload);
 
-    @PostMapping(value = "/{taskId}/save",
+    @PostMapping(value = "/v1/tasks/{taskId}/save",
         headers = "Content-type=application/json")
     void saveTask(@PathVariable(value = "taskId") String taskId,
         @RequestBody SaveTaskPayload saveTaskPayload);
 
-    @DeleteMapping(value = "/{taskId}")
+    @DeleteMapping(value = "/v1/tasks/{taskId}")
     EntityModel<CloudTask> deleteTask(@PathVariable(value = "taskId") String taskId);
 
     @PostMapping(headers = "Content-type=application/json")
     EntityModel<CloudTask> createNewTask(@RequestBody CreateTaskPayload createTaskPayload);
 
-    @PutMapping(value = "/{taskId}",
+    @PutMapping(value = "/v1/tasks/{taskId}",
         headers = "Content-type=application/json")
     EntityModel<CloudTask> updateTask(@PathVariable(value = "taskId") String taskId,
         @RequestBody UpdateTaskPayload updateTaskPayload);
 
-    @GetMapping(value = "/{taskId}/subtasks")
+    @GetMapping(value = "/v1/tasks/{taskId}/subtasks")
     PagedModel<EntityModel<CloudTask>> getSubtasks(Pageable pageable, @PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(value = "/{taskId}/assign",
+    @PostMapping(value = "/v1/tasks/{taskId}/assign",
         headers = "Content-type=application/json")
     EntityModel<CloudTask> assign(@PathVariable("taskId") String taskId,
                                   @RequestBody AssignTaskPayload assignTaskPayload);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
@@ -58,7 +58,7 @@ public interface TaskController {
     @DeleteMapping(value = "/v1/tasks/{taskId}")
     EntityModel<CloudTask> deleteTask(@PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(headers = "Content-type=application/json")
+    @PostMapping(path = "/v1/tasks", headers = "Content-type=application/json")
     EntityModel<CloudTask> createNewTask(@RequestBody CreateTaskPayload createTaskPayload);
 
     @PutMapping(value = "/v1/tasks/{taskId}",

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskVariableController.java
@@ -20,28 +20,23 @@ import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping(value = "/v1/tasks/{taskId}/variables",
-    produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface TaskVariableController {
 
-    @GetMapping(headers = "Content-type=application/json")
+    @GetMapping(path = "/v1/tasks/{taskId}/variables", headers = "Content-type=application/json")
     CollectionModel<EntityModel<CloudVariableInstance>> getVariables(@PathVariable(value = "taskId") String taskId);
 
-    @PostMapping(headers = "Content-type=application/json")
+    @PostMapping(path = "/v1/tasks/{taskId}/variables", headers = "Content-type=application/json")
     ResponseEntity<Void> createVariable(@PathVariable(value = "taskId") String taskId,
         @RequestBody CreateTaskVariablePayload createTaskVariablePayload);
 
-    @PutMapping(value = "/{variableName}",
+    @PutMapping(value = "/v1/tasks/{taskId}/variables/{variableName}",
         headers = "Content-type=application/json")
     ResponseEntity<Void> updateVariable(@PathVariable(value = "taskId") String taskId,
         @PathVariable(value = "variableName") String variableName,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/CollectionModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/CollectionModelAssembler.java
@@ -15,13 +15,13 @@
  */
 package org.activiti.cloud.services.rest.assemblers;
 
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.RepresentationModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.server.RepresentationModelAssembler;
-import org.springframework.hateoas.RepresentationModel;
-import org.springframework.hateoas.CollectionModel;
 
 public class CollectionModelAssembler {
 
@@ -29,9 +29,9 @@ public class CollectionModelAssembler {
                                                                    RepresentationModelAssembler<T, D> representationModelAssembler,
                                                                    Link ... links) {
 
-        return new CollectionModel<>(entities.stream()
-                                       .map(representationModelAssembler::toModel)
-                                       .collect(Collectors.toList()),
-                               links);
+        return CollectionModel.of(entities.stream()
+                                          .map(representationModelAssembler::toModel)
+                                          .collect(Collectors.toList()),
+                                  links);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ConnectorDefinitionRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ConnectorDefinitionRepresentationModelAssembler.java
@@ -15,15 +15,15 @@
  */
 package org.activiti.cloud.services.rest.assemblers;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.services.rest.controllers.ConnectorDefinitionControllerImpl;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.core.common.model.connector.ConnectorDefinition;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 public class ConnectorDefinitionRepresentationModelAssembler implements RepresentationModelAssembler<ConnectorDefinition, EntityModel<ConnectorDefinition>> {
 
@@ -33,8 +33,8 @@ public class ConnectorDefinitionRepresentationModelAssembler implements Represen
         Link selfRel = linkTo(methodOn(ConnectorDefinitionControllerImpl.class).getConnectorDefinition(connectorDefinition.getId())).withSelfRel();
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
 
-        return new EntityModel<>(connectorDefinition,
-                selfRel,
-                homeLink);
+        return EntityModel.of(connectorDefinition,
+                              selfRel,
+                              homeLink);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/GroupCandidatesRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/GroupCandidatesRepresentationModelAssembler.java
@@ -33,6 +33,6 @@ public class GroupCandidatesRepresentationModelAssembler implements Representati
 
     @Override
     public EntityModel<CandidateGroup> toModel(CandidateGroup groupCandidates) {
-        return new EntityModel<>(groupCandidates);
+        return EntityModel.of(groupCandidates);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionMetaRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionMetaRepresentationModelAssembler.java
@@ -15,17 +15,17 @@
  */
 package org.activiti.cloud.services.rest.assemblers;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
 import org.activiti.cloud.services.api.model.ProcessDefinitionMeta;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessDefinitionControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessDefinitionMetaControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessInstanceControllerImpl;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 public class ProcessDefinitionMetaRepresentationModelAssembler implements RepresentationModelAssembler<ProcessDefinitionMeta, EntityModel<ProcessDefinitionMeta>> {
 
@@ -37,7 +37,7 @@ public class ProcessDefinitionMetaRepresentationModelAssembler implements Repres
         Link startProcessLink = linkTo(methodOn(ProcessInstanceControllerImpl.class).startProcess(null)).withRel("startProcess");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
 
-        return new EntityModel<>(processDefinitionMeta,
+        return EntityModel.of(processDefinitionMeta,
                               metadata,
                               selfRel,
                               startProcessLink,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionRepresentationModelAssembler.java
@@ -56,7 +56,7 @@ public class ProcessDefinitionRepresentationModelAssembler implements Representa
         Link selfRel = linkTo(methodOn(ProcessDefinitionControllerImpl.class).getProcessDefinition(cloudProcessDefinition.getId())).withSelfRel();
         Link startProcessLink = linkTo(methodOn(ProcessInstanceControllerImpl.class).startProcess(null)).withRel("startProcess");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
-        return new EntityModel<>(cloudProcessDefinition,
+        return EntityModel.of(cloudProcessDefinition,
                                              selfRel,
                                              startProcessLink,
                                              homeLink);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessInstanceRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessInstanceRepresentationModelAssembler.java
@@ -58,7 +58,7 @@ public class ProcessInstanceRepresentationModelAssembler implements Representati
         Link selfLink = linkTo(methodOn(ProcessInstanceControllerImpl.class).getProcessInstanceById(cloudProcessInstance.getId())).withSelfRel();
         Link variablesLink = linkTo(methodOn(ProcessInstanceVariableControllerImpl.class).getVariables(cloudProcessInstance.getId())).withRel("variables");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
-        return new EntityModel<>(cloudProcessInstance,
+        return EntityModel.of(cloudProcessInstance,
                               selfLink,
                               variablesLink,
                               processInstancesRel,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessInstanceVariableRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessInstanceVariableRepresentationModelAssembler.java
@@ -41,7 +41,7 @@ public class ProcessInstanceVariableRepresentationModelAssembler implements Repr
         Link processVariables = linkTo(methodOn(ProcessInstanceVariableControllerImpl.class).getVariables(cloudVariableInstance.getProcessInstanceId())).withRel("processVariables");
         Link processInstance = linkTo(methodOn(ProcessInstanceControllerImpl.class).getProcessInstanceById(cloudVariableInstance.getProcessInstanceId())).withRel("processInstance");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
-        return new EntityModel<>(cloudVariableInstance,
+        return EntityModel.of(cloudVariableInstance,
                               processVariables,
                               processInstance,
                               homeLink);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskRepresentationModelAssembler.java
@@ -30,17 +30,17 @@
 
 package org.activiti.cloud.services.rest.assemblers;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.activiti.api.task.model.Task;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessInstanceControllerImpl;
 import org.activiti.cloud.services.rest.controllers.TaskControllerImpl;
-import org.springframework.hateoas.Link;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.activiti.api.task.model.Task.TaskStatus.ASSIGNED;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -74,7 +74,7 @@ public class TaskRepresentationModelAssembler implements RepresentationModelAsse
             links.add(linkTo(methodOn(TaskControllerImpl.class).getTaskById(cloudTask.getParentTaskId())).withRel("parent"));
         }
         links.add(linkTo(HomeControllerImpl.class).withRel("home"));
-        return new EntityModel<>(cloudTask,
+        return EntityModel.of(cloudTask,
                               links);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskVariableInstanceRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskVariableInstanceRepresentationModelAssembler.java
@@ -41,7 +41,7 @@ public class TaskVariableInstanceRepresentationModelAssembler implements Represe
         Link globalVariables = linkTo(methodOn(TaskVariableControllerImpl.class).getVariables(cloudVariableInstance.getTaskId())).withRel("variables");
         Link taskRel = linkTo(methodOn(TaskControllerImpl.class).getTaskById(cloudVariableInstance.getTaskId())).withRel("task");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
-        return new EntityModel<>(cloudVariableInstance,
+        return EntityModel.of(cloudVariableInstance,
                               globalVariables,
                               taskRel,
                               homeLink);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/UserCandidatesRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/UserCandidatesRepresentationModelAssembler.java
@@ -33,6 +33,6 @@ public class UserCandidatesRepresentationModelAssembler implements Representatio
 
     @Override
     public EntityModel<CandidateUser> toModel(CandidateUser candidateUser) {
-        return new EntityModel<>(candidateUser);
+        return EntityModel.of(candidateUser);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/HomeControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/HomeControllerImpl.java
@@ -43,7 +43,7 @@ public class HomeControllerImpl implements HomeController {
     @Override
     public EntityModel<HomeResource> getHomeInfo() {
 
-        return new EntityModel<>(new HomeResource(),
+        return EntityModel.of(new HomeResource(),
                               linkTo(ProcessDefinitionControllerImpl.class).withRel("process-definitions"),
                               linkTo(ProcessInstanceControllerImpl.class).withRel("process-instances"),
                               linkTo(TaskControllerImpl.class).withRel("tasks"));

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
@@ -47,9 +47,12 @@ import org.activiti.engine.RepositoryService;
 import org.activiti.engine.impl.util.IoUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -57,6 +60,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 @RestController
+@RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public class ProcessDefinitionControllerImpl implements ProcessDefinitionController {
 
     private final RepositoryService repositoryService;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -30,10 +30,6 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import static java.util.Collections.emptyList;
-
-import java.nio.charset.StandardCharsets;
-
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
@@ -55,15 +51,23 @@ import org.activiti.cloud.services.rest.assemblers.ProcessInstanceRepresentation
 import org.activiti.engine.RepositoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
-import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Collections.emptyList;
+
 @RestController
+@RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public class ProcessInstanceControllerImpl implements ProcessInstanceController {
 
     private final RepositoryService repositoryService;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImpl.java
@@ -26,12 +26,16 @@ import org.activiti.cloud.services.rest.api.ProcessInstanceTasksController;
 import org.activiti.cloud.services.rest.assemblers.TaskRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public class ProcessInstanceTasksControllerImpl implements ProcessInstanceTasksController {
 
     private final TaskRuntime taskRuntime;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
@@ -15,15 +15,6 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
-import javax.servlet.http.HttpServletResponse;
 import org.activiti.api.model.shared.model.ActivitiErrorMessage;
 import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.api.runtime.shared.NotFoundException;
@@ -37,6 +28,16 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 @RestControllerAdvice
 public class RuntimeBundleExceptionHandler {
 
@@ -44,42 +45,42 @@ public class RuntimeBundleExceptionHandler {
     @ResponseStatus(NO_CONTENT)
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiInterchangeInfoNotFoundException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(NOT_FOUND.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(NOT_FOUND.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(ActivitiForbiddenException.class)
     @ResponseStatus(FORBIDDEN)
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiForbiddenException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(FORBIDDEN.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(FORBIDDEN.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(UnprocessableEntityException.class)
     @ResponseStatus(UNPROCESSABLE_ENTITY)
     public EntityModel<ActivitiErrorMessage> handleAppException(UnprocessableEntityException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(UNPROCESSABLE_ENTITY.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(UNPROCESSABLE_ENTITY.value(), ex.getMessage()));
     }
 
     @ExceptionHandler({NotFoundException.class, ActivitiObjectNotFoundException.class})
     @ResponseStatus(NOT_FOUND)
     public EntityModel<ActivitiErrorMessage> handleAppException(RuntimeException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(NOT_FOUND.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(NOT_FOUND.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(BAD_REQUEST)
     public EntityModel<ActivitiErrorMessage> handleAppException(IllegalStateException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(BAD_REQUEST.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(BAD_REQUEST.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(ActivitiException.class)
     @ResponseStatus(INTERNAL_SERVER_ERROR)
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskControllerImpl.java
@@ -46,13 +46,17 @@ import org.activiti.cloud.services.rest.api.TaskController;
 import org.activiti.cloud.services.rest.assemblers.TaskRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public class TaskControllerImpl implements TaskController {
 
     private final TaskRepresentationModelAssembler taskRepresentationModelAssembler;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImpl.java
@@ -41,13 +41,17 @@ import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceRepresent
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public class TaskVariableControllerImpl implements TaskVariableController {
 
     private final TaskVariableInstanceRepresentationModelAssembler variableRepresentationModelAssembler;

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.356</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>7.1.355</activiti.version>
+    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/activiti-cloud-service-error-handlers/src/main/java/org/activiti/cloud/services/error/CommonExceptionHandler.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-error-handlers/src/main/java/org/activiti/cloud/services/error/CommonExceptionHandler.java
@@ -35,21 +35,21 @@ public class CommonExceptionHandler {
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiForbiddenException ex, HttpServletResponse response) {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public EntityModel<ActivitiErrorMessage> handleAppException(IllegalStateException ex, HttpServletResponse response) {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
     }
 
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public EntityModel<ActivitiErrorMessage> handleAppException(NotFoundException ex, HttpServletResponse response) {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        return new EntityModel<>(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }
 
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.common.messaging;
 import org.activiti.cloud.common.messaging.config.InputConverterFunction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.validation.annotation.Validated;
 
@@ -189,7 +190,7 @@ public class ActivitiCloudMessagingProperties {
     }
 
     @Autowired
-    public void configureInputConverters(Map<String, InputConverterFunction> inputConverters) {
+    public void configureInputConverters(@Lazy Map<String, InputConverterFunction> inputConverters) {
         this.inputConverters = new LinkedHashMap<>(inputConverters);
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @AutoConfigureBefore(BinderFactoryAutoConfiguration.class)
@@ -47,7 +48,7 @@ public class ActivitiMessagingDestinationsAutoConfiguration {
     }
 
     @Bean
-    public InputConverterFunction escapeIllegalChars(ActivitiCloudMessagingProperties messagingProperties) {
+    public InputConverterFunction escapeIllegalChars(@Lazy ActivitiCloudMessagingProperties messagingProperties) {
         return (value) -> value.replaceAll(messagingProperties.getDestinationIllegalCharsRegex(),
                                            messagingProperties.getDestinationIllegalCharsReplacement());
     }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
@@ -30,7 +30,6 @@ package org.activiti.cloud.services.common.security.keycloak.config;/*
  */
 
 
-import java.util.List;
 import org.activiti.api.runtime.shared.security.PrincipalGroupsProvider;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.PrincipalRolesProvider;
@@ -53,7 +52,7 @@ import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
 import org.keycloak.adapters.springsecurity.management.HttpSessionManager;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
@@ -69,6 +68,8 @@ import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
+import java.util.List;
+
 @Configuration
 @KeycloakConfiguration
 @ConditionalOnWebApplication
@@ -77,15 +78,16 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 @DependsOn({"keycloakConfigResolver"})
 public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigurerAdapter {
 
-
     /**
      * Registers the KeycloakAuthenticationProvider with the authentication manager.
      */
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth,
-        KeycloakAuthenticationProvider keycloakAuthenticationProvider) throws Exception {
-        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
-        auth.authenticationProvider(keycloakAuthenticationProvider);
+    @Bean
+    public InitializingBean configureGlobalAuthenticationManager(AuthenticationManagerBuilder auth,
+                                            KeycloakAuthenticationProvider keycloakAuthenticationProvider) {
+        return () -> {
+            keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
+            auth.authenticationProvider(keycloakAuthenticationProvider);
+        };
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedModelAssembler.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedModelAssembler.java
@@ -51,9 +51,9 @@ public class AlfrescoPagedModelAssembler<T> extends PagedResourcesAssembler<T> {
         PagedModel<R> pagedModel = toModel(page, assembler);
         ExtendedPageMetadata extendedPageMetadata = extendedPageMetadataConverter.toExtendedPageMetadata(pageable.getOffset(),
                                                                                                          pagedModel.getMetadata());
-        pagedModel = new PagedModel<>(pagedModel.getContent(),
-                                              extendedPageMetadata,
-                                              pagedModel.getLinks());
+        pagedModel = PagedModel.of(pagedModel.getContent(),
+                                   extendedPageMetadata,
+                                   pagedModel.getLinks());
 
         return pagedModel;
     }

--- a/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverterTest.java
@@ -16,9 +16,6 @@
 package org.activiti.cloud.alfresco.converter.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.lang.reflect.Type;
-import java.util.List;
-
 import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
 import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,11 +25,14 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.springframework.hateoas.PagedModel;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
+
+import java.lang.reflect.Type;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -129,7 +129,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
                                                                     eq(outputMessage));
 
         //when
-        httpMessageConverter.writeInternal(new EntityModel<>("content"),
+        httpMessageConverter.writeInternal(EntityModel.of("content"),
                                            type,
                                            outputMessage);
 

--- a/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PagedModelConverterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PagedModelConverterTest.java
@@ -15,9 +15,6 @@
  */
 package org.activiti.cloud.alfresco.converter.json;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
 import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
 import org.activiti.cloud.alfresco.rest.model.PaginationMetadata;
@@ -25,9 +22,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.hateoas.PagedModel;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -49,7 +49,7 @@ public class PagedModelConverterTest {
     @Test
     public void toAlfrescoContentListWrapperShouldConvertFromPagedModelToAlfrescoContentListWrapper() {
         //given
-        List<EntityModel<String>> elements = Collections.singletonList(new EntityModel<>("any"));
+        List<EntityModel<String>> elements = Collections.singletonList(EntityModel.of("any"));
         PagedModel.PageMetadata basePageMetaData = new PagedModel.PageMetadata(10,
                                                                                1,
                                                                                100);
@@ -58,8 +58,8 @@ public class PagedModelConverterTest {
         given(pageMetadataConverter.toAlfrescoPageMetadata(basePageMetaData, elements.size())).willReturn(alfrescoPageMetadata);
 
         //when
-        ListResponseContent<String> alfrescoPageContentListWrapper = pagedCollectionModelConverter.pagedCollectionModelToListResponseContent(new PagedModel<>(elements,
-                                                                                                                                                      basePageMetaData));
+        ListResponseContent<String> alfrescoPageContentListWrapper = pagedCollectionModelConverter.pagedCollectionModelToListResponseContent(PagedModel.of(elements,
+                                                                                                                                                           basePageMetaData));
 
         //then
         assertThat(alfrescoPageContentListWrapper).isNotNull();
@@ -73,10 +73,10 @@ public class PagedModelConverterTest {
     @Test
     public void toAlfrescoContentListWrapperShouldConvertFromCollectionModelToAlfrescoContentListWrapper() {
         //given
-        List<EntityModel<String>> elements = Collections.singletonList(new EntityModel<>("any"));
+        List<EntityModel<String>> elements = Collections.singletonList(EntityModel.of("any"));
 
         //when
-        ListResponseContent<String> alfrescoPageContentListWrapper = pagedCollectionModelConverter.resourcesToListResponseContent(new CollectionModel<>(elements));
+        ListResponseContent<String> alfrescoPageContentListWrapper = pagedCollectionModelConverter.resourcesToListResponseContent(CollectionModel.of(elements));
 
         //then
         assertThat(alfrescoPageContentListWrapper).isNotNull();

--- a/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedModelAssemblerTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedModelAssemblerTest.java
@@ -15,8 +15,6 @@
  */
 package org.activiti.cloud.alfresco.data.domain;
 
-import java.util.Collections;
-
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +24,10 @@ import org.mockito.Spy;
 import org.springframework.data.domain.Page;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.hateoas.RepresentationModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -67,12 +67,12 @@ public class AlfrescoPagedModelAssemblerTest {
                                                                                30);
         RepresentationModel resourceSupport = new RepresentationModel();
         Link link = mock(Link.class);
-        PagedModel<RepresentationModel> basePagedModel = new PagedModel<>(Collections.singletonList(resourceSupport),
-                                                                                        baseMetadata,
-                                                                                        link);
+        PagedModel<RepresentationModel> basePagedModel = PagedModel.of(Collections.singletonList(resourceSupport),
+                                                                                                 baseMetadata,
+                                                                                                 link);
 
         doReturn(basePagedModel).when(alfrescoPagedModelAssembler).toModel(page,
-                                                                                      resourceAssembler);
+                                                                           resourceAssembler);
         ExtendedPageMetadata extendedPageMetadata = mock(ExtendedPageMetadata.class);
         given(extendedPageMetadataConverter.toExtendedPageMetadata(alfrescoPageRequest.getOffset(), baseMetadata)).willReturn(extendedPageMetadata);
 

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -16,20 +16,29 @@
 package org.activiti.cloud.common.swagger.conf;
 
 import com.fasterxml.classmate.TypeResolver;
-import java.util.List;
-import java.util.function.Predicate;
 import org.activiti.cloud.common.swagger.BaseAPIInfoBuilder;
 import org.activiti.cloud.common.swagger.DocketCustomizer;
 import org.activiti.cloud.common.swagger.PathPrefixTransformationFilter;
 import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 import springfox.documentation.RequestHandler;
 import springfox.documentation.oas.annotations.EnableOpenApi;
 import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Provides base springfox configuration for swagger auto-generated specification file. It provides two
@@ -50,6 +59,7 @@ import springfox.documentation.spring.web.plugins.Docket;
  */
 @Configuration
 @EnableOpenApi
+@PropertySource("classpath:swagger-config.properties")
 public class SwaggerAutoConfiguration {
 
     @Bean
@@ -63,6 +73,39 @@ public class SwaggerAutoConfiguration {
     @ConditionalOnMissingBean
     public PathPrefixTransformationFilter pathPrefixTransformationFilter(@Value("${activiti.cloud.swagger.base-path:/}") String swaggerBasePath) {
         return new PathPrefixTransformationFilter(swaggerBasePath);
+    }
+
+    /**
+     * Springfox workaround required by Spring Boot 2.6
+     * See https://github.com/springfox/springfox/issues/346
+     */
+    @Bean
+    public static BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+        return new BeanPostProcessor() {
+
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof WebMvcRequestHandlerProvider || bean instanceof WebFluxRequestHandlerProvider) {
+                    customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+                }
+                return bean;
+            }
+
+            private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings) {
+                mappings.removeIf(mapping -> mapping.getPatternParser() != null);
+            }
+
+            @SuppressWarnings("unchecked")
+            private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+                try {
+                    Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+                    field.setAccessible(true);
+                    return (List<RequestMappingInfoHandlerMapping>) field.get(bean);
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
     }
 
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/resources/swagger-config.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/main/resources/swagger-config.properties
@@ -1,0 +1,3 @@
+# Springfox workaround required by Spring Boot 2.6
+# See https://github.com/springfox/springfox/issues/3462
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/rest/support/TestMvcClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/rest/support/TestMvcClient.java
@@ -15,25 +15,31 @@
  */
 package org.activiti.cloud.services.test.rest.support;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.client.LinkDiscoverer;
+import org.springframework.hateoas.client.LinkDiscoverers;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-
 import java.util.Optional;
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.client.LinkDiscoverer;
-import org.springframework.hateoas.client.LinkDiscoverers;
-import org.springframework.http.*;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.web.servlet.*;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Helper methods for rest api web integration testing from spring-data-rest-tests-core module
@@ -214,7 +220,7 @@ public class TestMvcClient {
      * @throws Exception
      */
     public List<Link> discover(String rel) throws Exception {
-        return discover(new Link(basePath), rel);
+        return discover(Link.of(basePath), rel);
     }
 
     /**

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.356</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>7.1.355</activiti.version>
+    <activiti.version>0.0.1-PR-3796-341-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
This PR updates Spring Boot version to 2.6.2 and Spring Cloud version to 2021.0.0

I have discovered and made tweaks for the following breaking changes in upstream dependencies:

- [x] Spring Hateoas removed deprecated class constructors replaced by static method constructors for entity model representations
- [x] Workaround for an open issue with Springfox 3.0 and Spring Boot 2.6: https://github.com/springfox/springfox/issues/3462
- [x] Removed circular dependencies in several auto configurations because Spring Boot 2.6+ started prohibiting circular references by default: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#circular-references-prohibited-by-default
- [x] Schema validation failed in ModelVersionEntity because the extensions Lob attribute did not align with Postgres TEXT datatype
- [x] @RequestMapping annotation is no longer allowed on @FeignClient interfaces due to this change: https://github.com/spring-cloud/spring-cloud-openfeign/blob/10ad8a0c6ea0a5b641eb31318c93055bdaf4c4f8/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java#L180

Part of https://github.com/Activiti/Activiti/issues/3798