### PR TITLE
fix: liquibase detected a modification to a released changeset

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql
@@ -16,6 +16,3 @@
 
 update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
   where id not like '%:%:%';
-
-update integration_context set id = concat(process_instance_id, ':', client_id, ':', execution_id)
-  where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/18-alter.oracle.schema.7.5.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/18-alter.oracle.schema.7.5.0.sql
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+update integration_context set id = concat(process_instance_id, ':', client_id, ':', execution_id)
   where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/18-alter.pg.schema.7.5.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/18-alter.pg.schema.7.5.0.sql
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-update bpmn_activity set id = concat(process_instance_id, ':', element_id, ':', execution_id)
+update integration_context set id = concat(process_instance_id, ':', client_id, ':', execution_id)
   where id not like '%:%:%';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
@@ -370,4 +370,24 @@
       stripComments="true"/>
   </changeSet>
 
+  <changeSet author="activiti-query"
+    id="alter18-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+      encoding="utf8"
+      path="changelog/18-alter.oracle.schema.7.5.0.sql"
+      relativeToChangelogFile="true"
+      splitStatements="false"
+      stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
+    id="alter18-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/18-alter.pg.schema.7.5.0.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
The following change: 

https://github.com/Activiti/activiti-cloud/commits/develop/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/16-alter.pg.schema.7.4.0.sql

has modified a liquibase changeset already release in patch version 7.2.3 and this broke a migration with the following error. 

```shell
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2022-07-15 16:01:48.580 ERROR 7 --- [ main] o.s.boot.SpringApplication : Application run failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'queryLiquibase' defined in class path resource [org/activiti/cloud/services/query/liquibase/ActivitiCloudQueryLiquibaseAutoConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ValidationFailedException: Validation Failed:
1 change sets check sum
config/query/liquibase/master.xml::alter16-schema::activiti-query was: 8:d3101c50109943d47c8de307d9bc1ff5 but is now: 8:0425f65879f59773be3d9670a80f992b
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1804) ~[spring-beans-5.3.20.jar!/:5.3.20]
at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:620) ~[spring-beans-5.3.20.jar!/:5.3.20]
```

This PR aims at fixing it by splitting the changeset into two parts: the one released in 7.2.3 and the modification added in a second time. 

Refs: OPSEXP-1610