### PR TITLE
return process variables for old tasks

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/19-alter.oracle.schema.7.5.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/19-alter.oracle.schema.7.5.0.sql
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table task_process_variable
+  add constraint uk_task_process_var unique (task_id, process_variable_id);
+
+insert into task_process_variable(task_id, process_variable_id)
+select t.id, pv.id
+from process_variable pv
+       join task t on pv.process_instance_id = t.process_instance_id
+where not exists (
+  select * from task_process_variable tpv
+  where  tpv.task_id = t.id and tpv.process_variable_id = pv.id
+  );

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/19-alter.pg.schema.7.5.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/19-alter.pg.schema.7.5.0.sql
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table task_process_variable
+  add constraint uk_task_process_var unique (task_id, process_variable_id);
+
+insert into task_process_variable(task_id, process_variable_id)
+select t.id, pv.id
+from process_variable pv
+       join task t on pv.process_instance_id = t.process_instance_id
+where not exists (
+  select * from task_process_variable tpv
+  where  tpv.task_id = t.id and tpv.process_variable_id = pv.id
+  );

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/h2.schema.sql
@@ -291,3 +291,5 @@ alter table task_process_variable
   add constraint fk_task_id foreign key (task_id) references task;
 alter table task_process_variable
   add constraint fk_process_variable_id foreign key (process_variable_id) references process_variable;
+alter table task_process_variable
+  add constraint uk_task_process_var unique (task_id, process_variable_id);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/master.xml
@@ -392,4 +392,24 @@
       stripComments="true"/>
   </changeSet>
 
+  <changeSet author="activiti-query"
+    id="alter19-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+      encoding="utf8"
+      path="changelog/19-alter.oracle.schema.7.5.0.sql"
+      relativeToChangelogFile="true"
+      splitStatements="false"
+      stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-query"
+    id="alter19-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/19-alter.pg.schema.7.5.0.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/ProcessVariablesMigrationHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/ProcessVariablesMigrationHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.starter.tests;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.math.BigInteger;
+
+@Component
+public class ProcessVariablesMigrationHelper {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Value("classpath:sql/task_process_variable_migration.sql")
+    private Resource sqlFile;
+
+    @Transactional
+    public BigInteger getTaskProcessVariableCount(String taskId) {
+        return (BigInteger) entityManager.createNativeQuery(
+            "select count(*) from task_process_variable tpv where tpv.task_id = '" + taskId + "'")
+            .getSingleResult();
+    }
+
+    @Transactional
+    public void deleteFromTaskProcessVariable(String taskId) {
+        entityManager.createNativeQuery("delete from task_process_variable tpv where tpv.task_id = '" + taskId + "'")
+            .executeUpdate();
+    }
+
+    @Transactional
+    public void migrateTaskProcessVariableData() throws IOException {
+        entityManager.createNativeQuery(new String(sqlFile.getInputStream().readAllBytes())).executeUpdate();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/sql/task_process_variable_migration.sql
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/sql/task_process_variable_migration.sql
@@ -1,0 +1,8 @@
+insert into task_process_variable(task_id, process_variable_id)
+select t.id, pv.id
+from process_variable pv
+       join task t on pv.process_instance_id = t.process_instance_id
+where not exists (
+  select * from task_process_variable tpv
+  where  tpv.task_id = t.id and tpv.process_variable_id = pv.id
+  );


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4027

Process variables for the old tasks are not returned in tasks endpoints.

This happens because after changing the logic to get variable values by name and process_definition_key, the process variables are visible for all process instances. However tasks are linked to process_variable by an additional table task_process_variable which does not contain historic data (is updated when a task or process variable is created). To make the requests work for historic tasks as well an additional liquibase script will be needed to migrate the data in this table. No changes in REST API needed.