### PR TITLE
fix(GH-3961): add integration context Liquibase script in Query Service for M17 upgrade

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/15-alter.oracle.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/15-alter.oracle.schema.7.4.0.sql
@@ -16,3 +16,6 @@
 
 update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
   where id not like '%:%:%';
+
+update integration_context set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+  where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/15-alter.oracle.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/15-alter.oracle.schema.7.4.0.sql
@@ -17,5 +17,5 @@
 update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
   where id not like '%:%:%';
 
-update integration_context set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+update integration_context set id = concat(process_instance_id, ':', client_id, ':', execution_id)
   where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
@@ -16,3 +16,6 @@
 
 update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
   where id not like '%:%:%';
+
+update integration_context set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+  where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
@@ -17,5 +17,5 @@
 update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
   where id not like '%:%:%';
 
-update integration_context set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+update integration_context set id = concat(process_instance_id, ':', client_id, ':', execution_id)
   where id not like '%:%:%';


### PR DESCRIPTION
To add missing update for the integration_context table  in Query Service for M17 upgrade

Part of https://github.com/Activiti/Activiti/issues/3961