### PR TITLE
Exclude unneeded spring-cloud-function-deployer from rabbit binder

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-starter/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-starter/pom.xml
@@ -26,6 +26,12 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.cloud</groupId>
+          <artifactId>spring-cloud-function-deployer</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Exclude transitive dependency spring-cloud-function-deployer which is not needed when not using the binder as an app runner and brings also maven as additional dependency in the app