### PR TITLE
#3927 Return process variables values in process-instances endpoint

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-model-shared-impl/src/main/java/org/activiti/cloud/api/model/shared/impl/events/CloudVariableCreatedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-model-shared-impl/src/main/java/org/activiti/cloud/api/model/shared/impl/events/CloudVariableCreatedEventImpl.java
@@ -21,6 +21,8 @@ import org.activiti.cloud.api.model.shared.events.CloudVariableCreatedEvent;
 
 public class CloudVariableCreatedEventImpl extends CloudVariableEventImpl implements CloudVariableCreatedEvent {
 
+    private String variableDefinitionId;
+
     public CloudVariableCreatedEventImpl() {
     }
 
@@ -39,5 +41,14 @@ public class CloudVariableCreatedEventImpl extends CloudVariableEventImpl implem
     @Override
     public VariableEvent.VariableEvents getEventType() {
         return VariableEvent.VariableEvents.VARIABLE_CREATED;
+    }
+
+    @Override
+    public String getVariableDefinitionId() {
+        return variableDefinitionId;
+    }
+
+    public void setVariableDefinitionId(String variableDefinitionId) {
+        this.variableDefinitionId = variableDefinitionId;
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/13-alter.oracle.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/13-alter.oracle.schema.7.4.0.sql
@@ -15,4 +15,4 @@
  */
 
 alter table process_variable
-  add column definition_id varchar(64);
+  add column variable_definition_id varchar(64);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/13-alter.oracle.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/13-alter.oracle.schema.7.4.0.sql
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.api.model.shared.events;
 
-import org.activiti.api.model.shared.event.VariableCreatedEvent;
-
-public interface CloudVariableCreatedEvent extends CloudVariableEvent,
-                                                   VariableCreatedEvent {
-
-    String getVariableDefinitionId();
-}
+alter table process_variable
+  add column definition_id varchar(64);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/14-alter.pg.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/14-alter.pg.schema.7.4.0.sql
@@ -15,4 +15,4 @@
  */
 
 alter table process_variable
-    add column definition_id varchar(64);
+    add column variable_definition_id varchar(64);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/14-alter.pg.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/14-alter.pg.schema.7.4.0.sql
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.api.model.shared.events;
 
-import org.activiti.api.model.shared.event.VariableCreatedEvent;
-
-public interface CloudVariableCreatedEvent extends CloudVariableEvent,
-                                                   VariableCreatedEvent {
-
-    String getVariableDefinitionId();
-}
+alter table process_variable
+    add column definition_id varchar(64);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
@@ -119,6 +119,7 @@ create table process_variable
     process_instance_id varchar(255),
     type                varchar(255),
     value               text,
+    definition_id       varchar(64),
     primary key (id)
 );
 create table task

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
@@ -119,7 +119,7 @@ create table process_variable
     process_instance_id varchar(255),
     type                varchar(255),
     value               text,
-    definition_id       varchar(64),
+    variable_definition_id varchar(64),
     primary key (id)
 );
 create table task

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
@@ -281,6 +281,16 @@
   </changeSet>
 
   <changeSet author="activiti-query"
+             id="alter13-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+             encoding="utf8"
+             path="changelog/13-alter.oracle.schema.7.4.0.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
     id="alter13-schema-m17" dbms="postgresql">
     <sqlFile dbms="postgresql"
       encoding="utf8"
@@ -288,6 +298,16 @@
       relativeToChangelogFile="true"
       splitStatements="true"
       stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
+             id="alter14-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+             encoding="utf8"
+             path="changelog/14-alter.pg.schema.7.4.0.sql"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
@@ -46,8 +46,6 @@ public abstract class AbstractVariableEntity extends ActivitiEntityMetadata impl
 
     private String processInstanceId;
 
-    private String definitionId;
-
     @JsonIgnore
     @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false,
@@ -149,14 +147,6 @@ public abstract class AbstractVariableEntity extends ActivitiEntityMetadata impl
 
     public void setProcessInstanceId(String processInstanceId) {
         this.processInstanceId = processInstanceId;
-    }
-
-    public String getDefinitionId() {
-        return definitionId;
-    }
-
-    public void setDefinitionId(String variableDefinitionId) {
-        this.definitionId = variableDefinitionId;
     }
 
     public ProcessInstanceEntity getProcessInstance() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/AbstractVariableEntity.java
@@ -46,6 +46,8 @@ public abstract class AbstractVariableEntity extends ActivitiEntityMetadata impl
 
     private String processInstanceId;
 
+    private String definitionId;
+
     @JsonIgnore
     @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false,
@@ -147,6 +149,14 @@ public abstract class AbstractVariableEntity extends ActivitiEntityMetadata impl
 
     public void setProcessInstanceId(String processInstanceId) {
         this.processInstanceId = processInstanceId;
+    }
+
+    public String getDefinitionId() {
+        return definitionId;
+    }
+
+    public void setDefinitionId(String variableDefinitionId) {
+        this.definitionId = variableDefinitionId;
     }
 
     public ProcessInstanceEntity getProcessInstance() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.api.model.shared.events;
+package org.activiti.cloud.services.query.model;
 
