### PR TITLE
fix(AAE-7872): EntityExistsException in BPMNActivityStartedEventHandler

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/BPMNActivityEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/BPMNActivityEntity.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import javax.persistence.Entity;
 import javax.persistence.Index;
 import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity(name="BPMNActivity")
 @Table(name="BPMN_ACTIVITY", indexes={
@@ -57,5 +58,27 @@ public class BPMNActivityEntity extends BaseBPMNActivityEntity implements CloudB
                                       .append(bpmnActivity.getExecutionId())
                                       .toString();
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        BPMNActivityEntity other = (BPMNActivityEntity) obj;
+
+        return getId() != null && Objects.equals(getId(), other.getId());
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -40,7 +40,7 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
 
-        entityManager.persist(bpmnActivityEntity);
+        entityManager.merge(bpmnActivityEntity);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -21,6 +21,7 @@ import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
 import org.activiti.cloud.services.query.model.BaseBPMNActivityEntity;
 
+import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import java.util.Date;
 
@@ -40,10 +41,10 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
 
-        if (entityManager.contains(bpmnActivityEntity)) {
-            entityManager.merge(bpmnActivityEntity);
-        } else {
+        try {
             entityManager.persist(bpmnActivityEntity);
+        } catch (EntityExistsException e) {
+            entityManager.merge(bpmnActivityEntity);
         }
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -21,7 +21,6 @@ import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent;
 import org.activiti.cloud.services.query.model.BaseBPMNActivityEntity;
 
-import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import java.util.Date;
 
@@ -35,17 +34,14 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
     public void handle(CloudRuntimeEvent<?, ?> event) {
         CloudBPMNActivityStartedEvent activityEvent = CloudBPMNActivityStartedEvent.class.cast(event);
 
-        BaseBPMNActivityEntity bpmnActivityEntity = createBpmnActivityEntity(event);
+        BaseBPMNActivityEntity bpmnActivityEntity = findOrCreateBPMNActivityEntity(event);
 
         // Activity can be cyclical, so we just update the status and started date anyways
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
+        bpmnActivityEntity.setCompletedDate(null);
         bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
 
-        try {
-            entityManager.persist(bpmnActivityEntity);
-        } catch (EntityExistsException e) {
-            entityManager.merge(bpmnActivityEntity);
-        }
+        entityManager.persist(bpmnActivityEntity);
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/BPMNActivityStartedEventHandler.java
@@ -40,7 +40,11 @@ public class BPMNActivityStartedEventHandler extends BaseBPMNActivityEventHandle
         bpmnActivityEntity.setStartedDate(new Date(activityEvent.getTimestamp()));
         bpmnActivityEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
 
-        entityManager.merge(bpmnActivityEntity);
+        if (entityManager.contains(bpmnActivityEntity)) {
+            entityManager.merge(bpmnActivityEntity);
+        } else {
+            entityManager.persist(bpmnActivityEntity);
+        }
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.starter.tests;
+
+import org.activiti.api.runtime.model.impl.BPMNActivityImpl;
+import org.activiti.api.runtime.model.impl.BPMNSequenceFlowImpl;
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
+import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCompletedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityStartedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudSequenceFlowTakenEventImpl;
+import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
+import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
+import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
+import org.activiti.cloud.services.query.model.BPMNActivityEntity;
+import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
+import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
+import org.activiti.cloud.starters.test.EventsAggregator;
+import org.activiti.cloud.starters.test.MyProducer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource("classpath:application-test.properties")
+@DirtiesContext
+@ContextConfiguration(initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
+public class QueryBPMNActivityIT {
+
+    private static final String PROC_URL = "/v1/process-instances";
+
+    @Autowired
+    private IdentityTokenProducer identityTokenProducer;
+
+    @Autowired
+    private ProcessDefinitionRepository processDefinitionRepository;
+
+    @Autowired
+    private ProcessModelRepository processModelRepository;
+
+    @Autowired
+    private ProcessInstanceRepository processInstanceRepository;
+
+    @Autowired
+    private BPMNActivityRepository bpmnActivityRepository;
+
+    @Autowired
+    private BPMNSequenceFlowRepository bpmnSequenceFlowRepository;
+
+    @Autowired
+    private MyProducer producer;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private String processDefinitionId = UUID.randomUUID().toString();
+
+    private String processDefinitionId2 = UUID.randomUUID().toString();
+
+    private EventsAggregator eventsAggregator;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        identityTokenProducer.setTestUser("hruser");
+
+        eventsAggregator = new EventsAggregator(producer);
+
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId(processDefinitionId2);
+        processDefinition.setKey("mySimpleProcess2");
+        processDefinition.setName("My Simple Process");
+
+        CloudProcessDeployedEventImpl processDeployedEvent = new CloudProcessDeployedEventImpl(processDefinition);
+        processDeployedEvent.setProcessModelContent(new String(Files.readAllBytes(Paths.get("src/test/resources/parse-for-test/SimpleProcessWithoutDiagram.bpmn20.xml")),
+                                                                     StandardCharsets.UTF_8));
+
+        producer.send(processDeployedEvent);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        processModelRepository.deleteAll();
+        processDefinitionRepository.deleteAll();
+        processInstanceRepository.deleteAll();
+        bpmnActivityRepository.deleteAll();
+        bpmnSequenceFlowRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldHandleCyclicalBPMNActivityEvents() throws InterruptedException {
+        //given
+        ProcessInstanceImpl process = new ProcessInstanceImpl();
+        process.setId(UUID.randomUUID().toString());
+        process.setName("process");
+        process.setProcessDefinitionKey("mySimpleProcess2");
+        process.setProcessDefinitionId(processDefinitionId2);
+        process.setProcessDefinitionVersion(1);
+
+        BPMNActivityImpl startActivity = new BPMNActivityImpl("startEvent1", "", "startEvent");
+        startActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        startActivity.setProcessInstanceId(process.getId());
+        startActivity.setExecutionId("executionId");
+
+        BPMNSequenceFlowImpl sequenceFlow = new BPMNSequenceFlowImpl("sid-68945AF1-396F-4B8A-B836-FC318F62313F", "startEvent1", "sid-CDFE7219-4627-43E9-8CA8-866CC38EBA94");
+        sequenceFlow.setProcessDefinitionId(process.getProcessDefinitionId());
+        sequenceFlow.setProcessInstanceId(process.getId());
+
+        BPMNActivityImpl taskActivity = new BPMNActivityImpl("sid-CDFE7219-4627-43E9-8CA8-866CC38EBA94", "Perform Action", "userTask");
+        taskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        taskActivity.setProcessInstanceId(process.getId());
+        taskActivity.setExecutionId("executionId");
+
+        eventsAggregator.addEvents(new CloudProcessCreatedEventImpl(process),
+                                   new CloudProcessStartedEventImpl(process, null, null),
+                                   new CloudBPMNActivityStartedEventImpl(startActivity, processDefinitionId, process.getId()),
+                                   new CloudBPMNActivityCompletedEventImpl(startActivity, processDefinitionId, process.getId()),
+                                   new CloudSequenceFlowTakenEventImpl(sequenceFlow),
+                                   new CloudBPMNActivityStartedEventImpl(taskActivity, processDefinitionId, process.getId()),
+                                   new CloudBPMNActivityCompletedEventImpl(taskActivity, processDefinitionId, process.getId())
+        );
+
+        //when
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+            List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+            assertThat(activities).hasSize(2);
+            assertThat(activities).extracting(BPMNActivityEntity::getElementId, BPMNActivityEntity::getActivityType,  BPMNActivityEntity::getStatus)
+                                  .containsExactly(tuple(startActivity.getElementId(),startActivity.getActivityType(), BPMNActivityEntity.BPMNActivityStatus.COMPLETED),
+                                                   tuple(taskActivity.getElementId(),taskActivity.getActivityType(), BPMNActivityEntity.BPMNActivityStatus.COMPLETED));
+        });
+
+        BPMNActivityImpl restartTaskActivity = new BPMNActivityImpl("sid-CDFE7219-4627-43E9-8CA8-866CC38EBA94", "Perform Action", "userTask");
+        restartTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        restartTaskActivity.setProcessInstanceId(process.getId());
+        restartTaskActivity.setExecutionId("executionId");
+
+        eventsAggregator.addEvents(new CloudBPMNActivityStartedEventImpl(taskActivity, processDefinitionId, process.getId()));
+
+        eventsAggregator.sendAll();
+
+        await().untilAsserted(() -> {
+            List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+            assertThat(activities).hasSize(2);
+            assertThat(activities).extracting(BPMNActivityEntity::getElementId, BPMNActivityEntity::getActivityType,  BPMNActivityEntity::getStatus)
+                                  .containsExactly(tuple(startActivity.getElementId(),startActivity.getActivityType(), BPMNActivityEntity.BPMNActivityStatus.COMPLETED),
+                                                   tuple(taskActivity.getElementId(),taskActivity.getActivityType(), BPMNActivityEntity.BPMNActivityStatus.STARTED));
+        });
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -62,8 +61,6 @@ import static org.awaitility.Awaitility.await;
 @DirtiesContext
 @ContextConfiguration(initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class})
 public class QueryBPMNActivityIT {
-
-    private static final String PROC_URL = "/v1/process-instances";
 
     @Autowired
     private IdentityTokenProducer identityTokenProducer;
@@ -86,12 +83,7 @@ public class QueryBPMNActivityIT {
     @Autowired
     private MyProducer producer;
 
-    @Autowired
-    private TestRestTemplate testRestTemplate;
-
     private String processDefinitionId = UUID.randomUUID().toString();
-
-    private String processDefinitionId2 = UUID.randomUUID().toString();
 
     private EventsAggregator eventsAggregator;
 
@@ -102,7 +94,7 @@ public class QueryBPMNActivityIT {
         eventsAggregator = new EventsAggregator(producer);
 
         ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
-        processDefinition.setId(processDefinitionId2);
+        processDefinition.setId(processDefinitionId);
         processDefinition.setKey("mySimpleProcess2");
         processDefinition.setName("My Simple Process");
 
@@ -129,7 +121,7 @@ public class QueryBPMNActivityIT {
         process.setId(UUID.randomUUID().toString());
         process.setName("process");
         process.setProcessDefinitionKey("mySimpleProcess2");
-        process.setProcessDefinitionId(processDefinitionId2);
+        process.setProcessDefinitionId(processDefinitionId);
         process.setProcessDefinitionVersion(1);
 
         BPMNActivityImpl startActivity = new BPMNActivityImpl("startEvent1", "", "startEvent");


### PR DESCRIPTION
This PR fixes EntityExistsException runtime exception in Query BPMNActivityStartedEventHandler due to cyclical task sequence flow, i.e. `Employee1 -> Employee Review -> Employee1 -> Employee Review (EntityExistsException)`

![image](https://user-images.githubusercontent.com/20428629/158111618-4a25c1cd-abfb-4ac4-87aa-95fef59c7067.png)
