### PR TITLE
Retrieve process variables by varName and processKey

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/17-alter.oracle.schema.7.4.1.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/17-alter.oracle.schema.7.4.1.sql
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+alter table process_variable
+    add column if not exists process_definition_key varchar(255);
+
+update process_variable pv set process_definition_key = pi.process_definition_key from process_instance PI
+  where pv.process_instance_id = pi.id;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/17-alter.pg.schema.7.4.1.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/17-alter.pg.schema.7.4.1.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table process_variable
+    add column if not exists process_definition_key varchar(255);
+
+update process_variable pv set process_definition_key = pi.process_definition_key from process_instance PI
+  where pv.process_instance_id = pi.id;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
@@ -120,6 +120,7 @@ create table process_variable
     type                varchar(255),
     value               text,
     variable_definition_id varchar(64),
+    process_definition_key varchar(255),
     primary key (id)
 );
 create table task

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
@@ -349,4 +349,25 @@
              splitStatements="true"
              stripComments="true"/>
   </changeSet>
+
+  <changeSet author="activiti-query"
+    id="alter17-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/17-alter.pg.schema.7.4.1.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
+    id="alter17-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+      encoding="utf8"
+      path="changelog/17-alter.oracle.schema.7.4.1.sql"
+      relativeToChangelogFile="true"
+      splitStatements="false"
+      stripComments="true"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessInstanceEntity.java
@@ -128,7 +128,7 @@ public class ProcessInstanceEntity extends ActivitiEntityMetadata implements Clo
     private Set<TaskEntity> tasks = new LinkedHashSet<>();
 
     @JsonView(JsonViews.ProcessVariables.class)
-    @Filter(name = "variableDefinitionIds")
+    @Filter(name = "variablesFilter")
     @OneToMany(fetch=FetchType.LAZY)
     @JoinColumn(name = "processInstanceId", referencedColumnName = "id", insertable = false, updatable = false
 		, foreignKey = @javax.persistence.ForeignKey(value = ConstraintMode.NO_CONSTRAINT, name = "none"))

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ProcessVariableEntity.java
@@ -30,7 +30,11 @@ import javax.persistence.Table;
 import java.util.Date;
 import java.util.Objects;
 
