### PR TITLE
fix: update spring-cloud.version to 2021.0.3

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Dependencies Parent</name>
   <properties>
-    <spring-cloud.version>2021.0.2</spring-cloud.version>
+    <spring-cloud.version>2021.0.3</spring-cloud.version>
     <testcontainers.version>1.16.3</testcontainers.version>
     <liquibase.version>4.8.0</liquibase.version>
     <h2.version>1.4.200</h2.version>


### PR DESCRIPTION
To update Spring Cloud version compatible with Spring Boot: 2.7.0: https://spring.io/blog/2022/05/27/spring-cloud-2021-0-3-is-available-compatible-with-spring-boot-2-7-0

Part of https://github.com/Activiti/Activiti/issues/3949