### PR TITLE
fix: update variable propagation logic

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>7.1.356</activiti.version>
+    <activiti.version>7.1.357</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>7.1.356</activiti.version>
+    <activiti.version>7.1.357</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>7.1.356</activiti.version>
+    <activiti.version>7.1.357</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/AggregateIntegrationResultReceivedEventCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/AggregateIntegrationResultReceivedEventCmd.java
@@ -39,11 +39,8 @@ class AggregateIntegrationResultReceivedEventCmd implements Command<Void> {
 
     @Override
     public Void execute(CommandContext commandContext) {
-        if (runtimeBundleProperties.getEventsProperties()
-            .isIntegrationAuditEventsEnabled()) {
-            CloudIntegrationResultReceivedEventImpl integrationResultReceived = new CloudIntegrationResultReceivedEventImpl(
-                integrationContext);
-
+        if (runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()) {
+            CloudIntegrationResultReceivedEventImpl integrationResultReceived = new CloudIntegrationResultReceivedEventImpl(integrationContext);
             processEngineEventsAggregator.add(integrationResultReceived);
         }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/AggregateIntegrationResultReceivedEventCmdTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/AggregateIntegrationResultReceivedEventCmdTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.services.connectors.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationResultReceivedEventImpl;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AggregateIntegrationResultReceivedEventCmdTest {
+
+    @InjectMocks
+    private AggregateIntegrationResultReceivedEventCmd command;
+
+    @Mock
+    private IntegrationContext integrationContext;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RuntimeBundleProperties runtimeBundleProperties;
+
+    @Mock
+    private ProcessEngineEventsAggregator processEngineEventsAggregator;
+
+    @Captor
+    private ArgumentCaptor<CloudIntegrationResultReceivedEventImpl> messageCaptor;
+
+    @Test
+    public void receiveShouldSendIntegrationAuditEventWhenIntegrationAuditEventsAreEnabled() {
+        //given
+        given(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).willReturn(true);
+
+        //when
+        command.execute(null);
+
+        //then
+        verify(processEngineEventsAggregator).add(messageCaptor.capture());
+        CloudIntegrationResultReceivedEventImpl event = messageCaptor.getValue();
+        assertThat(event.getEntity()).isEqualTo(integrationContext);
+
+    }
+
+    @Test
+    public void shouldNot_sentAuditEvent_when_integrationAuditEventsAreDisabled() {
+        //given
+        given(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).willReturn(false);
+
+        //when
+        command.execute(null);
+
+        //then
+        verifyNoInteractions(processEngineEventsAggregator);
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandlerTest.java
@@ -17,54 +17,35 @@ package org.activiti.services.connectors.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
-import org.activiti.bpmn.model.ServiceTask;
-import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
-import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
-import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
-import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationResultReceivedEventImpl;
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
-import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
-import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
-import org.activiti.cloud.services.events.message.MessageBuilderAppenderChain;
-import org.activiti.engine.ActivitiEngineAgenda;
-import org.activiti.engine.ManagementService;
-import org.activiti.engine.RuntimeService;
-import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
-import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.activiti.engine.impl.context.Context;
-import org.activiti.engine.impl.interceptor.Command;
-import org.activiti.engine.impl.interceptor.CommandContext;
-import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
-import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
-import org.activiti.engine.integration.IntegrationContextService;
-import org.activiti.engine.runtime.Execution;
-import org.activiti.engine.runtime.ExecutionQuery;
-import org.activiti.services.connectors.message.IntegrationContextMessageBuilderFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
+import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
+import org.activiti.engine.ManagementService;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.cmd.TriggerCmd;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
+import org.activiti.engine.integration.IntegrationContextService;
+import org.activiti.engine.runtime.Execution;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class ServiceTaskIntegrationResultEventHandlerTest {
 
     private static final String EXECUTION_ID = "execId";
@@ -84,174 +65,60 @@ public class ServiceTaskIntegrationResultEventHandlerTest {
     @Mock
     private IntegrationContextService integrationContextService;
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private RuntimeBundleProperties runtimeBundleProperties;
-
-    @Mock
-    private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
-
     @Mock
     private ManagementService managementService;
 
-    @Mock
-    private IntegrationContextMessageBuilderFactory messageBuilderFactory;
-
-    @Captor
-    private ArgumentCaptor<CloudRuntimeEvent<?, ?>> messageCaptor;
-
-    @Mock
-    private ExecutionQuery executionQuery;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private CommandContext commandContext;
-
-    @Mock
-    private ProcessEngineEventsAggregator processEngineEventsAggregator;
-
-    @Mock
-    private ExecutionEntity executionEntity;
-
-    @Mock
-    private ActivitiEngineAgenda agenda;
-
-    private static MockedStatic<Context> context;
-
-    @BeforeAll
-    public static void init() {
-        context = Mockito.mockStatic(Context.class);
-    }
-
-    @AfterAll
-    public static void close() {
-        context.close();
-    }
-
-    @BeforeEach
-    public void setUp() {
-        initMocks(this);
-        when(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).thenReturn(true);
-        when(runtimeBundleProperties.getServiceFullName()).thenReturn("myApp");
-        when(runtimeService.createExecutionQuery()
-                           .executionId(anyString())
-                           .list()).thenReturn(Collections.emptyList());
-        when(messageBuilderFactory.create(any())).thenReturn(new MessageBuilderAppenderChain());
-
-        ProcessEngineConfigurationImpl processEngineConfiguration = mock(ProcessEngineConfigurationImpl.class);
-        when(processEngineConfiguration.getEventDispatcher()).thenReturn(mock(ActivitiEventDispatcher.class));
-
-        context.when(Context::getProcessEngineConfiguration).thenReturn(processEngineConfiguration);
-        context.when(Context::getAgenda).thenReturn(agenda);
-
-        given(executionEntity.getId()).willReturn(EXECUTION_ID);
-
-        given(commandContext.getExecutionEntityManager().findById(anyString())).willReturn(executionEntity);
-
-        given(managementService.executeCommand(any())).willAnswer(invocation -> {
-            Command<Void> command = invocation.getArgument(0);
-
-            command.execute(commandContext);
-
-            return null;
-        });
-
-    }
-
     @Test
-    public void receive_should_setVariablesTriggerExecutionAndDeleteRelatedIntegrationContext() {
+    public void receive_should_triggerExecutionAndDeleteRelatedIntegrationContext() {
         //given
-        IntegrationContextEntityImpl integrationContextEntity = new IntegrationContextEntityImpl();
-        integrationContextEntity.setExecutionId(EXECUTION_ID);
-        integrationContextEntity.setId(ENTITY_ID);
-        integrationContextEntity.setProcessInstanceId(PROC_INST_ID);
-        integrationContextEntity.setProcessDefinitionId(PROC_DEF_ID);
+        IntegrationContextImpl integrationContext = buildIntegrationContext(Collections.singletonMap("var1", "v"));
+        IntegrationContextEntityImpl integrationContextEntity = buildIntegrationContextEntity();
+        given(integrationContextService.findById(integrationContext.getId())).willReturn(integrationContextEntity);
 
-        given(integrationContextService.findById(ENTITY_ID))
-            .willReturn(integrationContextEntity);
+        List<Execution> executions = Collections.singletonList(buildExecutionEntity());
+        when(runtimeService.createExecutionQuery().executionId(integrationContext.getExecutionId()).list()).thenReturn(executions);
 
-        List<Execution> executions = Collections.singletonList(executionEntity);
-
-        when(runtimeService.createExecutionQuery()
-                            .executionId(anyString())
-                            .list()).thenReturn(executions);
-        when(executions.get(0)
-                       .getActivityId()).thenReturn(CLIENT_ID);
-
-        Map<String, Object> variables = Collections.singletonMap("var1",
-                "v");
-
-        IntegrationContextImpl integrationContext = buildIntegrationContext(variables);
 
         //when
         handler.receive(new IntegrationResultImpl(new IntegrationRequestImpl(), integrationContext));
 
         //then
         verify(integrationContextService).deleteIntegrationContext(integrationContextEntity);
-        verify(executionEntity).setVariableLocal("var1", variables.get("var1"), false);
-        verify(agenda).planTriggerExecutionOperation(executionEntity);
-        verify(processEngineEventsAggregator).add(any(CloudRuntimeEvent.class));
+        final ArgumentCaptor<CompositeCommand> captor = ArgumentCaptor.forClass(
+            CompositeCommand.class);
+        verify(managementService).executeCommand(captor.capture());
+        final CompositeCommand command = captor.getValue();
+        assertThat(command.getCommands()).hasSize(2);
+        assertThat(command.getCommands().get(0)).isInstanceOf(TriggerCmd.class);
+        assertThat(command.getCommands().get(1)).isInstanceOf(AggregateIntegrationResultReceivedEventCmd.class);
+    }
+
+    private ExecutionEntity buildExecutionEntity() {
+        final ExecutionEntity executionEntity = mock(ExecutionEntity.class);
+        when(executionEntity.getActivityId()).thenReturn(CLIENT_ID);
+        return executionEntity;
+    }
+
+    private IntegrationContextEntityImpl buildIntegrationContextEntity() {
+        IntegrationContextEntityImpl integrationContextEntity = new IntegrationContextEntityImpl();
+        integrationContextEntity.setExecutionId(EXECUTION_ID);
+        integrationContextEntity.setId(ENTITY_ID);
+        integrationContextEntity.setProcessInstanceId(PROC_INST_ID);
+        integrationContextEntity.setProcessDefinitionId(PROC_DEF_ID);
+        return integrationContextEntity;
     }
 
     @Test
     public void receiveShouldDoNothingWhenIntegrationContextsIsNull() {
         //given
-        given(integrationContextService.findById(ENTITY_ID))
-                .willReturn(null);
-        given(executionQuery.list()).willReturn(Collections.singletonList(mock(Execution.class)));
-        Map<String, Object> variables = Collections.singletonMap("var1",
-                "v");
-
-        IntegrationContextImpl integrationContext = buildIntegrationContext(variables);
+        IntegrationContextImpl integrationContext = buildIntegrationContext(Collections.singletonMap("var1", "v"));
+        given(integrationContextService.findById(integrationContext.getId())).willReturn(null);
 
         //when
         handler.receive(new IntegrationResultImpl(new IntegrationRequestImpl(), integrationContext));
 
         //then
         verify(integrationContextService, never()).deleteIntegrationContext(any());
-    }
-
-    @Test
-    public void receiveShouldSendIntegrationAuditEventWhenIntegrationAuditEventsAreEnabled() {
-        //given
-        given(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).willReturn(true);
-
-        IntegrationContextEntityImpl integrationContextEntity = new IntegrationContextEntityImpl();
-        integrationContextEntity.setExecutionId(EXECUTION_ID);
-        integrationContextEntity.setId(ENTITY_ID);
-        integrationContextEntity.setProcessInstanceId(PROC_INST_ID);
-        integrationContextEntity.setProcessDefinitionId(PROC_DEF_ID);
-
-        List<Execution> executions = Collections.singletonList(executionEntity);
-
-        when(runtimeService.createExecutionQuery()
-                           .executionId(anyString())
-                           .list()).thenReturn(executions);
-        when(executions.get(0)
-                       .getActivityId()).thenReturn(CLIENT_ID);
-
-        given(integrationContextService.findById(ENTITY_ID)).willReturn(integrationContextEntity);
-        Map<String, Object> variables = Collections.singletonMap("var1",
-                "v");
-
-        given(runtimeBundleProperties.getServiceFullName()).willReturn("myApp");
-
-        IntegrationContextImpl integrationContext = buildIntegrationContext(variables);
-
-        IntegrationResult integrationResultEvent = new IntegrationResultImpl(new IntegrationRequestImpl(), integrationContext);
-
-        //when
-        handler.receive(integrationResultEvent);
-
-        //then
-        verify(processEngineEventsAggregator).add(messageCaptor.capture());
-        CloudIntegrationResultReceivedEventImpl event = (CloudIntegrationResultReceivedEventImpl) messageCaptor.getValue();
-        assertThat(event.getEntity().getId()).isEqualTo(ENTITY_ID);
-        assertThat(event.getEntity().getProcessInstanceId()).isEqualTo(PROC_INST_ID);
-        assertThat(event.getEntity().getProcessDefinitionId()).isEqualTo(PROC_DEF_ID);
-        assertThat(event.getEntity().getClientId()).isEqualTo(CLIENT_ID);
-        assertThat(event.getEntity().getClientName()).isEqualTo(CLIENT_NAME);
-        assertThat(event.getEntity().getClientType()).isEqualTo(CLIENT_TYPE);
-
-        runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(event);
     }
 
     private IntegrationContextImpl buildIntegrationContext(Map<String, Object> variables) {
@@ -264,37 +131,7 @@ public class ServiceTaskIntegrationResultEventHandlerTest {
         integrationContext.setClientId(CLIENT_ID);
         integrationContext.setClientName(CLIENT_NAME);
         integrationContext.setClientType(CLIENT_TYPE);
-
         return integrationContext;
     }
 
-    @Test
-    public void retrieveShouldNotSentAuditEventWhenIntegrationAuditEventsAreDisabled() {
-        //given
-        given(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).willReturn(false);
-
-        IntegrationContextEntityImpl integrationContextEntity = new IntegrationContextEntityImpl();
-
-        List<Execution> executions = Collections.singletonList(executionEntity);
-
-        when(runtimeService.createExecutionQuery()
-                           .executionId(anyString())
-                           .list()).thenReturn(executions);
-        when(executions.get(0)
-                       .getActivityId()).thenReturn(CLIENT_ID);
-
-        given(integrationContextService.findById(ENTITY_ID)).willReturn(integrationContextEntity);
-        Map<String, Object> variables = Collections.singletonMap("var1",
-                                                                 "v");
-
-        IntegrationContextImpl integrationContext = buildIntegrationContext(variables);
-        IntegrationResultImpl integrationResultEvent = new IntegrationResultImpl(new IntegrationRequestImpl(), integrationContext);
-
-        //when
-        handler.receive(integrationResultEvent);
-
-        //then
-        verify(processEngineEventsAggregator,
-               never()).add(any(CloudRuntimeEvent.class));
-    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/behavior/CloudActivityBehaviorFactory.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/behavior/CloudActivityBehaviorFactory.java
@@ -22,6 +22,7 @@ import org.activiti.bpmn.model.SignalEventDefinition;
 import org.activiti.bpmn.model.ThrowEvent;
 import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
 import org.activiti.engine.impl.bpmn.behavior.VariablesCalculator;
+import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
 import org.activiti.runtime.api.impl.MappingAwareActivityBehaviorFactory;
 import org.activiti.spring.process.ProcessVariablesInitiator;
 import org.springframework.context.ApplicationContext;
@@ -30,18 +31,15 @@ public class CloudActivityBehaviorFactory extends MappingAwareActivityBehaviorFa
 
     private ApplicationContext applicationContext;
 
-    public CloudActivityBehaviorFactory(ApplicationContext applicationContext,
-                                        VariablesCalculator variablesCalculator,
-                                        ProcessVariablesInitiator processVariablesInitiator
-                                        ) {
-        super(variablesCalculator, processVariablesInitiator);
+    public CloudActivityBehaviorFactory(ApplicationContext applicationContext, VariablesCalculator variablesCalculator,
+        ProcessVariablesInitiator processVariablesInitiator, VariablesPropagator variablesPropagator) {
+        super(variablesCalculator, processVariablesInitiator, variablesPropagator);
         this.applicationContext = applicationContext;
     }
 
     @Override
     public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
-                                                                                                           SignalEventDefinition signalEventDefinition,
-                                                                                                           Signal signal) {
+        SignalEventDefinition signalEventDefinition, Signal signal) {
         return (IntermediateThrowSignalEventActivityBehavior) applicationContext.getBean(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME, applicationContext, signalEventDefinition, signal);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiCloudEngineAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiCloudEngineAutoConfiguration.java
@@ -15,7 +15,10 @@
  */
 package org.activiti.cloud.starter.rb.configuration;
 
+import static org.activiti.spring.boot.ProcessEngineAutoConfiguration.BEHAVIOR_FACTORY_MAPPING_CONFIGURER;
+
 import org.activiti.cloud.common.messaging.config.ActivitiMessagingDestinationTransformer;
+import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
 import org.activiti.engine.impl.event.EventSubscriptionPayloadMappingProvider;
 import org.activiti.runtime.api.impl.ExtensionsVariablesMappingProvider;
 import org.activiti.spring.boot.ProcessEngineAutoConfiguration;
@@ -27,8 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import static org.activiti.spring.boot.ProcessEngineAutoConfiguration.BEHAVIOR_FACTORY_MAPPING_CONFIGURER;
-
 @AutoConfigureBefore(ProcessEngineAutoConfiguration.class)
 @Configuration
 @Import(RuntimeBundleSwaggerConfig.class)
@@ -37,14 +38,10 @@ public class ActivitiCloudEngineAutoConfiguration {
     @Bean(BEHAVIOR_FACTORY_MAPPING_CONFIGURER)
     @ConditionalOnMissingBean(name = BEHAVIOR_FACTORY_MAPPING_CONFIGURER)
     public SignalBehaviourConfigurer signalBehaviourConfigurator(ApplicationContext applicationContext,
-                                                                 ExtensionsVariablesMappingProvider variablesMappingProvider,
-                                                                 ProcessVariablesInitiator processVariablesInitiator,
-                                                                 EventSubscriptionPayloadMappingProvider eventSubscriptionPayloadMappingProvider
-    ) {
-        return new SignalBehaviourConfigurer(applicationContext,
-                                             variablesMappingProvider,
-                                             processVariablesInitiator,
-                                             eventSubscriptionPayloadMappingProvider);
+        ExtensionsVariablesMappingProvider variablesMappingProvider, ProcessVariablesInitiator processVariablesInitiator,
+        EventSubscriptionPayloadMappingProvider eventSubscriptionPayloadMappingProvider, VariablesPropagator variablesPropagator) {
+        return new SignalBehaviourConfigurer(applicationContext, variablesMappingProvider, processVariablesInitiator,
+            eventSubscriptionPayloadMappingProvider, variablesPropagator);
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/SignalBehaviourConfigurer.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/SignalBehaviourConfigurer.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.starter.rb.configuration;
 
 import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
+import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
 import org.activiti.engine.impl.event.EventSubscriptionPayloadMappingProvider;
 import org.activiti.runtime.api.impl.ExtensionsVariablesMappingProvider;
 import org.activiti.spring.SpringProcessEngineConfiguration;
@@ -29,25 +30,23 @@ public class SignalBehaviourConfigurer implements ProcessEngineConfigurationConf
     private ExtensionsVariablesMappingProvider variablesMappingProvider;
     private ProcessVariablesInitiator processVariablesInitiator;
     private EventSubscriptionPayloadMappingProvider eventSubscriptionPayloadMappingProvider;
+    private final VariablesPropagator variablesPropagator;
 
-    public SignalBehaviourConfigurer(ApplicationContext applicationContext,
-                                     ExtensionsVariablesMappingProvider variablesMappingProvider,
-                                     ProcessVariablesInitiator processVariablesInitiator,
-                                     EventSubscriptionPayloadMappingProvider eventSubscriptionPayloadMappingProvider
-    ) {
+    public SignalBehaviourConfigurer(ApplicationContext applicationContext, ExtensionsVariablesMappingProvider variablesMappingProvider,
+        ProcessVariablesInitiator processVariablesInitiator, EventSubscriptionPayloadMappingProvider eventSubscriptionPayloadMappingProvider,
+        VariablesPropagator variablesPropagator) {
         this.applicationContext = applicationContext;
         this.variablesMappingProvider = variablesMappingProvider;
         this.processVariablesInitiator = processVariablesInitiator;
         this.eventSubscriptionPayloadMappingProvider = eventSubscriptionPayloadMappingProvider;
+        this.variablesPropagator = variablesPropagator;
     }
 
     @Override
     public void configure(SpringProcessEngineConfiguration processEngineConfiguration) {
         processEngineConfiguration.setEventSubscriptionPayloadMappingProvider(eventSubscriptionPayloadMappingProvider);
 
-        processEngineConfiguration.setActivityBehaviorFactory(new CloudActivityBehaviorFactory(applicationContext,
-                                                                                               variablesMappingProvider,
-                                                                                               processVariablesInitiator
-        ));
+        processEngineConfiguration.setActivityBehaviorFactory(new CloudActivityBehaviorFactory(applicationContext, variablesMappingProvider,
+            processVariablesInitiator, variablesPropagator));
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import org.mockito.InjectMocks;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.messaging.SubscribableChannel;
 
@@ -25,6 +26,7 @@ public interface ConnectorIntegrationChannels {
     String VAR_MAPPING_INTEGRATION_EVENTS_CONSUMER = "varMappingIntegrationEventsConsumer";
     String CONSTANTS_INTEGRATION_EVENTS_CONSUMER = "constantsIntegrationEventsConsumer";
     String MEALS_CONNECTOR_CONSUMER  = "mealsConnectorConsumer";
+    String VALUE_PROCESSOR_CONSUMER = "valueProcessorConsumer";
 
     @Input(INTEGRATION_EVENTS_CONSUMER)
     SubscribableChannel integrationEventsConsumer();
@@ -40,5 +42,8 @@ public interface ConnectorIntegrationChannels {
 
     @Input(MEALS_CONNECTOR_CONSUMER)
     SubscribableChannel mealsConnectorConsumer();
+
+    @Input(VALUE_PROCESSOR_CONSUMER)
+    SubscribableChannel valueProcessorConsumer();
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -253,4 +253,11 @@ public class ServiceTaskConsumerHandler {
 
         sendIntegrationResult(integrationRequest, integrationContext);
     }
+
+    @StreamListener(value = ConnectorIntegrationChannels.VALUE_PROCESSOR_CONSUMER)
+    public void valueProcessorConnector(IntegrationRequest integrationRequest) {
+        IntegrationContext integrationContext = integrationRequest.getIntegrationContext();
+        integrationContext.addOutBoundVariable("providedValue", integrationContext.getInBoundVariable("input"));
+        sendIntegrationResult(integrationRequest, integrationContext);
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -48,6 +48,11 @@ spring.cloud.stream.bindings.restConnectorConsumer.destination=rest.GET
 spring.cloud.stream.bindings.restConnectorConsumer.group=integration
 spring.cloud.stream.bindings.restConnectorConsumer.contentType=application/json
 
+spring.cloud.stream.bindings.valueProcessorConsumer.destination=value-processor.process
+spring.cloud.stream.bindings.valueProcessorConsumer.group=integration
+spring.cloud.stream.bindings.valueProcessorConsumer.contentType=application/json
+
+
 activiti.keycloak.test-user=hruser
 activiti.keycloak.test-password=password
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/variable-mapping-with-loop-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/variable-mapping-with-loop-extensions.json
@@ -1,0 +1,50 @@
+{
+  "id": "process-fdee92a0-5a2b-48be-8696-245eff49aa07",
+  "type": "PROCESS",
+  "name": "variable-mapping-with-loop",
+  "extensions": {
+    "Process_N4qkN051N": {
+      "constants": {},
+      "mappings": {
+        "Task_0od1320": {
+          "outputs": {
+            "providedValue": {
+              "type": "variable",
+              "value": "providedValue"
+            }
+          },
+          "inputs": {
+            "input": {
+              "type": "variable",
+              "value": "providedValue"
+            }
+          }
+        },
+        "Task_125yjke": {
+          "outputs": {
+            "providedValue": {
+              "type": "variable",
+              "value": "formInput"
+            }
+          }
+        }
+      },
+      "properties": {
+        "e974d84d-aa76-4acb-903d-97582fe89861": {
+          "id": "e974d84d-aa76-4acb-903d-97582fe89861",
+          "name": "providedValue",
+          "type": "string",
+          "value": "",
+          "required": false
+        }
+      },
+      "assignments": {
+        "Task_125yjke": {
+          "type": "identity",
+          "assignment": "assignee",
+          "id": "Task_125yjke"
+        }
+      }
+    }
+  }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/variable-mapping-with-loop.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/variable-mapping-with-loop.bpmn20.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:activiti="http://activiti.org/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-fdee92a0-5a2b-48be-8696-245eff49aa07" name="variable-mapping-with-loop" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_N4qkN051N" name="variable-mapping-with-loop" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_1anr2ek</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1anr2ek" sourceRef="Event_1" targetRef="Task_125yjke" />
+    <bpmn2:userTask id="Task_125yjke" name="Enter values" activiti:formKey="form-29e73efe-5bd6-48c3-8c8d-598cb0ade731" activiti:assignee="hruser">
+      <bpmn2:incoming>SequenceFlow_1anr2ek</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_0g8zsg1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0urignn</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_0urignn" sourceRef="Task_125yjke" targetRef="Task_0od1320" />
+    <bpmn2:exclusiveGateway id="ExclusiveGateway_1mah1i8" default="SequenceFlow_0g8zsg1">
+      <bpmn2:incoming>SequenceFlow_03x97kf</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1xda66c</bpmn2:outgoing>
+      <bpmn2:outgoing>SequenceFlow_0g8zsg1</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:sequenceFlow id="SequenceFlow_03x97kf" sourceRef="Task_0od1320" targetRef="ExclusiveGateway_1mah1i8" />
+    <bpmn2:endEvent id="EndEvent_12fyn3x">
+      <bpmn2:incoming>SequenceFlow_1b0cog0</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1xda66c" sourceRef="ExclusiveGateway_1mah1i8" targetRef="UserTask_11es6fr">
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression">${(providedValue eq "go")}</bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="SequenceFlow_0g8zsg1" name="loop back" sourceRef="ExclusiveGateway_1mah1i8" targetRef="Task_125yjke" />
+    <bpmn2:serviceTask id="Task_0od1320" name="Process values" implementation="value-processor.process">
+      <bpmn2:incoming>SequenceFlow_0urignn</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_03x97kf</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:userTask id="UserTask_11es6fr" name="Wait" activiti:assignee="hruser" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_1xda66c</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1b0cog0</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1b0cog0" sourceRef="UserTask_11es6fr" targetRef="EndEvent_12fyn3x" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_N4qkN051N">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="142" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1anr2ek_di" bpmnElement="SequenceFlow_1anr2ek">
+        <di:waypoint x="178" y="230" />
+        <di:waypoint x="280" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_15oxjtp_di" bpmnElement="Task_125yjke">
+        <dc:Bounds x="280" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0urignn_di" bpmnElement="SequenceFlow_0urignn">
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="440" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1mah1i8_di" bpmnElement="ExclusiveGateway_1mah1i8" isMarkerVisible="true">
+        <dc:Bounds x="605" y="205" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_03x97kf_di" bpmnElement="SequenceFlow_03x97kf">
+        <di:waypoint x="540" y="230" />
+        <di:waypoint x="605" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_12fyn3x_di" bpmnElement="EndEvent_12fyn3x">
+        <dc:Bounds x="882" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1xda66c_di" bpmnElement="SequenceFlow_1xda66c">
+        <di:waypoint x="655" y="230" />
+        <di:waypoint x="740" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g8zsg1_di" bpmnElement="SequenceFlow_0g8zsg1">
+        <di:waypoint x="630" y="205" />
+        <di:waypoint x="630" y="110" />
+        <di:waypoint x="330" y="110" />
+        <di:waypoint x="330" y="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="459" y="92" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0k1gbu2_di" bpmnElement="Task_0od1320">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_11es6fr_di" bpmnElement="UserTask_11es6fr">
+        <dc:Bounds x="740" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1b0cog0_di" bpmnElement="SequenceFlow_1b0cog0">
+        <di:waypoint x="840" y="230" />
+        <di:waypoint x="882" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>7.1.356</activiti.version>
+    <activiti.version>7.1.357</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>7.1.356</activiti.version>
+    <activiti.version>7.1.357</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Simplify the propagation logic and make it consistent for user tasks, service tasks and call activities:
- Execution variables are only set in the context of a multi-instance, so that they can be collected into the result collection by the execution of the multi-instance root
- In other cases, task variables, connector outputs and subprocess variables (from call activities) are updating directly the process instance variables based on the defined mapping

Possible side effects:
- previously connector outputs were made available to the current execution even in the case where no mapping was defined, meaning that connector outputs could be directly used in sequence flow expressions. After this change this will be no longer the case. In order to be able to use connector outputs in further expressions you'll need to define a mapping for it (either explicit or using one of `MAP_ALL_OUTPUTS` or `MAP_ALL` options).

Ref https://github.com/Activiti/Activiti/issues/3787

Depends on https://github.com/Activiti/Activiti/pull/3799