### PR TITLE
Activiti/Activiti#3834 Centralize keycloak configuration into security module

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/resources/application.properties
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/resources/application.properties
@@ -7,8 +7,8 @@ spring.cloud.stream.bindings.auditConsumer.group=audit
 spring.cloud.stream.bindings.auditConsumer.contentType=application/json
 spring.jackson.serialization.fail-on-unwrapped-type-identifiers=false
 
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password
+activiti.identity.test-user=testuser
+activiti.identity.test-password=password
 
 keycloak.security-constraints[0].authRoles[0]=ACTIVITI_USER
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/application.properties
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/application.properties
@@ -1,4 +1,1 @@
 spring.main.banner-mode=off
-
-activiti.keycloak.client-id=activiti-keycloak
-activiti.keycloak.client-secret=dummy

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-juel/src/test/resources/application.properties
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-juel/src/test/resources/application.properties
@@ -5,14 +5,3 @@ keycloak.security-constraints[0].authRoles[0]=ACTIVITI_USER
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 keycloak.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 keycloak.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
-
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password
-
-activiti.keycloak.client-id=activiti-keycloak
-activiti.keycloak.client-secret=dummy
-
-keycloak.auth-server-url=http://localhost:8180/auth
-keycloak.realm=activiti
-keycloak.resource=activiti
-keycloak.public-client=true

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/resources/application.properties
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/resources/application.properties
@@ -4,9 +4,3 @@ keycloak.security-constraints[0].authRoles[0]=ACTIVITI_USER
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 keycloak.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 keycloak.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
-
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password
-
-activiti.keycloak.client-id=activiti-keycloak
-activiti.keycloak.client-secret=dummy

--- a/activiti-cloud-notifications-graphql-service/services/security/src/test/resources/application.properties
+++ b/activiti-cloud-notifications-graphql-service/services/security/src/test/resources/application.properties
@@ -1,2 +1,0 @@
-activiti.keycloak.client-id=activiti-keycloak
-activiti.keycloak.client-secret=dummy

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/resources/application.properties
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/resources/application.properties
@@ -8,6 +8,6 @@ spring.jpa.defer-datasource-initialization=true
 #activiti.cloud.security.user.testuser.mock-app-name.policy.read=defKey1
 #activiti.cloud.security.user.hruser.mock-app-name.policy.read=defKey2
 
-activiti.keycloak.test-user=testadmin
-activiti.keycloak.test-password=password
+activiti.identity.test-user=testadmin
+activiti.identity.test-password=password
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/resources/application-test.properties
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/resources/application-test.properties
@@ -5,8 +5,8 @@ spring.cloud.stream.bindings.myCmdResults.contentType=application/json
 spring.cloud.stream.bindings.myCmdProducer.destination=commandConsumer
 spring.cloud.stream.bindings.myCmdProducer.contentType=application/json
 keycloak.auth-server-url=http://localhost:8180/auth
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password
+activiti.identity.test-user=testuser
+activiti.identity.test-password=password
 
 
 activiti.security.policies[0].name=Test user on defKey1

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test-admin.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test-admin.properties
@@ -17,5 +17,5 @@ keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 keycloak.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 keycloak.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
 
-activiti.keycloak.test-user=testadmin
-activiti.keycloak.test-password=password
+activiti.identity.test-user=testadmin
+activiti.identity.test-password=password

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
@@ -17,5 +17,5 @@ keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 keycloak.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 keycloak.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
 
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password
+activiti.identity.test-user=testuser
+activiti.identity.test-password=password

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/resources/application.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/resources/application.properties
@@ -12,8 +12,8 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password="
 
