### PR TITLE
fix(GH-3980): Add support for analytics variable extension property in Modeling Service Api

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-925-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>7.5.0-alpha.17</activiti.version>
+    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/ProcessVariable.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-api/src/main/java/org/activiti/cloud/modeling/api/process/ProcessVariable.java
@@ -41,6 +41,8 @@ public class ProcessVariable {
 
     private String displayName;
 
+    private boolean analytics;
+
     public String getId() {
         return id;
     }
@@ -95,5 +97,13 @@ public class ProcessVariable {
 
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public boolean isAnalytics() {
+        return analytics;
+    }
+
+    public void setAnalytics(boolean analytics) {
+        this.analytics = analytics;
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -378,6 +378,29 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "not": {
+              "properties": {
+                "analytics": {
+                  "enum": [
+                    false
+                  ]
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "type": {
+                "pattern": "integer|string|boolean|date|datetime",
+                "message": {
+                  "pattern": "Mismatch value type - {{name}}({{id}}). Expected type for analytics is one of integer|string|boolean|date|datetime"
+                }
+              }
+            }
+          }
         }
       ],
       "required": [

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -113,6 +113,9 @@
         },
         "displayName": {
           "type": "string"
+        },
+        "analytics": {
+          "type": "boolean"
         }
       },
       "dependencies": {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/resources/schema/process-extensions-schema.json
@@ -394,9 +394,9 @@
           "then": {
             "properties": {
               "type": {
-                "pattern": "integer|string|boolean|date|datetime",
+                "pattern": "^integer$|^string$|^boolean$|^date$",
                 "message": {
-                  "pattern": "Mismatch value type - {{name}}({{id}}). Expected type for analytics is one of integer|string|boolean|date|datetime"
+                  "pattern": "Mismatch value type - {{name}}({{id}}). Expected type for analytics is one of integer|string|boolean|date"
                 }
               }
             }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
@@ -98,11 +98,12 @@ public class ProcessExtensionsValidatorTest {
             SemanticModelValidationException.class);
 
         List<ModelValidationError> validationErrors = semanticModelValidationException.getValidationErrors();
-        assertThat(validationErrors).hasSize(3);
+        assertThat(validationErrors).hasSize(4);
         assertThat(validationErrors).
             extracting("problem")
-            .containsOnly("string [file] does not match pattern integer|string|boolean|date|datetime",
-                          "string [folder] does not match pattern integer|string|boolean|date|datetime",
-                          "string [json] does not match pattern integer|string|boolean|date|datetime");
+            .containsOnly("string [datetime] does not match pattern ^integer$|^string$|^boolean$|^date$",
+                          "string [file] does not match pattern ^integer$|^string$|^boolean$|^date$",
+                          "string [folder] does not match pattern ^integer$|^string$|^boolean$|^date$",
+                          "string [json] does not match pattern ^integer$|^string$|^boolean$|^date$");
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
@@ -15,11 +15,6 @@
  */
 package org.activiti.cloud.services.modeling.validation.extensions;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
-
-import java.io.IOException;
-import java.util.List;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
 import org.activiti.cloud.modeling.api.config.ModelingApiAutoConfiguration;
@@ -34,6 +29,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 @SpringBootTest
 @ContextConfiguration(classes = {
@@ -82,4 +83,9 @@ public class ProcessExtensionsValidatorTest {
         processExtensionsValidator.validateModelExtensions(fileContent, ValidationContext.EMPTY_CONTEXT);
     }
 
+    @Test
+    public void shouldBeValidWhenAnalyticsIsPresent() throws IOException {
+        byte[] fileContent = FileUtils.resourceAsByteArray("extensions/process-with-analytics-variable.json");
+        processExtensionsValidator.validateModelExtensions(fileContent, ValidationContext.EMPTY_CONTEXT);
+    }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsValidatorTest.java
@@ -88,4 +88,21 @@ public class ProcessExtensionsValidatorTest {
         byte[] fileContent = FileUtils.resourceAsByteArray("extensions/process-with-analytics-variable.json");
         processExtensionsValidator.validateModelExtensions(fileContent, ValidationContext.EMPTY_CONTEXT);
     }
+
+    @Test
+    public void shouldBeInvalidWhenAnalyticsIsPresent() throws IOException {
+        byte[] fileContent = FileUtils.resourceAsByteArray("extensions/process-with-invalid-analytics-variable.json");
+
+        SemanticModelValidationException semanticModelValidationException = catchThrowableOfType(
+            () -> processExtensionsValidator.validateModelExtensions(fileContent, ValidationContext.EMPTY_CONTEXT),
+            SemanticModelValidationException.class);
+
+        List<ModelValidationError> validationErrors = semanticModelValidationException.getValidationErrors();
+        assertThat(validationErrors).hasSize(3);
+        assertThat(validationErrors).
+            extracting("problem")
+            .containsOnly("string [file] does not match pattern integer|string|boolean|date|datetime",
+                          "string [folder] does not match pattern integer|string|boolean|date|datetime",
+                          "string [json] does not match pattern integer|string|boolean|date|datetime");
+    }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
@@ -5,18 +5,42 @@
       "constants": {},
       "mappings": {},
       "properties": {
-        "47b3a61f-02c5-4e7e-bafb-f95e1a71d23d": {
-          "id": "47b3a61f-02c5-4e7e-bafb-f95e1a71d23d",
-          "name": "test",
+        "6b1feabe-fb23-11ec-b939-0242ac120002": {
+          "id": "6b1feabe-fb23-11ec-b939-0242ac120002",
+          "name": "var_string",
           "type": "string",
           "required": false,
-          "model": {
-            "$ref": "#/$defs/primitive/string"
-          },
+          "analytics": true
+        },
+        "73dd752c-fb23-11ec-b939-0242ac120002": {
+          "id": "73dd752c-fb23-11ec-b939-0242ac120002",
+          "name": "var_integer",
+          "type": "integer",
+          "required": false,
+          "analytics": true
+        },
+        "78f6e6a6-fb23-11ec-b939-0242ac120002": {
+          "id": "78f6e6a6-fb23-11ec-b939-0242ac120002",
+          "name": "var_boolean",
+          "type": "boolean",
+          "required": false,
+          "analytics": true
+        },
+        "80b8e3b2-fb23-11ec-b939-0242ac120002": {
+          "id": "80b8e3b2-fb23-11ec-b939-0242ac120002",
+          "name": "var_date",
+          "type": "date",
+          "required": false,
+          "analytics": true
+        },
+        "9c3401d0-fb23-11ec-b939-0242ac120002": {
+          "id": "9c3401d0-fb23-11ec-b939-0242ac120002",
+          "name": "var_datetime",
+          "type": "datetime",
+          "required": false,
           "analytics": true
         }
-      },
-      "assignments": {}
+      }
     }
   }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
@@ -32,13 +32,6 @@
           "type": "date",
           "required": false,
           "analytics": true
-        },
-        "9c3401d0-fb23-11ec-b939-0242ac120002": {
-          "id": "9c3401d0-fb23-11ec-b939-0242ac120002",
-          "name": "var_datetime",
-          "type": "datetime",
-          "required": false,
-          "analytics": true
         }
       }
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-analytics-variable.json
@@ -1,0 +1,22 @@
+{
+  "id": "process-baa8aa57-7cbb-40bc-bd70-a1da5f7b0311",
+  "extensions": {
+    "Process_jEKhhV0rp": {
+      "constants": {},
+      "mappings": {},
+      "properties": {
+        "47b3a61f-02c5-4e7e-bafb-f95e1a71d23d": {
+          "id": "47b3a61f-02c5-4e7e-bafb-f95e1a71d23d",
+          "name": "test",
+          "type": "string",
+          "required": false,
+          "model": {
+            "$ref": "#/$defs/primitive/string"
+          },
+          "analytics": true
+        }
+      },
+      "assignments": {}
+    }
+  }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-invalid-analytics-variable.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-invalid-analytics-variable.json
@@ -1,0 +1,33 @@
+{
+  "id": "process-baa8aa57-7cbb-40bc-bd70-a1da5f7b0311",
+  "extensions": {
+    "Process_jEKhhV0rp": {
+      "constants": {},
+      "mappings": {},
+      "properties": {
+        "c49e32f8-fb23-11ec-b939-0242ac120002": {
+          "id": "c49e32f8-fb23-11ec-b939-0242ac120002",
+          "name": "var_file",
+          "type": "file",
+          "required": false,
+          "analytics": true
+        },
+        "f2be210c-fb23-11ec-b939-0242ac120002": {
+          "id": "f2be210c-fb23-11ec-b939-0242ac120002",
+          "name": "var_folder",
+          "type": "folder",
+          "required": false,
+          "analytics": true
+
+        },
+        "ecc5c8b8-fb23-11ec-b939-0242ac120002": {
+          "id": "ecc5c8b8-fb23-11ec-b939-0242ac120002",
+          "name": "var_json",
+          "type": "json",
+          "required": false,
+          "analytics": true
+        }
+      }
+    }
+  }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-invalid-analytics-variable.json
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/resources/extensions/process-with-invalid-analytics-variable.json
@@ -26,6 +26,13 @@
           "type": "json",
           "required": false,
           "analytics": true
+        },
+        "9c3401d0-fb23-11ec-b939-0242ac120002": {
+          "id": "9c3401d0-fb23-11ec-b939-0242ac120002",
+          "name": "var_datetime",
+          "type": "datetime",
+          "required": false,
+          "analytics": true
         }
       }
     }

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -21,7 +21,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>7.5.0-alpha.17</activiti.version>
+    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.14.0</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -21,7 +21,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-925-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.14.0</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/pom.xml
@@ -21,7 +21,7 @@
     <module>activiti-cloud-acceptance-tests-modeling</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
     <everit-json-schema.version>1.14.0</everit-json-schema.version>
     <commons-collections4.version>4.4</commons-collections4.version>
   </properties>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>7.5.0-alpha.17</activiti.version>
+    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-925-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-925-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>7.5.0-alpha.17</activiti.version>
+    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>7.5.0-alpha.17</activiti.version>
+    <activiti.version>0.0.1-PR-3981-708-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -35,7 +35,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-3981-778-SNAPSHOT</activiti.version>
+    <activiti.version>0.0.1-PR-3981-925-SNAPSHOT</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
This PR adds `analytics` boolean property to process variable extensions schema for the following eligible variable types: 

- [x] `integer`
- [x] `string`
- [x] `boolean`
- [x] `date`

Depends on https://github.com/Activiti/Activiti/pull/3981

Part of https://github.com/Activiti/Activiti/issues/3980