### PR TITLE
fix: handle loops involving service tasks

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/resources/application.properties
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/resources/application.properties
@@ -15,4 +15,4 @@ authorizations.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 authorizations.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 authorizations.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
 
-spring.jpa.properties.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.generate_statistics=false

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
@@ -42,13 +42,18 @@ public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandle
         IntegrationContext integrationContext = integrationEvent.getEntity();
         String entityId = IntegrationContextEntity.IdBuilderHelper.from(integrationContext);
 
-        IntegrationContextEntity entity = new IntegrationContextEntity(event.getServiceName(),
-                                                                       event.getServiceFullName(),
-                                                                       event.getServiceVersion(),
-                                                                       event.getAppName(),
-                                                                       event.getAppVersion());
-        entity.setId(entityId);
-        entity.setClientId(integrationContext.getClientId());
+
+        // Activity can be cyclical, so try to find existing before creating a new one
+        IntegrationContextEntity entity = entityManager.find(IntegrationContextEntity.class, entityId);
+        if (entity == null) {
+            entity = new IntegrationContextEntity(event.getServiceName(),
+                event.getServiceFullName(),
+                event.getServiceVersion(),
+                event.getAppName(),
+                event.getAppVersion());
+            entity.setId(entityId);
+            entity.setClientId(integrationContext.getClientId());
+        }
         entity.setClientName(integrationContext.getClientName());
         entity.setClientType(integrationContext.getClientType());
         entity.setConnectorType(integrationContext.getConnectorType());

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application.properties
@@ -28,6 +28,6 @@ authorizations.security-constraints[0].securityCollections[0].patterns[0]=/v1/*
 authorizations.security-constraints[1].authRoles[0]=ACTIVITI_ADMIN
 authorizations.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
 
-spring.jpa.properties.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.generate_statistics=false
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false


### PR DESCRIPTION
Solves EntityExistsException while query service is handling INTEGRATION_REQUESTED event after a cycle in the process.

Fixes https://github.com/Activiti/Activiti/issues/3886