### PR TITLE
AAE-8993 avoid to create a new JWTAuthenticationToken and use the existing one

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtSecurityContextPrincipalProvider.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtSecurityContextPrincipalProvider.java
@@ -29,11 +29,8 @@ public class JwtSecurityContextPrincipalProvider implements SecurityContextPrinc
     @Override
     public Optional<Principal> getCurrentPrincipal() {
         return Optional.ofNullable(SecurityContextHolder.getContext())
-            .map(SecurityContext::getAuthentication)
-            .map(Authentication::getPrincipal)
-            .filter(Jwt.class::isInstance)
-            .map(Jwt.class::cast)
-            .map(jwt -> new JwtAuthenticationToken(jwt));
+            .map(SecurityContext::getAuthentication);
     }
 
 }
+

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtSecurityContextPrincipalProvider.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtSecurityContextPrincipalProvider.java
@@ -33,4 +33,3 @@ public class JwtSecurityContextPrincipalProvider implements SecurityContextPrinc
     }
 
 }
-


### PR DESCRIPTION
The previous code was doing silly stuff, basically, it creates a new JWTAuthenticationToken from the existing missing username.