### PR TITLE
fix(GH-3814): add subject and from properties in the process extensions json schema 

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>7.1.362</activiti.version>
+    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.363</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
@@ -5,8 +5,8 @@
       "templates": {
         "tasks": {
           "Task1": {
-            "from": "no-reply@activiti.org",
             "assignee": {
+              "from": "no-reply@activiti.org",
               "subject": "Task1 assignee subject",
               "type": "file",
               "value": "file://c/project/email.html"
@@ -22,6 +22,7 @@
               "value": "file1"
             },
             "candidate": {
+              "from": "no-reply@activiti.org",
               "subject": "Task2 assignee subject",
               "type": "variable",
               "value": "candidateTemplate"
@@ -29,13 +30,14 @@
           }
         },
         "default": {
-          "from": "no-reply@activiti.org",
           "assignee": {
+            "from": "no-reply@activiti.org",
             "subject": "Default assignee subject",
             "type": "file",
             "value": "classpath:email.html"
           },
           "candidate": {
+            "from": "no-reply@activiti.org",
             "subject": "Default candidate subject",
             "type": "variable",
             "value": "candidateTemplate"

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process-extensions/valid-templates-extensions.json
@@ -5,7 +5,9 @@
       "templates": {
         "tasks": {
           "Task1": {
+            "from": "no-reply@activiti.org",
             "assignee": {
+              "subject": "Task1 assignee subject",
               "type": "file",
               "value": "file://c/project/email.html"
             },
@@ -20,17 +22,21 @@
               "value": "file1"
             },
             "candidate": {
+              "subject": "Task2 assignee subject",
               "type": "variable",
               "value": "candidateTemplate"
             }
           }
         },
         "default": {
+          "from": "no-reply@activiti.org",
           "assignee": {
+            "subject": "Default assignee subject",
             "type": "file",
             "value": "classpath:email.html"
           },
           "candidate": {
+            "subject": "Default candidate subject",
             "type": "variable",
             "value": "candidateTemplate"
           }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -44,9 +44,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "from": {
-          "type": "string"
-        },
         "assignee" : {"$ref" :  "#/definitions/template"},
         "candidate" : {"$ref" :  "#/definitions/template"}
       }
@@ -55,6 +52,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "from": {
+          "type": "string"
+        },
         "subject": {
           "type": "string"
         },

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -44,6 +44,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "from": {
+          "type": "string"
+        },
         "assignee" : {"$ref" :  "#/definitions/template"},
         "candidate" : {"$ref" :  "#/definitions/template"}
       }
@@ -52,6 +55,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "subject": {
+          "type": "string"
+        },
         "type": {
           "type": "string",
           "enum": [

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.363</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>7.1.362</activiti.version>
+    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.12.2</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>7.1.362</activiti.version>
+    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.363</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.363</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>7.1.362</activiti.version>
+    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>7.1.362</activiti.version>
+    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-375-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3813-376-SNAPSHOT</activiti.version>
+    <activiti.version>7.1.363</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
This PR extends process extensions json with From and Subject properties to be able to customize task notification emails in the Modeler, i.e.

```
    "template": {
      "type": "object",
      "additionalProperties": false,
      "properties": {
        "from": {
          "type": "string"
        },
        "subject": {
          "type": "string"
        },
        "type": {
          "type": "string",
          "enum": [
            "file",
            "variable"
          ]
        },
        "value": {
          "type": "string"
        }
      },
      "required": [
        "type",
        "value"
      ]
    },
```

Part of https://github.com/Activiti/Activiti/issues/3814