### PR TITLE
Remove redundant auth check

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
@@ -19,10 +19,8 @@ import java.util.List;
 import org.activiti.cloud.identity.model.Group;
 import org.activiti.cloud.identity.model.User;
 import org.activiti.cloud.identity.model.UserRoles;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-@PreAuthorize("isAuthenticated()")
 public interface IdentityManagementService {
 
   List<User> findUsers(UserSearchParams userSearchParams);


### PR DESCRIPTION
When multiple threads are used, the security context does not get propagated between them, causing exceptions like:
```
org.springframework.security.authentication.AuthenticationCredentialsNotFoundException: An Authentication object was not found in the SecurityContext
```
We can remove the root cause since it was added as an extra security layer, made redundant by the main security on controllers