-import org.activiti.api.model.shared.event.VariableCreatedEvent;
+public class JsonViews {
 
-public interface CloudVariableCreatedEvent extends CloudVariableEvent,
-                                                   VariableCreatedEvent {
+    public static class General {
+    }
 
-    String getVariableDefinitionId();
+    public static class Variables {
+    }
+
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -16,11 +16,13 @@
 package org.activiti.cloud.services.query.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.annotations.PropertyType;
 import com.querydsl.core.annotations.QueryType;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Filter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.ConstraintMode;
@@ -125,7 +127,8 @@ public class ProcessInstanceEntity extends ActivitiEntityMetadata implements Clo
     	, foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))
     private Set<TaskEntity> tasks = new LinkedHashSet<>();
 
-    @JsonIgnore
+    @JsonView(JsonViews.Variables.class)
+    @Filter(name = "variableDefinitionIds")
     @OneToMany(fetch=FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
 		, foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
@@ -30,7 +30,7 @@ import javax.persistence.Table;
 import java.util.Date;
 import java.util.Objects;
 
-@FilterDef(name = "variableDefinitionIds", parameters = @ParamDef(name="variables", type = "string"), defaultCondition = "definition_id in (:variables)")
+@FilterDef(name = "variableDefinitionIds", parameters = @ParamDef(name="variables", type = "string"), defaultCondition = "variable_definition_id in (:variables)")
 @Entity(name="ProcessVariable")
 @Table(name = "PROCESS_VARIABLE",
         indexes = {
@@ -47,7 +47,7 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
     @SequenceGenerator(name="process_variable_sequence", sequenceName = "process_variable_sequence", allocationSize=50)
     private Long id;
 
-    private String definitionId;
+    private String variableDefinitionId;
 
     public ProcessVariableEntity() {
     }
@@ -94,12 +94,12 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
         return false;
     }
 
-    public String getDefinitionId() {
-        return definitionId;
+    public String getVariableDefinitionId() {
+        return variableDefinitionId;
     }
 
-    public void setDefinitionId(String variableDefinitionId) {
-        this.definitionId = variableDefinitionId;
+    public void setVariableDefinitionId(String variableDefinitionId) {
+        this.variableDefinitionId = variableDefinitionId;
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
@@ -47,6 +47,7 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
     @SequenceGenerator(name="process_variable_sequence", sequenceName = "process_variable_sequence", allocationSize=50)
     private Long id;
 
+    private String definitionId;
 
     public ProcessVariableEntity() {
     }
@@ -91,6 +92,14 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
     @Override
     public boolean isTaskVariable() {
         return false;
+    }
+
+    public String getDefinitionId() {
+        return definitionId;
+    }
+
+    public void setDefinitionId(String variableDefinitionId) {
+        this.definitionId = variableDefinitionId;
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
@@ -17,11 +17,20 @@ package org.activiti.cloud.services.query.model;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.util.Date;
 import java.util.Objects;
 
+@FilterDef(name = "variableDefinitionIds", parameters = @ParamDef(name="variables", type = "string"), defaultCondition = "definition_id in (:variables)")
 @Entity(name="ProcessVariable")
 @Table(name = "PROCESS_VARIABLE",
         indexes = {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
@@ -50,8 +50,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.persistence.EntityManager;
-
 @Configuration
 public class QueryRestWebMvcAutoConfiguration  {
 
@@ -209,12 +207,11 @@ public class QueryRestWebMvcAutoConfiguration  {
     public ProcessInstanceService processInstanceService(ProcessInstanceRepository processInstanceRepository,
                                                          TaskRepository taskRepository,
                                                          ProcessInstanceRestrictionService processInstanceRestrictionService,
-                                                         EntityManager entityManager,
                                                          SecurityPoliciesManager securityPoliciesApplicationService,
                                                          SecurityManager securityManager,
                                                          EntityFinder entityFinder
     ) {
         return new ProcessInstanceService(processInstanceRepository, taskRepository, processInstanceRestrictionService,
-            entityManager, securityPoliciesApplicationService, securityManager, entityFinder);
+            securityPoliciesApplicationService, securityManager, entityFinder);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
@@ -17,8 +17,11 @@ package org.activiti.cloud.conf;
 
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
+import org.activiti.cloud.services.query.app.repository.EntityFinder;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.activiti.cloud.services.query.rest.ProcessInstanceService;
 import org.activiti.cloud.services.query.rest.QueryLinkRelationProvider;
 import org.activiti.cloud.services.query.rest.TaskControllerHelper;
 import org.activiti.cloud.services.query.rest.TaskPermissionsHelper;
@@ -46,6 +49,8 @@ import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesPr
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
 
 @Configuration
 public class QueryRestWebMvcAutoConfiguration  {
@@ -197,5 +202,19 @@ public class QueryRestWebMvcAutoConfiguration  {
     public TaskPermissionsHelper taskPermissionsHelper(SecurityManager securityManager,
                                                        TaskControllerHelper taskControllerHelper) {
         return new TaskPermissionsHelper(securityManager, taskControllerHelper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessInstanceService processInstanceService(ProcessInstanceRepository processInstanceRepository,
+                                                         TaskRepository taskRepository,
+                                                         ProcessInstanceRestrictionService processInstanceRestrictionService,
+                                                         EntityManager entityManager,
+                                                         SecurityPoliciesManager securityPoliciesApplicationService,
+                                                         SecurityManager securityManager,
+                                                         EntityFinder entityFinder
+    ) {
+        return new ProcessInstanceService(processInstanceRepository, taskRepository, processInstanceRestrictionService,
+            entityManager, securityPoliciesApplicationService, securityManager, entityFinder);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
@@ -72,8 +72,8 @@ public class ProcessVariableCreatedEventHandler {
                                                                          new Date(variableCreatedEvent.getTimestamp()),
                                                                          new Date(variableCreatedEvent.getTimestamp()),
                                                                          null);
-        variableEntity.setValue(variableCreatedEvent.getEntity()
-                                                    .getValue());
+        variableEntity.setValue(variableCreatedEvent.getEntity().getValue());
+        variableEntity.setDefinitionId(variableCreatedEvent.getVariableDefinitionId());
         variableEntity.setProcessInstance(processInstanceEntity);
 
         entityManager.persist(variableEntity);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
@@ -73,7 +73,7 @@ public class ProcessVariableCreatedEventHandler {
                                                                          new Date(variableCreatedEvent.getTimestamp()),
                                                                          null);
         variableEntity.setValue(variableCreatedEvent.getEntity().getValue());
-        variableEntity.setDefinitionId(variableCreatedEvent.getVariableDefinitionId());
+        variableEntity.setVariableDefinitionId(variableCreatedEvent.getVariableDefinitionId());
         variableEntity.setProcessInstance(processInstanceEntity);
 
         entityManager.persist(variableEntity);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskVariableCreatedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskVariableCreatedEventHandler.java
@@ -78,6 +78,7 @@ public class TaskVariableCreatedEventHandler {
                                                                        new Date(variableCreatedEvent.getTimestamp()),
                                                                        null);
         taskVariableEntity.setValue(variableCreatedEvent.getEntity().getValue());
+        taskVariableEntity.setDefinitionId(variableCreatedEvent.getVariableDefinitionId());
         taskVariableEntity.setProcessInstance(processInstanceEntity);
         taskVariableEntity.setTask(taskEntity);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskVariableCreatedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskVariableCreatedEventHandler.java
@@ -78,7 +78,6 @@ public class TaskVariableCreatedEventHandler {
                                                                        new Date(variableCreatedEvent.getTimestamp()),
                                                                        null);
         taskVariableEntity.setValue(variableCreatedEvent.getEntity().getValue());
-        taskVariableEntity.setDefinitionId(variableCreatedEvent.getVariableDefinitionId());
         taskVariableEntity.setProcessInstance(processInstanceEntity);
         taskVariableEntity.setTask(taskEntity);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -15,28 +15,29 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import java.util.Optional;
-
+import com.fasterxml.jackson.annotation.JsonView;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.rest.assembler.ProcessInstanceRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Predicate;
+import java.util.Optional;
 
 @RestController
 @RequestMapping(
@@ -66,6 +67,7 @@ public class ProcessInstanceAdminController {
         this.entityFinder=entityFinder;
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET)
     public PagedModel<EntityModel<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                   Pageable pageable) {
@@ -79,6 +81,7 @@ public class ProcessInstanceAdminController {
                                                   processInstanceRepresentationModelAssembler);
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.GET)
     public EntityModel<CloudProcessInstance> findById(@PathVariable String processInstanceId) {
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
@@ -15,17 +15,19 @@
  */
 package org.activiti.cloud.services.query.rest;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.types.Predicate;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.rest.assembler.ProcessInstanceRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.querydsl.binding.QuerydslPredicate;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -55,6 +57,7 @@ public class ProcessInstanceDeleteController {
         this.processInstanceRepresentationModelAssembler = processInstanceRepresentationModelAssembler;
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.DELETE)
     public CollectionModel<EntityModel<CloudProcessInstance>> deleteProcessInstances (@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate) {
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -77,11 +77,11 @@ public class ProcessInstanceService {
 
     public Page<ProcessInstanceEntity> findAll(Predicate predicate, Pageable pageable) {
 
-        predicate = processInstanceRestrictionService.restrictProcessInstanceQuery(Optional.ofNullable(predicate)
+        Predicate transformedPredicate = processInstanceRestrictionService.restrictProcessInstanceQuery(Optional.ofNullable(predicate)
                 .orElseGet(BooleanBuilder::new),
             SecurityPolicyAccess.READ);
 
-        return processInstanceRepository.findAll(predicate, pageable);
+        return processInstanceRepository.findAll(transformedPredicate, pageable);
     }
 
     public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variables, Pageable pageable) {
@@ -106,7 +106,7 @@ public class ProcessInstanceService {
     }
 
     public Page<ProcessInstanceEntity> subprocesses(String processInstanceId, Predicate predicate, Pageable pageable) {
-        predicate = Optional.ofNullable(predicate).orElseGet(BooleanBuilder::new);
+        Predicate transformedPredicate = Optional.ofNullable(predicate).orElseGet(BooleanBuilder::new);
 
         ProcessInstanceEntity processInstanceEntity = entityFinder.findById(processInstanceRepository,
             processInstanceId,
@@ -119,7 +119,7 @@ public class ProcessInstanceService {
 
         QProcessInstanceEntity process = QProcessInstanceEntity.processInstanceEntity;
         BooleanExpression expression = process.parentId.eq(processInstanceId);
-        Predicate extendedPredicate = expression.and(predicate);
+        Predicate extendedPredicate = expression.and(transformedPredicate);
 
         return processInstanceRepository.findAll(extendedPredicate, pageable);
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.query.rest;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.services.query.app.repository.EntityFinder;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.QProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.QTaskEntity;
+import org.activiti.cloud.services.security.ProcessInstanceRestrictionService;
+import org.activiti.core.common.spring.security.policies.ActivitiForbiddenException;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
+import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+
+public class ProcessInstanceService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceService.class);
+
+    private final ProcessInstanceRepository processInstanceRepository;
+
+    private final TaskRepository taskRepository;
+
+    private final ProcessInstanceRestrictionService processInstanceRestrictionService;
+
+    private final EntityManager entityManager;
+
+    private final SecurityPoliciesManager securityPoliciesApplicationService;
+
+    private final SecurityManager securityManager;
+
+    private final EntityFinder entityFinder;
+
+    public ProcessInstanceService(ProcessInstanceRepository processInstanceRepository,
+                                  TaskRepository taskRepository,
+                                  ProcessInstanceRestrictionService processInstanceRestrictionService,
+                                  EntityManager entityManager,
+                                  SecurityPoliciesManager securityPoliciesApplicationService,
+                                  SecurityManager securityManager,
+                                  EntityFinder entityFinder) {
+        this.processInstanceRepository = processInstanceRepository;
+        this.taskRepository = taskRepository;
+        this.processInstanceRestrictionService = processInstanceRestrictionService;
+        this.entityManager = entityManager;
+        this.securityPoliciesApplicationService = securityPoliciesApplicationService;
+        this.securityManager = securityManager;
+        this.entityFinder = entityFinder;
+    }
+
+    public Page<ProcessInstanceEntity> findAll(Predicate predicate, Pageable pageable) {
+
+        predicate = processInstanceRestrictionService.restrictProcessInstanceQuery(Optional.ofNullable(predicate)
+                .orElseGet(BooleanBuilder::new),
+            SecurityPolicyAccess.READ);
+
+        return processInstanceRepository.findAll(predicate, pageable);
+    }
+
+    public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variables, Pageable pageable) {
+        Session session = entityManager.unwrap(Session.class);
+        Filter filter = session.enableFilter("variableDefinitionIds");
+        filter.setParameterList("variables", variables);
+
+        return findAll(predicate, pageable);
+    }
+
+    public ProcessInstanceEntity findById(String processInstanceId) {
+        ProcessInstanceEntity processInstanceEntity = entityFinder.findById(processInstanceRepository, processInstanceId,
+            String.format("Unable to find process instance for the given id:'%s'", processInstanceId));
+
+        if (!canRead(processInstanceEntity)) {
+            LOGGER.debug(String.format("User %s not permitted to access definition %s and/or process instance id %s",
+                securityManager.getAuthenticatedUserId(), processInstanceEntity.getProcessDefinitionKey(), processInstanceId));
+            throw new ActivitiForbiddenException(String.format("Operation not permitted for %s and/or process instance",
+                processInstanceEntity.getProcessDefinitionKey()));
+        }
+        return processInstanceEntity;
+    }
+
+    public Page<ProcessInstanceEntity> subprocesses(String processInstanceId, Predicate predicate, Pageable pageable) {
+        predicate = Optional.ofNullable(predicate).orElseGet(BooleanBuilder::new);
+
+        ProcessInstanceEntity processInstanceEntity = entityFinder.findById(processInstanceRepository,
+            processInstanceId,
+            "Unable to find process for the given id:'" + processInstanceId + "'");
+
+        if (!canRead(processInstanceEntity)) {
+            LOGGER.debug("User " + securityManager.getAuthenticatedUserId() + " not permitted to access definition " + processInstanceEntity.getProcessDefinitionKey() + " and/or process instance id " + processInstanceId);
+            throw new ActivitiForbiddenException("Operation not permitted for " + processInstanceEntity.getProcessDefinitionKey() + " and/or process instance");
+        }
+
+        QProcessInstanceEntity process = QProcessInstanceEntity.processInstanceEntity;
+        BooleanExpression expression = process.parentId.eq(processInstanceId);
+        Predicate extendedPredicate = expression.and(predicate);
+
+        return processInstanceRepository.findAll(extendedPredicate, pageable);
+    }
+
+    private boolean canRead(ProcessInstanceEntity processInstanceEntity) {
+        return securityPoliciesApplicationService.canRead(processInstanceEntity.getProcessDefinitionKey(),
+            processInstanceEntity.getServiceName()) &&
+            (securityManager.getAuthenticatedUserId().equals(processInstanceEntity.getInitiator()) ||
+                isInvolvedInATask(processInstanceEntity.getId()));
+    }
+
+    private boolean isInvolvedInATask(String processInstanceId) {
+        String authenticatedUserId = securityManager.getAuthenticatedUserId();
+        List<String> authenticatedUserGroups = securityManager.getAuthenticatedUserGroups();
+
+        QTaskEntity taskEntity = QTaskEntity.taskEntity;
+
+        BooleanExpression taskInvolved = taskEntity.assignee.eq(authenticatedUserId)
+            .or(taskEntity.owner.eq(authenticatedUserId))
+            .or(taskEntity.taskCandidateUsers.any().userId.eq(authenticatedUserId));
+
+        if (authenticatedUserGroups != null && authenticatedUserGroups.size() > 0) {
+            taskInvolved = taskInvolved.or(taskEntity.taskCandidateGroups.any().groupId.in(authenticatedUserGroups));
+        }
+
+        Predicate whereExpression = taskEntity.processInstanceId.eq(processInstanceId).and(taskInvolved);
+
+        return taskRepository.exists(whereExpression);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.persistence.EntityManager;
 import java.util.Optional;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -60,6 +60,7 @@ public class VariableEntityCreatedEventHandlerTest {
     public void handleShouldCreateAndStoreProcessInstanceVariable() {
         //given
         CloudVariableCreatedEventImpl event = new CloudVariableCreatedEventImpl(buildVariable());
+        event.setVariableDefinitionId("variableDefId");
 
         ProcessInstanceEntity processInstanceEntity = new ProcessInstanceEntity();
         when(entityManagerFinder.findProcessInstanceWithVariables(event.getEntity().getProcessInstanceId()))
@@ -80,7 +81,8 @@ public class VariableEntityCreatedEventHandlerTest {
                 .hasTaskId(event.getEntity().getTaskId())
                 .hasType(event.getEntity().getType())
                 .isNotTaskVariable()
-                .hasProcessInstance(processInstanceEntity);
+                .hasProcessInstance(processInstanceEntity)
+                .hasDefinitionId("variableDefId");
     }
 
     private static VariableInstanceImpl<String> buildVariable() {
@@ -91,6 +93,7 @@ public class VariableEntityCreatedEventHandlerTest {
     public void handleShouldCreateAndStoreTaskVariable() {
         //given
         CloudVariableCreatedEventImpl event = new CloudVariableCreatedEventImpl(buildVariableWithTaskId());
+        event.setVariableDefinitionId("variableDefId");
 
         ProcessInstanceEntity processInstanceEntity = new ProcessInstanceEntity();
 
@@ -116,7 +119,8 @@ public class VariableEntityCreatedEventHandlerTest {
                 .hasTaskId(event.getEntity().getTaskId())
                 .hasType(event.getEntity().getType())
                 .hasTask(taskEntity)
-                .hasProcessInstance(processInstanceEntity);
+                .hasProcessInstance(processInstanceEntity)
+                .hasDefinitionId("variableDefId");
     }
 
     private static VariableInstanceImpl<String> buildVariableWithTaskId() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
@@ -93,7 +93,6 @@ public class VariableEntityCreatedEventHandlerTest {
     public void handleShouldCreateAndStoreTaskVariable() {
         //given
         CloudVariableCreatedEventImpl event = new CloudVariableCreatedEventImpl(buildVariableWithTaskId());
-        event.setVariableDefinitionId("variableDefId");
 
         ProcessInstanceEntity processInstanceEntity = new ProcessInstanceEntity();
 
@@ -119,8 +118,7 @@ public class VariableEntityCreatedEventHandlerTest {
                 .hasTaskId(event.getEntity().getTaskId())
                 .hasType(event.getEntity().getType())
                 .hasTask(taskEntity)
-                .hasProcessInstance(processInstanceEntity)
-                .hasDefinitionId("variableDefId");
+                .hasProcessInstance(processInstanceEntity);
     }
 
     private static VariableInstanceImpl<String> buildVariableWithTaskId() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/VariableEntityCreatedEventHandlerTest.java
@@ -82,7 +82,7 @@ public class VariableEntityCreatedEventHandlerTest {
                 .hasType(event.getEntity().getType())
                 .isNotTaskVariable()
                 .hasProcessInstance(processInstanceEntity)
-                .hasDefinitionId("variableDefId");
+                .hasVariableDefinitionId("variableDefId");
     }
 
     private static VariableInstanceImpl<String> buildVariable() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationAdminControllerIT.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -32,6 +24,7 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.model.ApplicationEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -46,6 +39,16 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ApplicationAdminController.class)
 @Import({
@@ -75,6 +78,14 @@ public class ApplicationAdminControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnDeployedApplicationsWhenMediaTypeIsApplicationHalJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationControllerIT.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -32,6 +24,7 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.model.ApplicationEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -46,6 +39,16 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ApplicationController.class)
 @Import({
@@ -75,6 +78,14 @@ public class ApplicationControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnDeployedApplicationsWhenMediaTypeIsApplicationHalJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminControllerIT.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.activiti.cloud.services.query.rest.ProcessDefinitionBuilder.buildDefaultProcessDefinition;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -32,6 +24,7 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -46,6 +39,16 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.activiti.cloud.services.query.rest.ProcessDefinitionBuilder.buildDefaultProcessDefinition;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessDefinitionAdminController.class)
 @Import({
@@ -78,6 +81,14 @@ public class ProcessDefinitionAdminControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnAvailableProcessDefinitions() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionControllerIT.java
@@ -15,16 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.activiti.cloud.services.query.rest.ProcessDefinitionBuilder.buildDefaultProcessDefinition;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.querydsl.core.types.Predicate;
-import java.util.Collections;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -36,6 +27,7 @@ import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -50,6 +42,17 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.activiti.cloud.services.query.rest.ProcessDefinitionBuilder.buildDefaultProcessDefinition;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessDefinitionController.class)
 @Import({
@@ -85,6 +88,14 @@ public class ProcessDefinitionControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnAvailableProcessDefinitions() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -36,6 +28,7 @@ import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -50,6 +43,16 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceAdminController.class)
 @Import({
@@ -88,6 +91,14 @@ public class ProcessInstanceEntityAdminControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void findAllShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
@@ -31,6 +31,7 @@ import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -101,6 +103,11 @@ public class ProcessInstanceEntityControllerIT {
 
     @MockBean
     private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(entityManager).isNotNull();
+    }
 
     @Test
     public void findAllShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
@@ -15,17 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.querydsl.core.types.Predicate;
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -55,6 +45,18 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import javax.persistence.EntityManager;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceController.class)
 @Import({
@@ -96,6 +98,9 @@ public class ProcessInstanceEntityControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private EntityManager entityManager;
 
     @Test
     public void findAllShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityControllerIT.java
@@ -47,7 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
@@ -102,11 +102,11 @@ public class ProcessInstanceEntityControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
-    private EntityManager entityManager;
+    private EntityManagerFactory entityManagerFactory;
 
     @BeforeEach
     void setUp() {
-        assertThat(entityManager).isNotNull();
+        assertThat(entityManagerFactory).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
@@ -15,20 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.querydsl.core.types.Predicate;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -54,6 +41,20 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "activiti.rest.enable-deletion=true")
 @TestPropertySource("classpath:application-test.properties")
@@ -95,6 +96,9 @@ public class ProcessInstanceEntityDeleteControllerIT {
     @MockBean
     private TaskRepository taskRepository;
 
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
     @BeforeEach
     public void setUp() {
         when(securityManager.getAuthenticatedUserId()).thenReturn("admin");
@@ -104,6 +108,7 @@ public class ProcessInstanceEntityDeleteControllerIT {
         assertThat(securityPoliciesProperties).isNotNull();
         assertThat(taskLookupRestrictionService).isNotNull();
         assertThat(taskRepository).isNotNull();
+        assertThat(processInstanceService).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksAdminControllerIT.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.query.rest;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +34,7 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -73,6 +75,14 @@ public class ProcessInstanceEntityTasksAdminControllerIT {
 
     @MockBean
     private SecurityPoliciesProperties securityPoliciesProperties;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void getTasksShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksControllerIT.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-
 import com.querydsl.core.types.Predicate;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
@@ -37,6 +27,7 @@ import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -51,6 +42,17 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceTasksController.class)
 @EnableSpringDataWebSupport
@@ -83,6 +85,14 @@ public class ProcessInstanceEntityTasksControllerIT {
 
     @MockBean
     private TaskLookupRestrictionService taskLookupRestrictionService;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void getTasksShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityVariableEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityVariableEntityControllerIT.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
@@ -37,6 +27,7 @@ import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -51,6 +42,18 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceVariableController.class)
 @Import({
@@ -86,6 +89,14 @@ public class ProcessInstanceEntityVariableEntityControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void getVariablesShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelAdminControllerIT.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -35,6 +27,7 @@ import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessModelEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -45,6 +38,16 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessModelAdminController.class)
 @EnableSpringDataWebSupport
@@ -80,6 +83,14 @@ public class ProcessModelAdminControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnProcessModelById() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelControllerIT.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -37,6 +27,7 @@ import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessModelEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,6 +38,18 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessModelController.class)
 @EnableSpringDataWebSupport
@@ -82,6 +85,14 @@ public class ProcessModelControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void shouldReturnProcessModelById() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
@@ -15,18 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.querydsl.core.types.Predicate;
-import java.util.Collections;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
@@ -39,6 +28,7 @@ import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -53,6 +43,19 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TaskAdminController.class)
 @Import({
@@ -91,6 +94,14 @@ public class TaskEntityAdminControllerIT {
 
     @MockBean
     private TaskPermissionsHelper taskPermissionsHelper;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void allTasksShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
@@ -15,20 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import com.querydsl.core.types.Predicate;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
@@ -45,6 +31,7 @@ import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -59,6 +46,21 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TaskController.class)
 @Import({
@@ -94,6 +96,14 @@ public class TaskEntityControllerIT {
 
     @MockBean
     private SecurityPoliciesProperties securityPoliciesProperties;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void findAllShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
@@ -15,17 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.querydsl.core.types.Predicate;
-import java.util.Collections;
-import java.util.List;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -37,6 +27,7 @@ import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -48,6 +39,18 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.activiti.cloud.services.query.rest.TestTaskEntityBuilder.buildDefaultTask;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "activiti.rest.enable-deletion=true")
 @WebMvcTest(TaskDeleteController.class)
@@ -86,6 +89,14 @@ public class TaskEntityDeleteControllerIT {
 
     @MockBean
     private TaskLookupRestrictionService taskLookupRestrictionService;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void deleteTasksShouldReturnAllTasksAndDeleteThem() throws Exception{

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityVariableEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityVariableEntityControllerIT.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
@@ -37,6 +27,7 @@ import org.activiti.cloud.services.query.model.TaskVariableEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -51,6 +42,18 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TaskVariableController.class)
 @Import({
@@ -86,6 +89,14 @@ public class TaskEntityVariableEntityControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void getVariablesShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/VariableEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/VariableEntityAdminControllerIT.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.query.rest;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -36,6 +37,7 @@ import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.model.TaskVariableEntity;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -81,6 +83,14 @@ public class VariableEntityAdminControllerIT {
 
     @MockBean
     private TaskRepository taskRepository;
+
+    @MockBean
+    private ProcessInstanceService processInstanceService;
+
+    @BeforeEach
+    void setUp() {
+        assertThat(processInstanceService).isNotNull();
+    }
 
     @Test
     public void findAllShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/resources/query-messaging.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/main/resources/query-messaging.properties
@@ -8,3 +8,5 @@ spring.cloud.stream.instanceCount=${activiti.cloud.messaging.partition-count}
 
 springfox.enabled=false
 springdoc.enabled=true
+
+spring.jackson.mapper.default-view-inclusion=true

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.starter.tests;
 
-import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.ProcessInstance.ProcessInstanceStatus;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
@@ -910,9 +909,9 @@ public class QueryProcessInstancesEntityIT {
     @MethodSource({"processInstanceWithVariablesData"})
     void should_getProcessInstanceWithVariables(String variableDefinitions, int expectedSize, List<String> expectedVariableValues) {
         ProcessInstance runningProcess1 = processInstanceBuilder.aRunningProcessInstance("first");
-        VariableInstance createdVariable1 = variableBuilder.aCreatedVariableWithDefinitionId("aaa", "bbb", "string", "ccc")
+        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "bbb", "string", "ccc")
             .onProcessInstance(runningProcess1);
-        VariableInstance createdVariable2 = variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
             .onProcessInstance(runningProcess1);
         eventsAggregator.sendAll();
 
@@ -942,14 +941,14 @@ public class QueryProcessInstancesEntityIT {
     @Test
     void should_getAllProcessInstancesWithVariables() {
         ProcessInstance runningProcess1 = processInstanceBuilder.aRunningProcessInstance("first");
-        VariableInstance createdVariable1 = variableBuilder.aCreatedVariableWithDefinitionId("aaa", "111", "string", "ccc")
+        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "111", "string", "ccc")
             .onProcessInstance(runningProcess1);
-        VariableInstance createdVariable2 = variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
             .onProcessInstance(runningProcess1);
         ProcessInstance runningProcess2 = processInstanceBuilder.aRunningProcessInstance("second");
-        VariableInstance createdVariable3 = variableBuilder.aCreatedVariableWithDefinitionId("aaa", "222", "string", "ccc")
+        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "222", "string", "ccc")
             .onProcessInstance(runningProcess2);
-        VariableInstance createdVariable4 = variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
             .onProcessInstance(runningProcess2);
         eventsAggregator.sendAll();
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
@@ -7,6 +7,7 @@ spring.cloud.stream.bindings.queryConsumer.destination=engineEvents
 spring.cloud.stream.bindings.queryConsumer.group=query
 spring.cloud.stream.bindings.queryConsumer.contentType=application/json
 spring.jackson.serialization.fail-on-unwrapped-type-identifiers=false
+spring.jackson.mapper.default-view-inclusion=true
 
 spring.cloud.stream.bindings.notificationsConsumer.destination=engineEvents
 spring.cloud.stream.bindings.notificationsConsumer.group=notifications

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregato
 import org.activiti.cloud.services.events.message.CloudRuntimeEventMessageBuilderFactory;
 import org.activiti.cloud.services.events.message.ExecutionContextMessageBuilderFactory;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
+import org.activiti.spring.process.CachingProcessExtensionService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -269,8 +270,9 @@ public class CloudEventsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ToCloudVariableEventConverter cloudVariableEventConverter(RuntimeBundleInfoAppender runtimeBundleInfoAppender) {
-        return new ToCloudVariableEventConverter(runtimeBundleInfoAppender);
+    public ToCloudVariableEventConverter cloudVariableEventConverter(RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+                                                                     CachingProcessExtensionService processExtensionService) {
+        return new ToCloudVariableEventConverter(runtimeBundleInfoAppender, processExtensionService);
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/ToCloudVariableEventConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/ToCloudVariableEventConverterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.events.converter;
+
+import org.activiti.api.model.shared.model.VariableInstance;
+import org.activiti.api.runtime.event.impl.VariableCreatedEventImpl;
+import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
+import org.activiti.cloud.api.model.shared.events.CloudVariableCreatedEvent;
+import org.activiti.spring.process.CachingProcessExtensionService;
+import org.activiti.spring.process.model.Extension;
+import org.activiti.spring.process.model.VariableDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ToCloudVariableEventConverterTest {
+
+    @InjectMocks
+    private ToCloudVariableEventConverter toCloudVariableEventConverter;
+
+    @Mock
+    private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
+    @Mock
+    private CachingProcessExtensionService processExtensionService;
+
+    @Test
+    void should_convertToCloudVariableCreatedEventWithVariableDefinitionId() {
+        VariableInstance variableInstance = new VariableInstanceImpl<>("variableName", "string", "example", "processInstanceId", null);
+        VariableCreatedEventImpl event = new VariableCreatedEventImpl(variableInstance, "processDefinitionId");
+
+        Extension extension = new Extension();
+        HashMap<String, VariableDefinition> properties = new HashMap<>();
+        VariableDefinition variableDefinition = new VariableDefinition();
+        variableDefinition.setName("variableName");
+        variableDefinition.setId("variableDefinitionId");
+        properties.put("variableDefinitionId", variableDefinition);
+        extension.setProperties(properties);
+
+        when(processExtensionService.getExtensionsForId("processDefinitionId")).thenReturn(extension);
+
+        CloudVariableCreatedEvent cloudVariableCreatedEvent = toCloudVariableEventConverter.from(event);
+
+        assertThat(cloudVariableCreatedEvent.getVariableDefinitionId()).isEqualTo("variableDefinitionId");
+        VariableInstance entity = cloudVariableCreatedEvent.getEntity();
+        assertThat(entity.getName()).isEqualTo("variableName");
+        assertThat(entity.getType()).isEqualTo("string");
+        assertThat((String) entity.getValue()).isEqualTo("example");
+        assertThat(entity.getProcessInstanceId()).isEqualTo("processInstanceId");
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/ToCloudVariableEventConverterTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/ToCloudVariableEventConverterTest.java
@@ -19,6 +19,7 @@ import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.runtime.event.impl.VariableCreatedEventImpl;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.cloud.api.model.shared.events.CloudVariableCreatedEvent;
+import org.activiti.cloud.api.model.shared.impl.events.CloudVariableCreatedEventImpl;
 import org.activiti.spring.process.CachingProcessExtensionService;
 import org.activiti.spring.process.model.Extension;
 import org.activiti.spring.process.model.VariableDefinition;
@@ -31,6 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,5 +70,6 @@ class ToCloudVariableEventConverterTest {
         assertThat(entity.getType()).isEqualTo("string");
         assertThat((String) entity.getValue()).isEqualTo("example");
         assertThat(entity.getProcessInstanceId()).isEqualTo("processInstanceId");
+        verify(runtimeBundleInfoAppender).appendRuntimeBundleInfoTo(any(CloudVariableCreatedEventImpl.class));
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -15,19 +15,6 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
@@ -46,6 +33,7 @@ import org.activiti.cloud.services.rest.assemblers.CollectionModelAssembler;
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.common.util.DateFormatterProvider;
 import org.activiti.engine.RepositoryService;
+import org.activiti.spring.process.CachingProcessExtensionService;
 import org.activiti.spring.process.variable.VariableValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,6 +48,19 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceVariableControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -108,6 +109,9 @@ public class ProcessInstanceVariableControllerImplIT {
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;
 
+    @MockBean
+    private CachingProcessExtensionService cachingProcessExtensionService;
+
     @BeforeEach
     public void setUp() {
         //this assertion is not really necessary. It's only here to remove warning
@@ -117,6 +121,7 @@ public class ProcessInstanceVariableControllerImplIT {
         assertThat(resourcesAssembler).isNotNull();
         assertThat(processEngineChannels).isNotNull();
         assertThat(processDeployedProducer).isNotNull();
+        assertThat(cachingProcessExtensionService).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/SimpleProcess-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/SimpleProcess-extensions.json
@@ -3,7 +3,17 @@
   "name": "myProcess.bpmn",
   "extensions": {
     "SimpleProcess": {
-      "properties": {},
+      "properties": {
+        "0099e926-0af4-41ce-8ad9-a87fcc14c0b5": {
+          "id": "0099e926-0af4-41ce-8ad9-a87fcc14c0b5",
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "model": {
+            "$ref": "#/$defs/primitive/string"
+          }
+        }
+      },
       "mappings": {
         "sid-CDFE7219-4627-43E9-8CA8-866CC38EBA94": {
           "mappingType": "MAP_ALL"

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/basic-inclusive-gateway-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/basic-inclusive-gateway-extensions.json
@@ -3,7 +3,14 @@
   "name": "myProcess.bpmn",
   "extensions": {
     "basicInclusiveGateway": {
-      "properties": {},
+      "properties": {
+        "0099e926-0af4-41ce-8ad9-a87fcc14c0b5": {
+          "id": "0099e926-0af4-41ce-8ad9-a87fcc14c0b5",
+          "name": "input",
+          "type": "integer",
+          "required": false
+        }
+      },
       "mappings": {
         "task0": {
           "mappingType": "MAP_ALL"

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/basicExclusiveGateway-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/basicExclusiveGateway-extensions.json
@@ -3,7 +3,14 @@
   "name": "myProcess.bpmn",
   "extensions": {
     "basicExclusiveGateway": {
-      "properties": {},
+      "properties": {
+        "0099e926-0af4-41ce-8ad9-a87fcc14c0b5": {
+          "id": "0099e926-0af4-41ce-8ad9-a87fcc14c0b5",
+          "name": "input",
+          "type": "integer",
+          "required": false
+        }
+      },
       "mappings": {
         "task1": {
           "mappingType": "MAP_ALL"

--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
@@ -17,12 +17,12 @@ package org.activiti.cloud.starters.test.builder;
 
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.api.task.model.Task;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableCreatedEventImpl;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableDeletedEventImpl;
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableUpdatedEventImpl;
 import org.activiti.cloud.starters.test.EventsAggregator;
-import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 
 public class VariableEventContainedBuilder {
 
@@ -38,10 +38,17 @@ public class VariableEventContainedBuilder {
     public <T> VariableEventContainedBuilder aCreatedVariable(String name,
                                                               T value,
                                                               String type) {
-        variableInstance = buildVariable(name,
-                                         type,
-                                         value);
-        eventsAggregator.addEvents(new CloudVariableCreatedEventImpl(variableInstance));
+        return aCreatedVariableWithDefinitionId(name, value, type, null);
+    }
+
+    public <T> VariableEventContainedBuilder aCreatedVariableWithDefinitionId(String name,
+                                                                              T value,
+                                                                              String type,
+                                                                              String variableDefinitionId) {
+        variableInstance = buildVariable(name, type, value);
+        CloudVariableCreatedEventImpl cloudVariableCreatedEvent = new CloudVariableCreatedEventImpl(variableInstance);
+        cloudVariableCreatedEvent.setVariableDefinitionId(variableDefinitionId);
+        eventsAggregator.addEvents(cloudVariableCreatedEvent);
         return this;
     }
 


### PR DESCRIPTION
Saves the variable definition id to query service database and retrieves it in the process-instances endpoint with a query param: variableDefinitions=...
Ref: https://github.com/Activiti/Activiti/issues/3927