### PR TITLE
[#3944] fix disabled open in view findAllWithVariables service

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -85,6 +86,7 @@ public class ProcessInstanceService {
         return processInstanceRepository.findAll(transformedPredicate, pageable);
     }
 
+    @Transactional
     public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variables, Pageable pageable) {
         Session session = entityManager.unwrap(Session.class);
         Filter filter = session.enableFilter("variableDefinitionIds");

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityDisabledOpenInViewIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityDisabledOpenInViewIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.starter.tests;
+
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(locations = "classpath:application-test.properties", properties = "spring.jpa.open-in-view=false")
+public class QueryProcessInstancesEntityDisabledOpenInViewIT extends QueryProcessInstancesEntityIT {
+
+}


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/3944

When running an application with spring.jpa.open-in-view=false, the query in org.activiti.cloud.services.query.rest.ProcessInstanceService#findAllWithVariables doesn't enable the filter variableDefinitionIds and returns all variables. Running the service in one transaction preserves the session and the enabled filter.