### PR TITLE
[AAE-7855] variables in process definition

### DIFF
--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessRuntimeBundleSteps.java
@@ -15,19 +15,7 @@
  */
 package org.activiti.cloud.acc.core.steps.runtime;
 
-import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
-import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
-import java.util.stream.Collectors;
 import net.thucydides.core.annotations.Step;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -51,6 +39,20 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
+import static org.activiti.cloud.acc.core.helper.SvgToPng.svgToPng;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableRuntimeFeignContext
 public class ProcessRuntimeBundleSteps {
@@ -222,7 +224,7 @@ public class ProcessRuntimeBundleSteps {
 
     @Step
     public Collection<ProcessDefinition> getProcessDefinitions(){
-        return processDefinitionsApiClient.getProcessDefinitions(DEFAULT_PAGEABLE)
+        return processDefinitionsApiClient.getProcessDefinitions(List.of(), DEFAULT_PAGEABLE)
             .getContent()
             .stream()
             .map(EntityModel::getContent)

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudProcessDefinitionImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudProcessDefinitionImpl.java
@@ -18,12 +18,12 @@ package org.activiti.cloud.api.process.model.impl;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.VariableDefinition;
 import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
-import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implements CloudProcessDefinition {
+public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implements ExtendedCloudProcessDefinition {
 
     private String id;
     private String name;
@@ -46,7 +46,6 @@ public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implement
         version = processDefinition.getVersion();
         formKey = processDefinition.getFormKey();
         category = processDefinition.getCategory();
-        variableDefinitions = processDefinition.getVariableDefinitions();
     }
 
     @Override

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudProcessDefinitionImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/CloudProcessDefinitionImpl.java
@@ -16,8 +16,12 @@
 package org.activiti.cloud.api.process.model.impl;
 
 import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.VariableDefinition;
 import org.activiti.cloud.api.model.shared.impl.CloudRuntimeEntityImpl;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implements CloudProcessDefinition {
 
@@ -28,6 +32,7 @@ public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implement
     private int version;
     private String formKey;
     private String category;
+    private List<VariableDefinition> variableDefinitions = new ArrayList<>();
 
     public CloudProcessDefinitionImpl() {
     }
@@ -41,6 +46,7 @@ public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implement
         version = processDefinition.getVersion();
         formKey = processDefinition.getFormKey();
         category = processDefinition.getCategory();
+        variableDefinitions = processDefinition.getVariableDefinitions();
     }
 
     @Override
@@ -104,5 +110,14 @@ public class CloudProcessDefinitionImpl extends CloudRuntimeEntityImpl implement
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    @Override
+    public List<VariableDefinition> getVariableDefinitions() {
+        return variableDefinitions;
+    }
+
+    public void setVariableDefinitions(List<VariableDefinition> variableDefinitions) {
+        this.variableDefinitions = variableDefinitions;
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudProcessDefinition.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudProcessDefinition.java
@@ -16,8 +16,16 @@
 package org.activiti.cloud.api.process.model;
 
 import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.VariableDefinition;
 import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
 
+import java.util.List;
+
 public interface CloudProcessDefinition extends CloudRuntimeEntity, ProcessDefinition {
+
+    @Override
+    default List<VariableDefinition> getVariableDefinitions() {
+        return List.of();
+    }
 
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ExtendedCloudProcessDefinition.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ExtendedCloudProcessDefinition.java
@@ -15,9 +15,12 @@
  */
 package org.activiti.cloud.api.process.model;
 
-import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
+import org.activiti.api.process.model.VariableDefinition;
 
-public interface CloudProcessDefinition extends CloudRuntimeEntity, ProcessDefinition {
+import java.util.List;
+
+public interface ExtendedCloudProcessDefinition extends CloudProcessDefinition {
+
+    List<VariableDefinition> getVariableDefinitions();
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>activiti-spring-connector</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti</groupId>
+      <artifactId>activiti-spring-process-extensions</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-api</artifactId>
     </dependency>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.runtime.ProcessRuntime;
+import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
+
+import java.util.List;
+
+public class ProcessDefinitionService {
+
+    private final ProcessRuntime processRuntime;
+    private final List<ProcessDefinitionDecorator> processDefinitionDecorators;
+
+    public ProcessDefinitionService(ProcessRuntime processRuntime, List<ProcessDefinitionDecorator> processDefinitionDecorators) {
+        this.processRuntime = processRuntime;
+        this.processDefinitionDecorators = processDefinitionDecorators;
+    }
+
+    public Page<ProcessDefinition> getProcessDefinitions(Pageable pageable, List<String> include) {
+        Page<ProcessDefinition> processDefinitions = processRuntime.processDefinitions(pageable);
+        processDefinitions.getContent().replaceAll(processDefinition -> decorateAll(processDefinition, include));
+        return processDefinitions;
+    }
+
+    private ExtendedCloudProcessDefinition decorateAll(ProcessDefinition processDefinition, List<String> include) {
+        ExtendedCloudProcessDefinition decoratedProcessDefinition = new CloudProcessDefinitionImpl(processDefinition);
+        for (String param : include) {
+            decoratedProcessDefinition = decorate(decoratedProcessDefinition, param);
+        }
+        return decoratedProcessDefinition;
+    }
+
+    private ExtendedCloudProcessDefinition decorate(ExtendedCloudProcessDefinition processDefinition, String includeParam) {
+        return processDefinitionDecorators.stream()
+            .filter(decorator -> decorator.applies(includeParam))
+            .findFirst()
+            .map(decorator -> decorator.decorate(processDefinition))
+            .orElse(processDefinition);
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -17,13 +17,11 @@ package org.activiti.cloud.services.core.conf;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 import org.activiti.api.model.shared.Payload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.services.core.ProcessDefinitionService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.ProcessVariableDateConverter;
 import org.activiti.cloud.services.core.ProcessVariableJsonNodeConverter;
@@ -46,6 +44,8 @@ import org.activiti.cloud.services.core.commands.StartMessageCmdExecutor;
 import org.activiti.cloud.services.core.commands.StartProcessInstanceCmdExecutor;
 import org.activiti.cloud.services.core.commands.SuspendProcessInstanceCmdExecutor;
 import org.activiti.cloud.services.core.commands.UpdateTaskVariableCmdExecutor;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionVariablesDecorator;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.core.pageable.sort.ProcessDefinitionSortApplier;
 import org.activiti.cloud.services.core.pageable.sort.ProcessInstanceSortApplier;
@@ -53,6 +53,7 @@ import org.activiti.cloud.services.core.pageable.sort.TaskSortApplier;
 import org.activiti.common.util.DateFormatterProvider;
 import org.activiti.image.ProcessDiagramGenerator;
 import org.activiti.image.impl.DefaultProcessDiagramGenerator;
+import org.activiti.spring.process.CachingProcessExtensionService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.annotation.Bean;
@@ -60,6 +61,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
 import org.springframework.format.support.FormattingConversionService;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 @Configuration
 @PropertySource("classpath:config/command-endpoint-channels.properties")
@@ -222,4 +228,18 @@ public class ServicesCoreAutoConfiguration {
     public ProcessVariablesPayloadConverter processVariablesPayloadConverter(ProcessVariableValueConverter variableValueConverter) {
         return new ProcessVariablesPayloadConverter(variableValueConverter);
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionVariablesDecorator processDefinitionVariablesDecorator(CachingProcessExtensionService cachingProcessExtensionService) {
+        return new ProcessDefinitionVariablesDecorator(cachingProcessExtensionService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionService processDefinitionService(ProcessRuntime processRuntime,
+                                                             List<ProcessDefinitionDecorator> processDefinitionDecorators) {
+        return new ProcessDefinitionService(processRuntime, processDefinitionDecorators);
+    }
+
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionDecorator.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionDecorator.java
@@ -13,11 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.api.process.model;
+package org.activiti.cloud.services.core.decorator;
 
-import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.cloud.api.model.shared.CloudRuntimeEntity;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.apache.commons.lang3.StringUtils;
 
-public interface CloudProcessDefinition extends CloudRuntimeEntity, ProcessDefinition {
+public interface ProcessDefinitionDecorator {
+
+    String getHandledValue();
+
+    ExtendedCloudProcessDefinition decorate(ExtendedCloudProcessDefinition processDefinition);
+
+    default boolean applies(String include){
+        return StringUtils.equalsIgnoreCase(getHandledValue(), include);
+    }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionVariablesDecorator.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionVariablesDecorator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core.decorator;
+
+import org.activiti.api.runtime.model.impl.VariableDefinitionImpl;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.spring.process.CachingProcessExtensionService;
+import org.activiti.spring.process.model.VariableDefinition;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ProcessDefinitionVariablesDecorator implements ProcessDefinitionDecorator {
+
+    private static final String HANDLED_VALUE = "variables";
+
+    private final CachingProcessExtensionService processExtensionService;
+
+    public ProcessDefinitionVariablesDecorator(CachingProcessExtensionService processExtensionService) {
+        this.processExtensionService = processExtensionService;
+    }
+
+    @Override
+    public String getHandledValue() {
+        return HANDLED_VALUE;
+    }
+
+    @Override
+    public ExtendedCloudProcessDefinition decorate(ExtendedCloudProcessDefinition processDefinition) {
+        Map<String, VariableDefinition> variables =
+            processExtensionService.getExtensionsForId(processDefinition.getId()).getProperties();
+        processDefinition.getVariableDefinitions().addAll(variables.values().stream()
+            .filter(variableDefinition -> Boolean.TRUE.equals(variableDefinition.getDisplay()))
+            .map(this::convert)
+            .collect(Collectors.toList()));
+        return processDefinition;
+    }
+
+    private org.activiti.api.process.model.VariableDefinition convert(VariableDefinition variableDefinition) {
+        VariableDefinitionImpl variableDefinitionImpl = new VariableDefinitionImpl();
+        variableDefinitionImpl.setId(variableDefinition.getId());
+        variableDefinitionImpl.setName(variableDefinition.getName());
+        variableDefinitionImpl.setDescription(variableDefinition.getDescription());
+        variableDefinitionImpl.setType(variableDefinition.getType());
+        variableDefinitionImpl.setRequired(variableDefinition.isRequired());
+        variableDefinitionImpl.setDisplay(variableDefinition.getDisplay());
+        variableDefinitionImpl.setDisplayName(variableDefinition.getDisplayName());
+        return variableDefinitionImpl;
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDefinitionServiceTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDefinitionServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.VariableDefinition;
+import org.activiti.api.process.runtime.ProcessRuntime;
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
+import org.activiti.api.runtime.model.impl.VariableDefinitionImpl;
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
+import org.activiti.runtime.api.query.impl.PageImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDefinitionServiceTest {
+
+    private final ProcessRuntime processRuntime = Mockito.mock(ProcessRuntime.class);
+
+    private final ProcessDefinitionDecorator processDefinitionDecorator = Mockito.mock(ProcessDefinitionDecorator.class);
+
+    private final ProcessDefinitionService processDefinitionService =
+        new ProcessDefinitionService(processRuntime, List.of(processDefinitionDecorator));
+
+    @Test
+    void should_getProcessDefinitionsWithVariables_whenIncludeVariablesParameterPresent() {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId("id");
+        ArrayList<ProcessDefinition> processDefinitions = new ArrayList<>();
+        processDefinitions.add(processDefinition);
+        when(processRuntime.processDefinitions(any()))
+            .thenReturn(new PageImpl<>(processDefinitions, 1));
+
+        VariableDefinitionImpl variableDefinition = new VariableDefinitionImpl();
+        when(processDefinitionDecorator.applies("variables")).thenReturn(true);
+        when(processDefinitionDecorator.decorate(argThat(argument -> argument.getId().equals(processDefinition.getId()))))
+            .thenAnswer(call -> {
+                CloudProcessDefinitionImpl cloudProcessDefinition = new CloudProcessDefinitionImpl(processDefinition);
+                cloudProcessDefinition.setVariableDefinitions(List.of(variableDefinition));
+                return cloudProcessDefinition;
+            });
+
+        List<ProcessDefinition> result =
+            processDefinitionService.getProcessDefinitions(Pageable.of(0, 50), List.of("variables")).getContent();
+
+        assertThat(result).hasSize(1);
+        List<VariableDefinition> variableDefinitions = ((ExtendedCloudProcessDefinition) result.get(0)).getVariableDefinitions();
+        assertThat(variableDefinitions).hasSize(1);
+        assertThat(variableDefinitions.get(0)).isEqualTo(variableDefinition);
+        verify(processDefinitionDecorator).decorate(argThat(argument -> argument.getId().equals(processDefinition.getId())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyIncludeVariables")
+    void should_getProcessDefinitionsWithVariables_whenIncludeVariablesParameterNotPresent(List<String> include) {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId("id");
+        ArrayList<ProcessDefinition> processDefinitions = new ArrayList<>();
+        processDefinitions.add(processDefinition);
+        when(processRuntime.processDefinitions(any()))
+            .thenReturn(new PageImpl<>(processDefinitions, 1));
+
+        lenient().when(processDefinitionDecorator.applies("variables")).thenReturn(true);
+
+        List<ProcessDefinition> result =
+            processDefinitionService.getProcessDefinitions(Pageable.of(0, 50), include).getContent();
+
+        assertThat(result).hasSize(1);
+        verify(processDefinitionDecorator, never()).decorate(any());
+    }
+
+    private static Stream<Arguments> emptyIncludeVariables() {
+        return Stream.of(Arguments.of(List.of()), Arguments.of(List.of("")), Arguments.of(List.of("other")));
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionVariablesDecoratorTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/decorator/ProcessDefinitionVariablesDecoratorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core.decorator;
+
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.activiti.spring.process.CachingProcessExtensionService;
+import org.activiti.spring.process.model.Extension;
+import org.activiti.spring.process.model.VariableDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDefinitionVariablesDecoratorTest {
+
+    @InjectMocks
+    private ProcessDefinitionVariablesDecorator processDefinitionVariablesDecorator;
+
+    @Mock
+    private CachingProcessExtensionService processExtensionService;
+
+    @ParameterizedTest
+    @CsvSource({"variables, true", "VARIABLES, true", "else, false"})
+    void should_applyToVariablesParam(String includeParam, boolean shouldApply) {
+        boolean applies = processDefinitionVariablesDecorator.applies(includeParam);
+        assertThat(applies).isEqualTo(shouldApply);
+    }
+
+    @Test
+    void should_decorateProcessDefinitions() {
+        CloudProcessDefinitionImpl givenProcessDefinition = new CloudProcessDefinitionImpl();
+        givenProcessDefinition.setId("PROC_ID");
+        Extension extension = new Extension();
+        VariableDefinition givenVariableDefinition = new VariableDefinition();
+        givenVariableDefinition.setId("VAR_ID");
+        givenVariableDefinition.setName("var1");
+        givenVariableDefinition.setDescription("Variable no 1");
+        givenVariableDefinition.setType("string");
+        givenVariableDefinition.setRequired(true);
+        givenVariableDefinition.setDisplay(true);
+        givenVariableDefinition.setDisplayName("Variable 1");
+        extension.setProperties(Map.of("var1", givenVariableDefinition));
+
+        when(processExtensionService.getExtensionsForId("PROC_ID")).thenReturn(extension);
+
+        ExtendedCloudProcessDefinition decoratedProcessDefinition = processDefinitionVariablesDecorator.decorate(givenProcessDefinition);
+
+        assertThat(decoratedProcessDefinition.getVariableDefinitions()).hasSize(1);
+        org.activiti.api.process.model.VariableDefinition variableDefinition = decoratedProcessDefinition.getVariableDefinitions().get(0);
+        assertThat(variableDefinition.getId()).isEqualTo("VAR_ID");
+        assertThat(variableDefinition.getName()).isEqualTo("var1");
+        assertThat(variableDefinition.getDescription()).isEqualTo("Variable no 1");
+        assertThat(variableDefinition.getType()).isEqualTo("string");
+        assertThat(variableDefinition.isRequired()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplay()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplayName()).isEqualTo("Variable 1");
+    }
+
+    @Test
+    void should_decorateProcessDefinitionsWithDisplayableVariables() {
+        CloudProcessDefinitionImpl givenProcessDefinition = new CloudProcessDefinitionImpl();
+        givenProcessDefinition.setId("PROC_ID");
+        Extension extension = new Extension();
+        VariableDefinition givenVariableDefinition1 = new VariableDefinition();
+        givenVariableDefinition1.setDisplay(false);
+        givenVariableDefinition1.setDisplayName("Variable 1");
+        VariableDefinition givenVariableDefinition2 = new VariableDefinition();
+        givenVariableDefinition1.setDisplay(true);
+        givenVariableDefinition1.setDisplayName("Variable 2");
+        extension.setProperties(Map.of("var1", givenVariableDefinition1, "var2", givenVariableDefinition2));
+
+        when(processExtensionService.getExtensionsForId("PROC_ID")).thenReturn(extension);
+
+        ExtendedCloudProcessDefinition decoratedProcessDefinition = processDefinitionVariablesDecorator.decorate(givenProcessDefinition);
+
+        assertThat(decoratedProcessDefinition.getVariableDefinitions()).hasSize(1);
+        org.activiti.api.process.model.VariableDefinition variableDefinition = decoratedProcessDefinition.getVariableDefinitions().get(0);
+        assertThat(variableDefinition.getDisplay()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplayName()).isEqualTo("Variable 2");
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.rest.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.springframework.cloud.openfeign.CollectionFormat;
 import org.springframework.data.domain.Pageable;
@@ -23,13 +24,19 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
 
 public interface ProcessDefinitionController {
 
     @GetMapping("/v1/process-definitions")
     @CollectionFormat(feign.CollectionFormat.CSV)
-    PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(Pageable pageable);
+    PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(@Parameter(description = "List of values to include in response")
+                                                                          @RequestParam(value = "include", required = false)
+                                                                          List<String> include,
+                                                                          Pageable pageable);
 
     @GetMapping(value = "/v1/process-definitions/{id}")
     EntityModel<CloudProcessDefinition> getProcessDefinition(@PathVariable(value = "id") String id);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionController.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.rest.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 import org.springframework.cloud.openfeign.CollectionFormat;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.EntityModel;
@@ -33,10 +34,10 @@ public interface ProcessDefinitionController {
 
     @GetMapping("/v1/process-definitions")
     @CollectionFormat(feign.CollectionFormat.CSV)
-    PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(@Parameter(description = "List of values to include in response")
-                                                                          @RequestParam(value = "include", required = false)
-                                                                          List<String> include,
-                                                                          Pageable pageable);
+    PagedModel<EntityModel<ExtendedCloudProcessDefinition>> getProcessDefinitions(
+        @Parameter(description = "List of values to include in response")
+        @RequestParam(value = "include", required = false) List<String> include,
+        Pageable pageable);
 
     @GetMapping(value = "/v1/process-definitions/{id}")
     EntityModel<CloudProcessDefinition> getProcessDefinition(@PathVariable(value = "id") String id);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ExtendedCloudProcessDefinitionRepresentationModelAssembler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ExtendedCloudProcessDefinitionRepresentationModelAssembler.java
@@ -13,25 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package org.activiti.cloud.services.rest.assemblers;
 
 import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessDefinitionControllerImpl;
@@ -43,23 +27,23 @@ import org.springframework.hateoas.server.RepresentationModelAssembler;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
-public class ProcessDefinitionRepresentationModelAssembler implements RepresentationModelAssembler<ProcessDefinition, EntityModel<CloudProcessDefinition>> {
+public class ExtendedCloudProcessDefinitionRepresentationModelAssembler implements RepresentationModelAssembler<ProcessDefinition, EntityModel<ExtendedCloudProcessDefinition>> {
 
     private ToCloudProcessDefinitionConverter converter;
 
-    public ProcessDefinitionRepresentationModelAssembler(ToCloudProcessDefinitionConverter converter) {
+    public ExtendedCloudProcessDefinitionRepresentationModelAssembler(ToCloudProcessDefinitionConverter converter) {
         this.converter = converter;
     }
 
     @Override
-    public EntityModel<CloudProcessDefinition> toModel(ProcessDefinition processDefinition) {
+    public EntityModel<ExtendedCloudProcessDefinition> toModel(ProcessDefinition processDefinition) {
         ExtendedCloudProcessDefinition cloudProcessDefinition = converter.from(processDefinition);
         Link selfRel = linkTo(methodOn(ProcessDefinitionControllerImpl.class).getProcessDefinition(cloudProcessDefinition.getId())).withSelfRel();
         Link startProcessLink = linkTo(methodOn(ProcessInstanceControllerImpl.class).startProcess(null)).withRel("startProcess");
         Link homeLink = linkTo(HomeControllerImpl.class).withRel("home");
         return EntityModel.of(cloudProcessDefinition,
-                                             selfRel,
-                                             startProcessLink,
-                                             homeLink);
+            selfRel,
+            startProcessLink,
+            homeLink);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ToCloudProcessDefinitionConverter.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ToCloudProcessDefinitionConverter.java
@@ -16,7 +16,7 @@
 package org.activiti.cloud.services.rest.assemblers;
 
 import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 
@@ -28,9 +28,12 @@ public class ToCloudProcessDefinitionConverter {
         this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
     }
 
-    public CloudProcessDefinition from(ProcessDefinition processDefinition) {
+    public ExtendedCloudProcessDefinition from(ProcessDefinition processDefinition) {
         CloudProcessDefinitionImpl cloudProcessDefinition = new CloudProcessDefinitionImpl(processDefinition);
         runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(cloudProcessDefinition);
+        if (processDefinition instanceof ExtendedCloudProcessDefinition) {
+            cloudProcessDefinition.setVariableDefinitions(((ExtendedCloudProcessDefinition) processDefinition).getVariableDefinitions());
+        }
         return cloudProcessDefinition;
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestWebMvcAutoConfiguration.java
@@ -15,9 +15,9 @@
  */
 package org.activiti.cloud.services.rest.conf;
 
-import java.util.List;
-
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.cloud.services.rest.assemblers.ExtendedCloudProcessDefinitionRepresentationModelAssembler;
+import org.activiti.cloud.services.rest.assemblers.CollectionModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.ConnectorDefinitionRepresentationModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.GroupCandidatesRepresentationModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessDefinitionMetaRepresentationModelAssembler;
@@ -33,7 +33,6 @@ import org.activiti.cloud.services.rest.assemblers.ToCloudProcessInstanceConvert
 import org.activiti.cloud.services.rest.assemblers.ToCloudTaskConverter;
 import org.activiti.cloud.services.rest.assemblers.ToCloudVariableInstanceConverter;
 import org.activiti.cloud.services.rest.assemblers.UserCandidatesRepresentationModelAssembler;
-import org.activiti.cloud.services.rest.assemblers.CollectionModelAssembler;
 import org.activiti.cloud.services.rest.controllers.RuntimeBundleLinkRelationProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -45,6 +44,8 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
@@ -79,6 +80,11 @@ public class ServicesRestWebMvcAutoConfiguration implements WebMvcConfigurer {
     @Bean
     public ProcessDefinitionRepresentationModelAssembler processDefinitionRepresentationModelAssembler(RuntimeBundleInfoAppender runtimeBundleInfoAppender) {
         return new ProcessDefinitionRepresentationModelAssembler(new ToCloudProcessDefinitionConverter(runtimeBundleInfoAppender));
+    }
+
+    @Bean
+    public ExtendedCloudProcessDefinitionRepresentationModelAssembler cloudProcessDefinitionRepresentationModelAssembler(RuntimeBundleInfoAppender runtimeBundleInfoAppender) {
+        return new ExtendedCloudProcessDefinitionRepresentationModelAssembler(new ToCloudProcessDefinitionConverter(runtimeBundleInfoAppender));
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
@@ -47,17 +47,19 @@ import org.activiti.engine.RepositoryService;
 import org.activiti.engine.impl.util.IoUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -91,8 +93,10 @@ public class ProcessDefinitionControllerImpl implements ProcessDefinitionControl
     }
 
     @Override
-    public PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(Pageable pageable) {
-        Page<ProcessDefinition> page = processRuntime.processDefinitions(pageConverter.toAPIPageable(pageable));
+    public PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(@RequestParam(required = false, defaultValue = "")
+                                                                                         List<String> include,
+                                                                                 Pageable pageable) {
+        Page<ProcessDefinition> page = processRuntime.processDefinitions(pageConverter.toAPIPageable(pageable), include);
         return pagedCollectionModelAssembler.toModel(pageable,
                                                   pageConverter.toSpringPage(pageable, page),
                                                   representationModelAssembler);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
@@ -37,9 +37,12 @@ import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.services.core.ProcessDefinitionService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.rest.api.ProcessDefinitionController;
+import org.activiti.cloud.services.rest.assemblers.ExtendedCloudProcessDefinitionRepresentationModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessDefinitionRepresentationModelAssembler;
 import org.activiti.editor.language.json.converter.BpmnJsonConverter;
 import org.activiti.engine.ActivitiException;
@@ -71,35 +74,43 @@ public class ProcessDefinitionControllerImpl implements ProcessDefinitionControl
 
     private final ProcessDefinitionRepresentationModelAssembler representationModelAssembler;
 
+    private final ExtendedCloudProcessDefinitionRepresentationModelAssembler extendedCloudProcessDefinitionRepresentationModelAssembler;
+
     private final ProcessRuntime processRuntime;
 
     private final AlfrescoPagedModelAssembler<ProcessDefinition> pagedCollectionModelAssembler;
 
     private final SpringPageConverter pageConverter;
 
+    private final ProcessDefinitionService processDefinitionService;
+
     @Autowired
     public ProcessDefinitionControllerImpl(RepositoryService repositoryService,
                                            ProcessDiagramGeneratorWrapper processDiagramGenerator,
                                            ProcessDefinitionRepresentationModelAssembler representationModelAssembler,
+                                           ExtendedCloudProcessDefinitionRepresentationModelAssembler extendedCloudProcessDefinitionRepresentationModelAssembler,
                                            ProcessRuntime processRuntime,
                                            AlfrescoPagedModelAssembler<ProcessDefinition> pagedCollectionModelAssembler,
-                                           SpringPageConverter pageConverter) {
+                                           SpringPageConverter pageConverter,
+                                           ProcessDefinitionService processDefinitionService) {
         this.repositoryService = repositoryService;
         this.processDiagramGenerator = processDiagramGenerator;
         this.representationModelAssembler = representationModelAssembler;
+        this.extendedCloudProcessDefinitionRepresentationModelAssembler = extendedCloudProcessDefinitionRepresentationModelAssembler;
         this.processRuntime = processRuntime;
         this.pagedCollectionModelAssembler = pagedCollectionModelAssembler;
         this.pageConverter = pageConverter;
+        this.processDefinitionService = processDefinitionService;
     }
 
     @Override
-    public PagedModel<EntityModel<CloudProcessDefinition>> getProcessDefinitions(@RequestParam(required = false, defaultValue = "")
+    public PagedModel<EntityModel<ExtendedCloudProcessDefinition>> getProcessDefinitions(@RequestParam(required = false, defaultValue = "")
                                                                                          List<String> include,
-                                                                                 Pageable pageable) {
-        Page<ProcessDefinition> page = processRuntime.processDefinitions(pageConverter.toAPIPageable(pageable), include);
+                                                                                         Pageable pageable) {
+        Page<ProcessDefinition> page = processDefinitionService.getProcessDefinitions(pageConverter.toAPIPageable(pageable), include);
         return pagedCollectionModelAssembler.toModel(pageable,
                                                   pageConverter.toSpringPage(pageable, page),
-                                                  representationModelAssembler);
+            extendedCloudProcessDefinitionRepresentationModelAssembler);
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/assemblers/ExtendedCloudProcessDefinitionRepresentationModelAssemblerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/assemblers/ExtendedCloudProcessDefinitionRepresentationModelAssemblerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.rest.assemblers;
+
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.hateoas.IanaLinkRelations.SELF;
+
+@ExtendWith(MockitoExtension.class)
+public class ExtendedCloudProcessDefinitionRepresentationModelAssemblerTest {
+
+    @InjectMocks
+    private ExtendedCloudProcessDefinitionRepresentationModelAssembler representationModelAssembler;
+
+    @Mock
+    private ToCloudProcessDefinitionConverter converter;
+
+    @Test
+    public void toResourceShouldReturnResourceWithSelfLinkContainingResourceId() {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId("my-identifier");
+        given(converter.from(processDefinition)).willReturn(new CloudProcessDefinitionImpl(processDefinition));
+
+        EntityModel<ExtendedCloudProcessDefinition> processDefinitionResource =
+            representationModelAssembler.toModel(processDefinition);
+
+        Optional<Link> selfResourceLink = processDefinitionResource.getLink(SELF);
+
+        assertThat(selfResourceLink).isPresent();
+        assertThat(selfResourceLink.get().getHref()).contains("my-identifier");
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -15,20 +15,9 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -58,6 +47,18 @@ import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessDefinitionAdminControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -97,6 +98,9 @@ public class ProcessDefinitionAdminControllerImplIT {
 
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;
+
+    @MockBean
+    private ProcessRuntime processRuntime;
 
     @BeforeEach
     public void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -106,6 +106,7 @@ public class ProcessDefinitionAdminControllerImplIT {
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
         assertThat(processDeployedProducer).isNotNull();
+        assertThat(processRuntime).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -111,6 +111,7 @@ public class ProcessInstanceAdminControllerImplIT {
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
         assertThat(processDeployedProducer).isNotNull();
+        assertThat(processRuntime).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -15,20 +15,6 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.MessagePayloadBuilder;
@@ -37,6 +23,7 @@ import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -65,6 +52,20 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceAdminControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -102,6 +103,9 @@ public class ProcessInstanceAdminControllerImplIT {
 
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;
+
+    @MockBean
+    private ProcessRuntime processRuntime;
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
This PR is adding query param `include`, which now only takes `variables` value. If this param is in the request, the endpoint returns displayable variable definitions for each process definition.