### PR TITLE
Allow same project name for different users

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ProjectEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ProjectEntity.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.modeling.entity;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import java.util.HashSet;
-import java.util.Set;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -31,9 +23,21 @@ import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
 import org.hibernate.annotations.GenericGenerator;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 /**
  * Project model entity
  */
+@Table(name = "Project", uniqueConstraints = @UniqueConstraint(columnNames = {"name", "createdBy"}))
 @Entity(name = "Project")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
@@ -49,7 +53,6 @@ public class ProjectEntity extends AuditableEntity<String> implements Project<St
     @GenericGenerator(name = "system-uuid", strategy = "uuid2")
     private String id;
 
-    @Column(unique = true)
     private String name;
 
     private String description;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/04.pg.update.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/04.pg.update.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table if exists project
+  drop constraint UK_3k75vvu7mevyvvb5may5lj8k7;
+alter table if exists project
+  add constraint unique_project_name_createdby unique (name, created_by);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/h2.schema.sql
@@ -54,7 +54,7 @@ create table project_models
 alter table model_versions
     add constraint UK_ei9juhk09r20q4bmvgpjrcrs3 unique (versions_version, versions_versioned_entity_id);
 alter table project
-    add constraint UK_3k75vvu7mevyvvb5may5lj8k7 unique (name);
+    add constraint unique_project_name_createdby unique (name, created_by);
 alter table model
     add constraint FKqjpgrrtoo1bryor3iymmb03pu foreign key (latest_version_version, latest_version_versioned_entity_id) references model_version;
 alter table model_versions

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
@@ -58,4 +58,13 @@
       splitStatements="true"
       stripComments="true"/>
   </changeSet>
+
+  <changeSet id="project-name-creator-uk" author="aae-modeling">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/04.pg.update.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
 </databaseChangeLog>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.modeling.rest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.cloud.modeling.api.Project;
+import org.activiti.cloud.modeling.repository.ProjectRepository;
+import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
+import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
+import org.activiti.cloud.services.modeling.entity.ProjectEntity;
+import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
+import static org.activiti.cloud.services.modeling.mock.MockFactory.project;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@SpringBootTest(classes = ModelingRestApplication.class)
+@WebAppConfiguration
+@DirtiesContext
+@Transactional
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ProjectControllerExistingNameIT {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    /*
+     The following test is to be run before other tests in this class
+     in order to create the projects with a different user.
+    */
+    @Test
+    @Order(1)
+    @Transactional(propagation = Propagation.NEVER)
+    @WithActivitiMockUser(username = "otherUser", roles = {"ACTIVITI_MODELER"})
+    public void should_createProjectWithOtherUser() throws Exception {
+        projectRepository.createProject(project("application-xy"));
+        projectRepository.createProject(project("creating-project"));
+        projectRepository.createProject(project("updating-project"));
+        projectRepository.createProject(project("copying-project"));
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+            .hasSize(4)
+            .extracting(ProjectEntity::getCreatedBy).containsOnly("otherUser");
+    }
+
+    @Test
+    @Order(2)
+    @Transactional(propagation = Propagation.NEVER)
+    @WithMockModelerUser
+    public void should_returnStatusCreated_when_importingProjectWithExistingNameCreatedByOtherUser() throws Exception {
+        MockMultipartFile zipFile = new MockMultipartFile("file",
+            "project-xy.zip",
+            "project/zip",
+            resourceAsByteArray("project/project-xy.zip"));
+
+        mockMvc.perform(multipart("/v1/projects/import")
+                .file(zipFile)
+                .accept(APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated());
+
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+            .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
+            .contains(tuple("otherUser", "application-xy"),
+                tuple("testuser", "application-xy"));
+    }
+
+    @Test
+    @Order(3)
+    @Transactional(propagation = Propagation.NEVER)
+    @WithMockModelerUser
+    public void should_returnStatusCreated_when_creatingProjectWithExistingNameCreatedByOtherUser() throws Exception {
+        mockMvc.perform(post("/v1/projects")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(project("creating-project"))))
+            .andExpect(status().isCreated());
+
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+            .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
+            .contains(tuple("otherUser", "creating-project"),
+                tuple("testuser", "creating-project"));
+    }
+
+    @Test
+    @Order(4)
+    @Transactional(propagation = Propagation.NEVER)
+    @WithMockModelerUser
+    public void should_returnStatusOk_when_updatingProjectWithExistingNameCreatedByOtherUser() throws Exception {
+        Project project = projectRepository.createProject(project("project-to-update"));
+
+        mockMvc.perform(put("/v1/projects/{projectId}",
+                project.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(project("updating-project"))))
+            .andExpect(status().isOk());
+
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+            .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
+            .contains(tuple("otherUser", "updating-project"),
+                tuple("testuser", "updating-project"));
+    }
+
+    @Test
+    @Order(5)
+    @Transactional(propagation = Propagation.NEVER)
+    @WithMockModelerUser
+    public void should_returnStatusOk_when_copyingProjectWithExistingNameCreatedByOtherUser() throws Exception {
+        Project project = projectRepository.createProject(project("project-to-copy"));
+
+        mockMvc.perform(post("/v1/projects/{projectId}/copy?name=copying-project", project.getId()))
+            .andExpect(status().isOk());
+
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+            .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
+            .contains(tuple("otherUser", "copying-project"),
+                tuple("testuser", "copying-project"));
+    }
+
+}


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/3979

Changes the unique constraint on project table from `(name)` to `(name, created_by)` so that different users may create a project with the same name. The same user cannot create a project with same name as his another project (in this case the POST response has 409 status).