### PR TITLE
AAE-9312 add identity API to add application roles to users

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
@@ -23,6 +23,7 @@ import org.activiti.cloud.services.identity.keycloak.model.KeycloakRoleMapping;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakUser;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -67,4 +68,19 @@ public interface KeycloakClient {
     @Headers("Content-Type: application/json")
     List<KeycloakRoleMapping> getGroupClientRoleMapping(@PathVariable("id") String id,
         @PathVariable("client") String client);
+
+    @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles")
+    @Headers("Content-Type: application/json")
+    List<KeycloakRoleMapping> getClientRoles(@PathVariable("id") String id);
+
+    @RequestMapping(method = RequestMethod.POST, value = "/users/{id}/role-mappings/clients/{client}")
+    @Headers("Content-Type: application/json")
+    List<KeycloakRoleMapping> addUserClientRoleMapping(@PathVariable("id") String id,
+        @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
+
+    @RequestMapping(method = RequestMethod.POST, value = "/groups/{id}/role-mappings/clients/{client}")
+    @Headers("Content-Type: application/json")
+    List<KeycloakRoleMapping> addGroupClientRoleMapping(@PathVariable("id") String id,
+        @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
+
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.identity;
 
 import java.util.List;
 import org.activiti.cloud.identity.model.Group;
+import org.activiti.cloud.identity.model.SecurityRepresentation;
 import org.activiti.cloud.identity.model.User;
 import org.activiti.cloud.identity.model.UserRoles;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -29,4 +30,5 @@ public interface IdentityManagementService {
 
   UserRoles getUserRoles(Jwt principal);
 
+  void addApplicationPermissions(String application, List<SecurityRepresentation> securityRepresentations);
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityException extends RuntimeException{
+    public IdentityException(String message) {
+        super("Invalid Security data: " + message);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidApplicationException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidApplicationException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityInvalidApplicationException extends IdentityException{
+    public IdentityInvalidApplicationException(String application) {
+        super("application {" + application + "} is invalid or doesn't exist");
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidGroupException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidGroupException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+public class IdentityInvalidGroupException extends IdentityException {
+    public IdentityInvalidGroupException(String groupName) {
+        super("group {"+ groupName + "} is invalid or doesn't exist");
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidGroupRoleException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidGroupRoleException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityInvalidGroupRoleException extends IdentityException {
+    public IdentityInvalidGroupRoleException(String groupName, String role) {
+        super("role {" + role  + "} can't be assigned to group {" + groupName + "}");
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidRoleException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidRoleException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityInvalidRoleException extends IdentityException {
+    public IdentityInvalidRoleException() {
+        super("invalid role");
+    }
+
+    public IdentityInvalidRoleException(String role) {
+        super("role {"+ role + "} is invalid or doesn't exist");
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityInvalidUserException extends IdentityException {
+    public IdentityInvalidUserException(String username) {
+        super("user {"+ username + "} is invalid or doesn't exist");
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserRoleException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserRoleException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.exceptions;
+
+public class IdentityInvalidUserRoleException extends IdentityException {
+    public IdentityInvalidUserRoleException(String username, String role) {
+        super("role {" + role  + "} can't be assigned to user {" + username + "}");
+    }
+}
+

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserRoleException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/exceptions/IdentityInvalidUserRoleException.java
@@ -20,4 +20,3 @@ public class IdentityInvalidUserRoleException extends IdentityException {
         super("role {" + role  + "} can't be assigned to user {" + username + "}");
     }
 }
-

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/model/SecurityRepresentation.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/model/SecurityRepresentation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public class SecurityRepresentation {
+
+    private String role;
+
+    private List<String> groups;
+
+    private List<String> users;
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
+    }
+
+    public List<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<String> users) {
+        this.users = users;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecurityRepresentation that = (SecurityRepresentation) o;
+        return Objects.equals(role, that.role) &&
+            Objects.equals(groups, that.groups) &&
+            Objects.equals(users, that.users);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(role, groups, users);
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/EnableIdentityManagementRestAPI.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/EnableIdentityManagementRestAPI.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.activiti.cloud.identity.web.controller.IdentityManagementController;
+import org.activiti.cloud.identity.web.controller.IdentityManagementRestExceptionHandler;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -30,6 +31,8 @@ import org.springframework.context.annotation.Import;
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Import({IdentityManagementController.class})
+@Import({IdentityManagementController.class,
+    IdentityManagementRestExceptionHandler.class
+})
 public @interface EnableIdentityManagementRestAPI {
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementController.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementController.java
@@ -21,11 +21,14 @@ import org.activiti.cloud.identity.GroupSearchParams;
 import org.activiti.cloud.identity.IdentityManagementService;
 import org.activiti.cloud.identity.UserSearchParams;
 import org.activiti.cloud.identity.model.Group;
+import org.activiti.cloud.identity.model.SecurityRepresentation;
 import org.activiti.cloud.identity.model.User;
 import org.activiti.cloud.identity.model.UserRoles;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -73,4 +76,12 @@ public class IdentityManagementController {
     public UserRoles getUserRoles(@AuthenticationPrincipal Jwt principal) {
         return identityManagementService.getUserRoles(principal);
     }
+
+    @RequestMapping(value = "/permissions/{application}", method = RequestMethod.POST)
+    public void addApplicationPermissions(
+        @PathVariable String application,
+        @RequestBody List<SecurityRepresentation> securityRepresentations) {
+          identityManagementService.addApplicationPermissions(application, securityRepresentations);
+    }
+
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementRestExceptionHandler.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementRestExceptionHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity.web.controller;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletResponse;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidApplicationException;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidGroupException;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidGroupRoleException;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidRoleException;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidUserException;
+import org.activiti.cloud.identity.exceptions.IdentityInvalidUserRoleException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class IdentityManagementRestExceptionHandler {
+
+    @ExceptionHandler({IdentityInvalidUserRoleException.class,
+        IdentityInvalidUserException.class,
+        IdentityInvalidRoleException.class,
+        IdentityInvalidGroupException.class,
+        IdentityInvalidGroupRoleException.class})
+    @ResponseStatus(BAD_REQUEST)
+    public void handleAppException(Exception ex,
+        HttpServletResponse response) throws IOException {
+        response.sendError(BAD_REQUEST.value(),
+            ex.getMessage());
+    }
+
+    @ExceptionHandler(IdentityInvalidApplicationException.class)
+    @ResponseStatus(NOT_FOUND)
+    public void handleAppException(IdentityInvalidApplicationException ex,
+        HttpServletResponse response) throws IOException {
+        response.sendError(NOT_FOUND.value(),
+            ex.getMessage());
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
@@ -48,11 +48,27 @@
           }
         }
       }
-    ]
+    ],
+    "client": {
+      "test-client": [
+        {
+          "name": "ACTIVITI_USER",
+          "clientRole": true
+        },
+        {
+          "name": "ACTIVITI_ADMIN",
+          "clientRole": true
+        }
+      ]
+    }
   },
   "groups": [
     {
-      "name": "hr"
+      "id": "60c6753b-4f1c-498a-96d2-be6790fae09c",
+      "name": "hr",
+      "realmRoles": [
+        "ACTIVITI_USER"
+      ]
     },
     {
       "name": "testgroup"
@@ -246,6 +262,7 @@
       ]
     },
     {
+      "id": "5f682999-d11d-4a42-bc42-86b7e6752223",
       "username": "testadmin",
       "enabled": true,
       "firstName": "Test",
@@ -295,6 +312,9 @@
           "uma_authorization",
           "ACTIVITI_USER",
           "offline_access"
+        ],
+        "realm-management": [
+          "manage-users"
         ]
       },
       "groups": [
@@ -410,6 +430,31 @@
       "serviceAccountsEnabled": true,
       "publicClient": false,
       "protocol": "openid-connect",
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "clientId": "test-client",
+      "enabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "publicClient": true,
+      "redirectUris": [
+        "*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
       "defaultClientScopes": [
         "web-origins",
         "profile",


### PR DESCRIPTION
Add a new API to identity `POST v1/permissions/{application}` that allows adding client roles to users and groups.
The request body:

```
[
  {"role":"ACTIVITI_ADMIN",
  "users":["superadminuser","testadmin"],
  "groups":[]},
  {"role":"ACTIVITI_USER",
  "users":["hruser","salesuser","testuser"],
  "groups":["hr","sales"]}
]

```