-activiti.keycloak.test-user=hruser
-activiti.keycloak.test-password=password
+activiti.identity.test-user=hruser
+activiti.identity.test-password=password
 
 keycloak.security-constraints[0].authRoles[0]=ACTIVITI_USER
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -81,7 +81,7 @@ public abstract class AbstractMQServiceTaskIT {
     @Autowired
     protected BindingServiceProperties bindingServiceProperties;
 
-    @Value("${activiti.keycloak.test-user:hruser}")
+    @Value("${activiti.identity.test-user:hruser}")
     protected String keycloakTestUser;
 
     @BeforeEach

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -79,7 +79,7 @@ public class ProcessInstanceIT {
     @Autowired
     private ProcessDefinitionRestTemplate processDefinitionRestTemplate;
 
-    @Value("${activiti.keycloak.test-user}")
+    @Value("${activiti.identity.test-user}")
     protected String keycloakTestUser;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -67,7 +67,7 @@ public class TaskVariableMappingIT {
     @Autowired
     private VariablesUtil variablesUtil;
 
-    @Value("${activiti.keycloak.test-user:hruser}")
+    @Value("${activiti.identity.test-user:hruser}")
     protected String keycloakTestUser;
 
     @BeforeEach

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -142,7 +142,7 @@ public class AuditProducerIT {
     private static final String SIMPLE_PROCESS_CATEGORY = "test-category";
     private static final String PROCESS_DEFINITIONS_URL = "/v1/process-definitions/";
 
-    @Value("${activiti.keycloak.test-user}")
+    @Value("${activiti.identity.test-user}")
     protected String keycloakTestUser;
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -79,7 +79,7 @@ public class ConnectorAuditProducerIT {
 
     public static final String AUDIT_PRODUCER_IT = "AuditProducerIT";
 
-    @Value("${activiti.keycloak.test-user}")
+    @Value("${activiti.identity.test-user}")
     protected String keycloakTestUser;
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -100,7 +100,7 @@ public class EmbeddedSubProcessAuditIT {
 
     private static final String PROCESS_DEFINITIONS_URL = "/v1/process-definitions/";
 
-    @Value("${activiti.keycloak.test-user}")
+    @Value("${activiti.identity.test-user}")
     protected String keycloakTestUser;
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -53,8 +53,8 @@ spring.cloud.stream.bindings.valueProcessorConsumer.group=integration
 spring.cloud.stream.bindings.valueProcessorConsumer.contentType=application/json
 
 
-activiti.keycloak.test-user=hruser
-activiti.keycloak.test-password=password
+activiti.identity.test-user=hruser
+activiti.identity.test-password=password
 
 keycloak.security-constraints[0].authRoles[0]=ACTIVITI_USER
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=/v1/*

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/resources/keycloak-configuration.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/resources/keycloak-configuration.properties
@@ -7,8 +7,5 @@ keycloak.cors=true
 keycloak.principal-attribute=preferred-username
 
 activiti.keycloak.client-id=activiti-keycloak
-activiti.keycloak.client-secret=545bc187-f10f-41f9-8d5f-cfca3dbada9c",
+activiti.keycloak.client-secret=545bc187-f10f-41f9-8d5f-cfca3dbada9c"
 activiti.keycloak.grant-type=client_credentials
-
-activiti.keycloak.test-user=testuser
-activiti.keycloak.test-password=password

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/resources/keycloak-configuration.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/resources/keycloak-configuration.properties
@@ -5,3 +5,10 @@ keycloak.ssl-required=${ACT_KEYCLOAK_SSL_REQUIRED:none}
 keycloak.public-client=${ACT_KEYCLOAK_CLIENT:true}
 keycloak.cors=true
 keycloak.principal-attribute=preferred-username
+
+activiti.keycloak.client-id=activiti-keycloak
+activiti.keycloak.client-secret=545bc187-f10f-41f9-8d5f-cfca3dbada9c",
+activiti.keycloak.grant-type=client_credentials
+
+activiti.keycloak.test-user=testuser
+activiti.keycloak.test-password=password

--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/identity/keycloak/interceptor/KeycloakTokenProducer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/identity/keycloak/interceptor/KeycloakTokenProducer.java
@@ -38,10 +38,10 @@ public class KeycloakTokenProducer implements ClientHttpRequestInterceptor {
     @Value("${keycloak.resource:}")
     protected String resource;
 
-    @Value("${activiti.keycloak.test-user:}")
+    @Value("${activiti.identity.test-user:}")
     protected String keycloakTestUser;
 
-    @Value("${activiti.keycloak.test-password:}")
+    @Value("${activiti.identity.test-password:}")
     protected String keycloakTestPassword;
 
     public KeycloakTokenProducer(KeycloakProperties keycloakProperties) {


### PR DESCRIPTION
The following properties:
`activiti.keycloak.client-id`
`activiti.keycloak.client-secret`
have been centralized into the existing keycloak security module.

The following ones:
`activiti.keycloak.test-user=testuser`
`activiti.keycloak.test-password=password`
have been renamed to a more abstract, non-keycloak related, name, since they are used only internally