### PR TITLE
AAE-9131 Fix JWS Authentication error

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/security/src/main/java/org/activiti/cloud/services/notifications/qraphql/ws/security/JWSAuthenticationManager.java
+++ b/activiti-cloud-notifications-graphql-service/services/security/src/main/java/org/activiti/cloud/services/notifications/qraphql/ws/security/JWSAuthenticationManager.java
@@ -43,18 +43,22 @@ public class JWSAuthenticationManager implements AuthenticationManager {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         JWSAuthentication token = null;
         try {
-            token = JWSAuthentication.class.cast(authentication);
+            if(authentication instanceof JWSAuthentication) {
 
-            String credentials = (String) token.getCredentials();
+                token = JWSAuthentication.class.cast(authentication);
 
-            AccessToken accessToken = tokenVerifier.verifyToken(credentials);
+                String credentials = (String) token.getCredentials();
 
-            Collection<? extends GrantedAuthority> authorities = authoritiesMapper.getGrantedAuthorities(accessToken.getRealmAccess()
-                                                                                                                    .getRoles());
-            User user = new User(accessToken.getPreferredUsername(), credentials, authorities);
+                AccessToken accessToken = tokenVerifier.verifyToken(credentials);
 
-            token = new JWSAuthentication(credentials, user, authorities);
-            token.setDetails(accessToken);
+                Collection<? extends GrantedAuthority> authorities = authoritiesMapper
+                    .getGrantedAuthorities(accessToken.getRealmAccess().getRoles());
+
+                User user = new User(accessToken.getPreferredUsername(), credentials, authorities);
+
+                token = new JWSAuthentication(credentials, user, authorities);
+                token.setDetails(accessToken);
+            }
 
         } catch (VerificationException e) {
             throw new BadCredentialsException("Invalid token", e);

--- a/activiti-cloud-notifications-graphql-service/services/security/src/test/java/org/activiti/cloud/services/notifications/qraphql/ws/security/JWSAuthenticationManagerTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/security/src/test/java/org/activiti/cloud/services/notifications/qraphql/ws/security/JWSAuthenticationManagerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.notifications.qraphql.ws.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+
+@ExtendWith(MockitoExtension.class)
+public class JWSAuthenticationManagerTest {
+
+    @Mock
+    BearerTokenAuthentication bearerTokenAuthentication;
+
+    @InjectMocks
+    private JWSAuthenticationManager authenticationManager;
+
+    @Test
+    public void shouldReturnNullWhenIsNotJWSAuthentication() {
+        assertThat(authenticationManager.authenticate(bearerTokenAuthentication))
+        .isNull();
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapter.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapter.java
@@ -56,13 +56,13 @@ public class KeycloakResourceJwtAdapter implements JwtAdapter {
     }
 
     private List<String> getFromClient(String clientId, Jwt jwt) {
-        JSONObject resourceAccess = jwt.getClaim("resource_access");
-
-        if (resourceAccess.get(clientId) != null) {
-            return getRoles((JSONObject) resourceAccess.get(clientId));
-        } else {
-            return Collections.emptyList();
+        if(jwt.hasClaim("resource_access")) {
+            JSONObject resourceAccess = jwt.getClaim("resource_access");
+            if (resourceAccess.get(clientId) != null) {
+                return getRoles((JSONObject) resourceAccess.get(clientId));
+            }
         }
+        return Collections.emptyList();
     }
 
     private List<String> getRoles(JSONObject getRolesParent) {

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.common.security.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.shaded.json.JSONObject;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class KeycloakResourceJwtAdapterTest {
+
+    @Mock
+    Jwt jwt;
+
+    @InjectMocks
+    KeycloakResourceJwtAdapter keycloakResourceJwtAdapter;
+
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(keycloakResourceJwtAdapter, "resourceId",
+            "app");
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenResourceAccessIsNull() {
+        when(jwt.hasClaim("resource_access")).thenReturn(false);
+        assertThat(keycloakResourceJwtAdapter.getRoles()).isEmpty();
+    }
+
+    @Test
+    public void shouldNotThrowAnyExceptionWhenRolesIsNull(){
+        JSONObject rolesParent = new JSONObject();
+        rolesParent.put("roles", null);
+        when(jwt.hasClaim("resource_access")).thenReturn(true);
+        when(jwt.getClaim("resource_access")).thenReturn(rolesParent);
+
+        assertDoesNotThrow(() -> keycloakResourceJwtAdapter.getRoles());
+    }
+
+    @Test
+    public void shouldReturnRoles(){
+        JSONObject client = new JSONObject();
+        JSONObject roles = new JSONObject();
+        roles.put("roles", List.of("roleA", "roleB"));
+        client.put("app", roles);
+        when(jwt.hasClaim("resource_access")).thenReturn(true);
+        when(jwt.getClaim("resource_access")).thenReturn(client);
+
+        assertThat(keycloakResourceJwtAdapter.getRoles())
+            .hasSize(2)
+            .containsExactly("roleA", "roleB");
+    }
+
+}


### PR DESCRIPTION
Fix JWSAuthenticationManager returning null in case the Authentication is not a JWSAuthentication. In this way, the Spring ProviderManager will manage the wrong token exception received from the previous provider (JwtAuthenticationProvider).

Also fixing KeycloakResourceJwtAdapter to avoidNullPointerException when user have no resource roles