-@FilterDef(name = "variableDefinitionIds", parameters = @ParamDef(name="variables", type = "string"), defaultCondition = "variable_definition_id in (:variables)")
+@FilterDef(name = "variablesFilter",
+        parameters = {
+            @ParamDef(name = "variableKeys", type = "string")
+        },
+        defaultCondition = "concat(process_definition_key, '/', name) in (:variableKeys)")
 @Entity(name="ProcessVariable")
 @Table(name = "PROCESS_VARIABLE",
         indexes = {
@@ -48,6 +52,8 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
     private Long id;
 
     private String variableDefinitionId;
+
+    private String processDefinitionKey;
 
     public ProcessVariableEntity() {
     }
@@ -100,6 +106,14 @@ public class ProcessVariableEntity extends AbstractVariableEntity {
 
     public void setVariableDefinitionId(String variableDefinitionId) {
         this.variableDefinitionId = variableDefinitionId;
+    }
+
+    public String getProcessDefinitionKey() {
+        return processDefinitionKey;
+    }
+
+    public void setProcessDefinitionKey(String processDefinitionKey) {
+        this.processDefinitionKey = processDefinitionKey;
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/TaskEntity.java
@@ -184,7 +184,7 @@ public class TaskEntity extends ActivitiEntityMetadata implements QueryCloudTask
     private Set<TaskVariableEntity> variables = new LinkedHashSet<>();
 
     @JsonView(JsonViews.ProcessVariables.class)
-    @Filter(name = "variableDefinitionIds")
+    @Filter(name = "variablesFilter")
     @ManyToMany(fetch=FetchType.LAZY, cascade = CascadeType.MERGE)
     @JoinTable(
         name = "task_process_variable",

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessVariableCreatedEventHandler.java
@@ -76,6 +76,7 @@ public class ProcessVariableCreatedEventHandler {
                                                                          null);
         variableEntity.setValue(variableCreatedEvent.getEntity().getValue());
         variableEntity.setVariableDefinitionId(variableCreatedEvent.getVariableDefinitionId());
+        variableEntity.setProcessDefinitionKey(variableCreatedEvent.getProcessDefinitionKey());
         variableEntity.setProcessInstance(processInstanceEntity);
 
         entityManager.persist(variableEntity);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
@@ -62,7 +62,7 @@ public class ProcessInstanceController {
     }
 
     @JsonView(JsonViews.General.class)
-    @RequestMapping(method = RequestMethod.GET, params = "!variableDefinitions")
+    @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
     public PagedModel<EntityModel<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                  Pageable pageable) {
         return pagedCollectionModelAssembler.toModel(pageable,
@@ -71,12 +71,12 @@ public class ProcessInstanceController {
     }
 
     @JsonView(JsonViews.ProcessVariables.class)
-    @RequestMapping(method = RequestMethod.GET, params = "variableDefinitions")
+    @RequestMapping(method = RequestMethod.GET, params = "variableKeys")
     public PagedModel<EntityModel<CloudProcessInstance>> findAllWithVariables(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
-                                                                              @RequestParam(value = "variableDefinitions", required = false, defaultValue = "") List<String> variables,
+                                                                              @RequestParam(value = "variableKeys", required = false, defaultValue = "") List<String> variableKeys,
                                                                               Pageable pageable) {
         return pagedCollectionModelAssembler.toModel(pageable,
-            processInstanceService.findAllWithVariables(predicate, variables, pageable),
+            processInstanceService.findAllWithVariables(predicate, variableKeys, pageable),
             processInstanceRepresentationModelAssembler);
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -87,10 +87,10 @@ public class ProcessInstanceService {
     }
 
     @Transactional
-    public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variables, Pageable pageable) {
+    public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variableKeys, Pageable pageable) {
         Session session = entityManager.unwrap(Session.class);
-        Filter filter = session.enableFilter("variableDefinitionIds");
-        filter.setParameterList("variables", variables);
+        Filter filter = session.enableFilter("variablesFilter");
+        filter.setParameterList("variableKeys", variableKeys);
         Page<ProcessInstanceEntity> processInstanceEntities = findAll(predicate, pageable);
         // Due to performance issues (e.g. https://github.com/Activiti/Activiti/issues/3139)
         // we have to explicitly initialize the lazy loaded field to be able to work with disabled Open Session in View

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -92,7 +92,7 @@ public class TaskController {
     }
 
     @JsonView(JsonViews.General.class)
-    @RequestMapping(method = RequestMethod.GET, params = "!variableDefinitions")
+    @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
     public PagedModel<EntityModel<QueryCloudTask>> findAll(@RequestParam(name = "rootTasksOnly", defaultValue = "false") Boolean rootTasksOnly,
                                                        @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,
                                                        @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
@@ -103,15 +103,15 @@ public class TaskController {
     }
 
     @JsonView(JsonViews.ProcessVariables.class)
-    @RequestMapping(method = RequestMethod.GET, params = "variableDefinitions")
+    @RequestMapping(method = RequestMethod.GET, params = "variableKeys")
     public PagedModel<EntityModel<QueryCloudTask>> findAllWithProcessVariables(@RequestParam(name = "rootTasksOnly", defaultValue = "false") Boolean rootTasksOnly,
                                                                                              @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,
                                                                                              @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
-                                                                                             @RequestParam(value = "variableDefinitions", required = false, defaultValue = "") List<String> processVariableDefinitions,
+                                                                                             @RequestParam(value = "variableKeys", required = false, defaultValue = "") List<String> processVariableKeys,
                                                                                              VariableSearch variableSearch,
                                                                                              Pageable pageable) {
         return taskControllerHelper.findAllWithProcessVariables(predicate, variableSearch, pageable, Arrays.asList(new RootTasksFilter(rootTasksOnly),
-            new StandAloneTaskFilter(standalone), taskLookupRestrictionService), processVariableDefinitions);
+            new StandAloneTaskFilter(standalone), taskLookupRestrictionService), processVariableKeys);
     }
 
     @JsonView(JsonViews.General.class)

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
@@ -74,10 +74,10 @@ public class TaskControllerHelper {
                                                                                VariableSearch variableSearch,
                                                                                Pageable pageable,
                                                                                List<QueryDslPredicateFilter> filters,
-                                                                               List<String> processVariableDefinitions) {
+                                                                               List<String> processVariableKeys) {
         Session session = entityManager.unwrap(Session.class);
-        Filter filter = session.enableFilter("variableDefinitionIds");
-        filter.setParameterList("variables", processVariableDefinitions);
+        Filter filter = session.enableFilter("variablesFilter");
+        filter.setParameterList("variableKeys", processVariableKeys);
 
         Page<TaskEntity> page = findPage(predicate, variableSearch, pageable, filters);
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -907,16 +907,16 @@ public class QueryProcessInstancesEntityIT {
 
     @ParameterizedTest
     @MethodSource({"processInstanceWithVariablesData"})
-    void should_getProcessInstanceWithVariables(String variableDefinitions, int expectedSize, List<String> expectedVariableValues) {
+    void should_getProcessInstanceWithVariables(String variableKeys, int expectedSize, List<String> expectedVariableValues) {
         ProcessInstance runningProcess1 = processInstanceBuilder.aRunningProcessInstance("first");
-        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "bbb", "string", "ccc")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcess1);
-        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcess1);
         eventsAggregator.sendAll();
 
         ResponseEntity<PagedModel<ProcessInstanceEntity>> responseEntityFiltered = testRestTemplate.exchange(PROC_URL
-                + (variableDefinitions == null ? "" : "?variableDefinitions=" + variableDefinitions),
+                + (variableKeys == null ? "" : "?variableKeys=" + variableKeys),
             HttpMethod.GET,
             identityTokenProducer.entityWithAuthorizationHeader(),
             PAGED_PROCESS_INSTANCE_RESPONSE_TYPE,
@@ -930,9 +930,9 @@ public class QueryProcessInstancesEntityIT {
 
     public static Stream<Arguments> processInstanceWithVariablesData() {
         return Stream.of(
-            Arguments.of("ccc", 1, List.of("bbb")),
-            Arguments.of("fff", 1, List.of("eee")),
-            Arguments.of("ccc,fff", 2, List.of("bbb", "eee")),
+            Arguments.of("varAProcessDefinitionKey/varAName", 1, List.of("varAValue")),
+            Arguments.of("varBProcessDefinitionKey/varBName", 1, List.of("varBValue")),
+            Arguments.of("varAProcessDefinitionKey/varAName,varBProcessDefinitionKey/varBName", 2, List.of("varAValue", "varBValue")),
             Arguments.of("other", 0, null),
             Arguments.of(null, 0, null)
         );
@@ -941,19 +941,19 @@ public class QueryProcessInstancesEntityIT {
     @Test
     void should_getAllProcessInstancesWithVariables() {
         ProcessInstance runningProcess1 = processInstanceBuilder.aRunningProcessInstance("first");
-        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "111", "string", "ccc")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "111", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcess1);
-        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcess1);
         ProcessInstance runningProcess2 = processInstanceBuilder.aRunningProcessInstance("second");
-        variableBuilder.aCreatedVariableWithDefinitionId("aaa", "222", "string", "ccc")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "222", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcess2);
-        variableBuilder.aCreatedVariableWithDefinitionId("ddd", "eee", "string", "fff")
+        variableBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcess2);
         eventsAggregator.sendAll();
 
         ResponseEntity<PagedModel<ProcessInstanceEntity>> responseEntityFiltered = testRestTemplate.exchange(PROC_URL
-                + "?variableDefinitions=ccc",
+                + "?variableKeys=varAProcessDefinitionKey/varAName",
             HttpMethod.GET,
             identityTokenProducer.entityWithAuthorizationHeader(),
             PAGED_PROCESS_INSTANCE_RESPONSE_TYPE,

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -1024,8 +1024,8 @@ public class QueryTasksIT {
                                          PAGED_TASKS_RESPONSE_TYPE);
     }
 
-    private ResponseEntity<PagedModel<QueryCloudTask>> executeRequestGetTasksWithProcessVariables(String... variableDefinitionIds) {
-        return testRestTemplate.exchange(TASKS_URL + "?variableDefinitions=" + String.join(",", variableDefinitionIds),
+    private ResponseEntity<PagedModel<QueryCloudTask>> executeRequestGetTasksWithProcessVariables(String... variableKeys) {
+        return testRestTemplate.exchange(TASKS_URL + "?variableKeys=" + String.join(",", variableKeys),
                                          HttpMethod.GET,
                                          identityTokenProducer.entityWithAuthorizationHeader(),
                                          PAGED_TASKS_RESPONSE_TYPE);
@@ -2105,17 +2105,17 @@ public class QueryTasksIT {
         //given
         taskEventContainedBuilder.aCompletedTask("Task", runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varAName", "varAValue", "string", "varADefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varBName", "varBValue", "string", "varBDefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
         eventsAggregator.sendAll();
 
         await().untilAsserted(() -> {
             //when
-            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varADefinitionId").getBody().getContent();
+            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varAProcessDefinitionKey/varAName").getBody().getContent();
 
             //then
             assertThat(retrievedTasks)
@@ -2131,17 +2131,17 @@ public class QueryTasksIT {
         //given
         taskEventContainedBuilder.aCreatedTask("Task", runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varAName", "varAValue", "string", "varADefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varBName", "varBValue", "string", "varBDefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
         eventsAggregator.sendAll();
 
         await().untilAsserted(() -> {
             //when
-            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varADefinitionId").getBody().getContent();
+            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varAProcessDefinitionKey/varAName").getBody().getContent();
 
             //then
             assertThat(retrievedTasks)
@@ -2155,9 +2155,9 @@ public class QueryTasksIT {
     @Test
     public void should_getCreatedTaskWithPreviouslyCreatedProcessVariables() {
         //given
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varAName", "varAValue", "string", "varADefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varBName", "varBValue", "string", "varBDefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
         taskEventContainedBuilder.aCreatedTask("Task", runningProcessInstance);
@@ -2166,7 +2166,7 @@ public class QueryTasksIT {
 
         await().untilAsserted(() -> {
             //when
-            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varADefinitionId").getBody().getContent();
+            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varAProcessDefinitionKey/varAName").getBody().getContent();
 
             //then
             assertThat(retrievedTasks)
@@ -2187,17 +2187,17 @@ public class QueryTasksIT {
         taskEventContainedBuilder.aCompletedTask("Other completed task", otherProcessInstance);
         taskEventContainedBuilder.aCompletedTask("Other created task", otherProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varAName", "varAValue", "string", "varADefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varBName", "varBValue", "string", "varBDefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
         eventsAggregator.sendAll();
 
         await().untilAsserted(() -> {
             //when
-            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varADefinitionId").getBody().getContent();
+            Collection<QueryCloudTask> retrievedTasks = executeRequestGetTasksWithProcessVariables("varAProcessDefinitionKey/varAName").getBody().getContent();
 
             //then
             assertThat(retrievedTasks)
@@ -2221,10 +2221,10 @@ public class QueryTasksIT {
         taskEventContainedBuilder.aCompletedTask("Other completed task", otherProcessInstance);
         taskEventContainedBuilder.aCompletedTask("Other created task", otherProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varAName", "varAValue", "string", "varADefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varAName", "varAValue", "string", "varAProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
-        variableEventContainedBuilder.aCreatedVariableWithDefinitionId("varBName", "varBValue", "string", "varBDefinitionId")
+        variableEventContainedBuilder.aCreatedVariableWithProcessDefinitionKey("varBName", "varBValue", "string", "varBProcessDefinitionKey")
             .onProcessInstance(runningProcessInstance);
 
         eventsAggregator.sendAll();

--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/VariableEventContainedBuilder.java
@@ -38,16 +38,16 @@ public class VariableEventContainedBuilder {
     public <T> VariableEventContainedBuilder aCreatedVariable(String name,
                                                               T value,
                                                               String type) {
-        return aCreatedVariableWithDefinitionId(name, value, type, null);
+        return aCreatedVariableWithProcessDefinitionKey(name, value, type, null);
     }
 
-    public <T> VariableEventContainedBuilder aCreatedVariableWithDefinitionId(String name,
-                                                                              T value,
-                                                                              String type,
-                                                                              String variableDefinitionId) {
+    public <T> VariableEventContainedBuilder aCreatedVariableWithProcessDefinitionKey(String name,
+                                                                                      T value,
+                                                                                      String type,
+                                                                                      String processDefinitionKey) {
         variableInstance = buildVariable(name, type, value);
         CloudVariableCreatedEventImpl cloudVariableCreatedEvent = new CloudVariableCreatedEventImpl(variableInstance);
-        cloudVariableCreatedEvent.setVariableDefinitionId(variableDefinitionId);
+        cloudVariableCreatedEvent.setProcessDefinitionKey(processDefinitionKey);
         eventsAggregator.addEvents(cloudVariableCreatedEvent);
         return this;
     }


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/3994

Process variables for the old processes (before 7.4.0) are not returned.
This happens because the system uses the variable definition id and before this field was not present in the database.

In order to retrieve all process variables we can combine variableName (already in the process_variable table) and processDefinitionKey (which should be migrated from process_instance to process_variable table).

The request will have the following form:

`http://{domain-name}/query/v1/process-instances?variableKeys={processDefinitionKey}%2F{variableName}`

e.g.

`http://localhost:8081/query/v1/process-instances?variableKeys=Process_90W_3nLpw%2FinitializedVar`

The response format will not change, but it will include both older and newly created process variables.