### PR TITLE
fix(AAE-8283): Query Service GraphQL - problem with null values in query

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -14,7 +14,7 @@
   <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.4.17</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.4.18</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -14,7 +14,7 @@
   <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.4.18</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.4.19</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -14,7 +14,7 @@
   <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.4.16</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.4.17</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/resources/application.properties
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.defer-datasource-initialization=true
 
 activiti.identity.test-user=testadmin
 activiti.identity.test-password=password
+
+
+logging.level.com.introproventures.graphql.jpa.query=DEBUG

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/resources/data.sql
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/resources/data.sql
@@ -2,12 +2,13 @@ insert into process_instance (id, last_modified, last_modified_from, last_modifi
   ('0', CURRENT_TIMESTAMP, null, null, 'process_definition_id', 'RUNNING', 'initiator',null, 'bus_key','def_key'),
   ('1', CURRENT_TIMESTAMP, null, null, 'process_definition_id', 'RUNNING', 'initiator',null, 'bus_key','def_key');
 
-insert into task (id, assignee, created_date, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status, owner, claimed_date) values
-  ('1', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 5, 'process_definition_id', 0, 'COMPLETED'  , 'owner', null),
-  ('2', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 10, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
-  ('3', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 5, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
-  ('4', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 10, 'process_definition_id', 1, 'CREATED'  , 'owner', null),
-  ('5', 'assignee', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 5, 'process_definition_id', 1, 'COMPLETED'  , 'owner', null);
+insert into task (id, assignee, business_key, created_date, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status, owner, claimed_date) values
+  ('1', 'assignee', 'bk1', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 5, 'process_definition_id', 0, 'COMPLETED'  , 'owner', null),
+  ('2', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 10, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+  ('3', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 5, 'process_definition_id', 0, 'CREATED'  , 'owner', null),
+  ('4', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 10, 'process_definition_id', 1, 'CREATED'  , 'owner', null),
+  ('5', 'assignee', null, CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 10, 'process_definition_id', 1, 'COMPLETED'  , 'owner', null),
+  ('6', 'assignee', 'bk6', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task6', 10, 'process_definition_id', 0, 'ASSIGNED'  , 'owner', null);
 
 insert into PROCESS_VARIABLE (id, create_time, execution_id, last_updated_time, name, process_instance_id, type, value) values
   (1, CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'initiator', 1, 'map', '{"value": { "key" : ["1","2","3","4","5"]}}');


### PR DESCRIPTION
- [x] Update Graphql-jpa-query dependency version to [0.4.19](https://github.com/introproventures/graphql-jpa-query/releases/tag/0.4.19) with the fix for nullable scalar values in EQ/NE predicates

- [x] Add test coverage for the following queries:

```
{
  Tasks(
    page: { start: 1, limit: 100 }
    where: { status: { IN: [CREATED, ASSIGNED] }, dueDate: { EQ: null } }
  ) {
    select {
      id
      businessKey
      name
      status
      priority(orderBy: DESC)
      dueDate(orderBy: ASC)
      assignee
    }
  }
}

```

```
{
  Tasks(
    page: { start: 1, limit: 100 }
    where: { status: { IN: [COMPLETED, ASSIGNED] }, businessKey: { NE: null } }
  ) {
    select {
      id
      businessKey
      name
      status
      priority(orderBy: DESC)
      dueDate(orderBy: ASC)
      assignee
    }
  }
}

```

Fixes https://github.com/Activiti/Activiti/issues/3902


