### PR TITLE
Add include parameter to project controller

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ProjectRestApi.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/api/ProjectRestApi.java
@@ -77,6 +77,8 @@ public interface ProjectRestApi {
 
     String PROJECT_FILTERS_PARAM_DESCR = "The filter name to filter the returned projects";
 
+    String PROJECT_INCLUDE_PARAM_DESCR = "The name of values to include with the returned projects";
+
     String UPLOAD_FILE_PARAM_NAME = "file";
 
     String EXPORT_AS_ATTACHMENT_PARAM_NAME = "attachment";
@@ -84,6 +86,8 @@ public interface ProjectRestApi {
     String PROJECT_NAME_PARAM_NAME = "name";
 
     String PROJECT_FILTERS_PARAM_NAME = "filters";
+
+    String PROJECT_INCLUDE_PARAM_NAME = "include";
 
     @Operation(
             tags = PROJECTS,
@@ -95,7 +99,9 @@ public interface ProjectRestApi {
                                                  @Parameter(description = PROJECT_NAME_PARAM_DESCR)
                                                  @RequestParam(name = PROJECT_NAME_PARAM_NAME, required = false) String name,
                                                  @Parameter(description = PROJECT_FILTERS_PARAM_DESCR)
-                                                 @RequestParam(name = PROJECT_FILTERS_PARAM_NAME, required = false) List<String> filters);
+                                                 @RequestParam(name = PROJECT_FILTERS_PARAM_NAME, required = false) List<String> filters,
+                                                 @Parameter(description = PROJECT_INCLUDE_PARAM_DESCR)
+                                                 @RequestParam(name = PROJECT_INCLUDE_PARAM_NAME, required = false) List<String> include);
 
     @Operation(
             tags = PROJECTS,
@@ -112,7 +118,9 @@ public interface ProjectRestApi {
     @GetMapping(path = "/projects/{projectId}")
     EntityModel<Project> getProject(
             @Parameter(description = GET_PROJECT_ID_PARAM_DESCR, required = true)
-            @PathVariable String projectId);
+            @PathVariable String projectId,
+            @Parameter(description = PROJECT_INCLUDE_PARAM_DESCR)
+            @RequestParam(name = PROJECT_INCLUDE_PARAM_NAME, required = false) List<String> include);
 
     @Operation(
             tags = PROJECTS,

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ProjectRepresentationModelAssembler.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/assembler/ProjectRepresentationModelAssembler.java
@@ -26,6 +26,7 @@ import org.springframework.hateoas.server.RepresentationModelAssembler;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 import static org.activiti.cloud.modeling.api.ProcessModelType.PROCESS;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
@@ -40,7 +41,7 @@ public class ProjectRepresentationModelAssembler implements RepresentationModelA
     public EntityModel<Project> toModel(Project project) {
         return EntityModel.of(
                 project,
-                linkTo(methodOn(ProjectController.class).getProject(project.getId())).withSelfRel(),
+                linkTo(methodOn(ProjectController.class).getProject(project.getId(), List.of())).withSelfRel(),
                 getExportProjectLink(project.getId()),
                 getImportProjectModelLink(project.getId()),
                 linkTo(methodOn(ModelController.class).getModels(project.getId(),

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
@@ -65,15 +65,17 @@ public class ProjectController implements ProjectRestApi {
     @Override
     public PagedModel<EntityModel<Project>> getProjects(Pageable pageable,
             @RequestParam(name = PROJECT_NAME_PARAM_NAME, required = false) String name,
-            @RequestParam(name = PROJECT_FILTERS_PARAM_NAME, required = false) List<String> filters) {
-        return pagedCollectionModelAssembler.toModel(pageable, projectService.getProjects(pageable, name, filters),
+            @RequestParam(name = PROJECT_FILTERS_PARAM_NAME, required = false) List<String> filters,
+            @RequestParam(name = PROJECT_INCLUDE_PARAM_NAME, required = false) List<String> include) {
+        return pagedCollectionModelAssembler.toModel(pageable, projectService.getProjects(pageable, name, filters, include),
             representationModelAssembler);
     }
 
     @Override
-    public EntityModel<Project> getProject(
-            @PathVariable String projectId) {
-        return representationModelAssembler.toModel(findProjectRepresentationById(projectId));
+    public EntityModel<Project> getProject(@PathVariable String projectId,
+                                           @RequestParam(name = PROJECT_INCLUDE_PARAM_NAME, required = false)
+                                               List<String> include) {
+        return representationModelAssembler.toModel(findProjectRepresentationById(projectId, include));
     }
 
     @Override
@@ -140,8 +142,8 @@ public class ProjectController implements ProjectRestApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found: " + projectId));
     }
 
-    public Project findProjectRepresentationById(String projectId) {
-        return projectService.findProjectRepresentationById(projectId)
+    public Project findProjectRepresentationById(String projectId, List<String> include) {
+        return projectService.findProjectRepresentationById(projectId, include)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found: " + projectId));
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ProjectController.java
@@ -75,7 +75,7 @@ public class ProjectController implements ProjectRestApi {
     public EntityModel<Project> getProject(@PathVariable String projectId,
                                            @RequestParam(name = PROJECT_INCLUDE_PARAM_NAME, required = false)
                                                List<String> include) {
-        return representationModelAssembler.toModel(findProjectRepresentationById(projectId, include));
+        return representationModelAssembler.toModel(findProjectById(projectId, include));
     }
 
     @Override
@@ -142,8 +142,8 @@ public class ProjectController implements ProjectRestApi {
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found: " + projectId));
     }
 
-    public Project findProjectRepresentationById(String projectId, List<String> include) {
-        return projectService.findProjectRepresentationById(projectId, include)
+    public Project findProjectById(String projectId, List<String> include) {
+        return projectService.findProjectById(projectId, include)
                 .orElseThrow(() -> new ResourceNotFoundException("Project not found: " + projectId));
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
@@ -87,7 +87,7 @@ public class ProjectControllerExistingNameIT {
         projectRepository.createProject(project("creating-project"));
         projectRepository.createProject(project("updating-project"));
         projectRepository.createProject(project("copying-project"));
-        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null, null))
             .hasSize(4)
             .extracting(ProjectEntity::getCreatedBy).containsOnly("otherUser");
     }
@@ -107,7 +107,7 @@ public class ProjectControllerExistingNameIT {
                 .accept(APPLICATION_JSON_VALUE))
             .andExpect(status().isCreated());
 
-        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null, null))
             .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
             .contains(tuple("otherUser", "application-xy"),
                 tuple("testuser", "application-xy"));
@@ -123,7 +123,7 @@ public class ProjectControllerExistingNameIT {
             .content(mapper.writeValueAsString(project("creating-project"))))
             .andExpect(status().isCreated());
 
-        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null, null))
             .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
             .contains(tuple("otherUser", "creating-project"),
                 tuple("testuser", "creating-project"));
@@ -142,7 +142,7 @@ public class ProjectControllerExistingNameIT {
                 .content(mapper.writeValueAsString(project("updating-project"))))
             .andExpect(status().isOk());
 
-        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null, null))
             .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
             .contains(tuple("otherUser", "updating-project"),
                 tuple("testuser", "updating-project"));
@@ -158,7 +158,7 @@ public class ProjectControllerExistingNameIT {
         mockMvc.perform(post("/v1/projects/{projectId}/copy?name=copying-project", project.getId()))
             .andExpect(status().isOk());
 
-        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null))
+        assertThat((Page<ProjectEntity>) projectRepository.getProjects(Pageable.ofSize(50), null, null))
             .extracting(ProjectEntity::getCreatedBy, ProjectEntity::getName)
             .contains(tuple("otherUser", "copying-project"),
                 tuple("testuser", "copying-project"));

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerTest.java
@@ -50,17 +50,17 @@ class ProjectControllerTest {
     @Test
     void should_getProject() {
         Project projectMock = mock(Project.class);
-        when(projectService.findProjectRepresentationById("projectId", null)).thenReturn(Optional.of(projectMock));
+        when(projectService.findProjectById("projectId", null)).thenReturn(Optional.of(projectMock));
         EntityModel<Project> foundProject = projectController.getProject("projectId", null);
-        verify(projectService, times(1)).findProjectRepresentationById("projectId", null);
+        verify(projectService, times(1)).findProjectById("projectId", null);
         assertThat(foundProject.getContent()).isEqualTo(projectMock);
         assertThat(representationModelAssembler).isNotNull();
     }
 
     @Test
     void should_throwException_when_projectNotFound() {
-        when(projectService.findProjectRepresentationById("projectId", null)).thenReturn(Optional.empty());
+        when(projectService.findProjectById("projectId", null)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> projectController.getProject("projectId", null)).isInstanceOf(ResourceNotFoundException.class);
-        verify(projectService, times(1)).findProjectRepresentationById("projectId", null);
+        verify(projectService, times(1)).findProjectById("projectId", null);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerTest.java
@@ -31,7 +31,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectControllerTest {
@@ -47,17 +50,17 @@ class ProjectControllerTest {
     @Test
     void should_getProject() {
         Project projectMock = mock(Project.class);
-        when(projectService.findProjectRepresentationById("projectId")).thenReturn(Optional.of(projectMock));
-        EntityModel<Project> foundProject = projectController.getProject("projectId");
-        verify(projectService, times(1)).findProjectRepresentationById("projectId");
+        when(projectService.findProjectRepresentationById("projectId", null)).thenReturn(Optional.of(projectMock));
+        EntityModel<Project> foundProject = projectController.getProject("projectId", null);
+        verify(projectService, times(1)).findProjectRepresentationById("projectId", null);
         assertThat(foundProject.getContent()).isEqualTo(projectMock);
         assertThat(representationModelAssembler).isNotNull();
     }
 
     @Test
     void should_throwException_when_projectNotFound() {
-        when(projectService.findProjectRepresentationById("projectId")).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> projectController.getProject("projectId")).isInstanceOf(ResourceNotFoundException.class);
-        verify(projectService, times(1)).findProjectRepresentationById("projectId");
+        when(projectService.findProjectRepresentationById("projectId", null)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> projectController.getProject("projectId", null)).isInstanceOf(ResourceNotFoundException.class);
+        verify(projectService, times(1)).findProjectRepresentationById("projectId", null);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelingServiceAutoConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelingServiceAutoConfiguration.java
@@ -15,9 +15,6 @@
  */
 package org.activiti.cloud.services.modeling.service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.ContentUpdateListener;
 import org.activiti.cloud.modeling.api.Model;
@@ -34,6 +31,10 @@ import org.activiti.cloud.modeling.repository.ProjectRepository;
 import org.activiti.cloud.services.modeling.converter.ProcessModelContentConverter;
 import org.activiti.cloud.services.modeling.service.api.ModelService;
 import org.activiti.cloud.services.modeling.service.api.ProjectService;
+import org.activiti.cloud.services.modeling.service.decorators.ProjectDecorator;
+import org.activiti.cloud.services.modeling.service.decorators.ProjectDecoratorService;
+import org.activiti.cloud.services.modeling.service.filters.ProjectFilter;
+import org.activiti.cloud.services.modeling.service.filters.ProjectFilterService;
 import org.activiti.cloud.services.modeling.validation.extensions.ExtensionsModelValidator;
 import org.activiti.cloud.services.modeling.validation.project.ProjectValidator;
 import org.everit.json.schema.loader.SchemaLoader;
@@ -41,6 +42,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Configuration
 public class ModelingServiceAutoConfiguration {
@@ -59,7 +64,6 @@ public class ModelingServiceAutoConfiguration {
     public ExtensionsModelValidator extensionsModelValidator(SchemaLoader modelExtensionsSchemaLoader) {
         return new ExtensionsModelValidator(modelExtensionsSchemaLoader);
     }
-
 
     @Bean
     public ModelExtensionsService modelExtensionsService(Set<ModelExtensionsValidator> metadataValidators,
@@ -100,7 +104,9 @@ public class ModelingServiceAutoConfiguration {
                                          JsonConverter<Project> jsonConverter,
                                          JsonConverter<ProjectDescriptor> projectDescriptorJsonConverter,
                                          JsonConverter<Map> jsonMetadataConverter,
-                                         Set<ProjectValidator> projectValidators) {
+                                         Set<ProjectValidator> projectValidators,
+                                         ProjectFilterService projectFilterService,
+                                         ProjectDecoratorService projectDecoratorService) {
 
         return new ProjectServiceImpl(projectRepository,
                                       modelService,
@@ -108,7 +114,9 @@ public class ModelingServiceAutoConfiguration {
                                       projectDescriptorJsonConverter,
                                       jsonConverter,
                                       jsonMetadataConverter,
-                                      projectValidators);
+                                      projectValidators,
+                                      projectFilterService,
+                                      projectDecoratorService);
 
     }
 
@@ -128,5 +136,17 @@ public class ModelingServiceAutoConfiguration {
     @ConditionalOnMissingBean
     public SchemaService schemaService(List<SchemaProvider> schemaProviders) {
         return new SchemaService(schemaProviders);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProjectFilterService projectFilterService(List<ProjectFilter> projectFilters) {
+        return new ProjectFilterService(projectFilters);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProjectDecoratorService projectDecoratorService(List<ProjectDecorator> projectDecorators) {
+        return new ProjectDecoratorService(projectDecorators);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ProjectService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ProjectService.java
@@ -59,11 +59,11 @@ public interface ProjectService {
 
     Project replaceProjectContentWithProvidedModelsInFile(Project project, InputStream inputStream) throws IOException;
 
-    default Page<Project> getProjects(Pageable pageable, String name, List<String> filters) {
+    default Page<Project> getProjects(Pageable pageable, String name, List<String> filters, List<String> include) {
         return getProjects(pageable, name);
     }
 
-    default Optional<Project> findProjectRepresentationById(String projectId){
+    default Optional<Project> findProjectRepresentationById(String projectId, List<String> include){
         return findProjectById(projectId);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ProjectService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ProjectService.java
@@ -32,8 +32,7 @@ import java.util.Optional;
  * Business logic related to {@link Project} entities
  */
 public interface ProjectService {
-    Page<Project> getProjects(Pageable pageable,
-                              String name);
+    Page<Project> getProjects(Pageable pageable, String name, List<String> filters, List<String> include);
 
     Project createProject(Project project);
 
@@ -42,7 +41,11 @@ public interface ProjectService {
 
     void deleteProject(Project project);
 
-    Optional<Project> findProjectById(String projectId);
+    Optional<Project> findProjectById(String projectId, List<String> include);
+
+    default Optional<Project> findProjectById(String projectId) {
+        return findProjectById(projectId, null);
+    }
 
     FileContent exportProject(Project project) throws IOException;
 
@@ -59,11 +62,4 @@ public interface ProjectService {
 
     Project replaceProjectContentWithProvidedModelsInFile(Project project, InputStream inputStream) throws IOException;
 
-    default Page<Project> getProjects(Pageable pageable, String name, List<String> filters, List<String> include) {
-        return getProjects(pageable, name);
-    }
-
-    default Optional<Project> findProjectRepresentationById(String projectId, List<String> include){
-        return findProjectById(projectId);
-    }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecorator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecorator.java
@@ -13,31 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.modeling.repository;
+
+package org.activiti.cloud.services.modeling.service.decorators;
 
 import org.activiti.cloud.modeling.api.Project;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Optional;
 
-/**
- * Interface for {@link Project} entities repository
- */
-public interface ProjectRepository<P extends Project> {
+public interface ProjectDecorator {
 
-    Page<P> getProjects(Pageable pageable,
-                        String nameToFilter,
-                        List<String> filteredProjectIds);
+    String decoratorName();
 
-    Optional<P> findProjectById(String projectId);
+    void decorate(Project project);
 
-    P createProject(P project);
-
-    P updateProject(P projectToUpdate);
-
-    P copyProject(P projectToCopy, String newProjectName);
-
-    void deleteProject(P project);
+    void decorateAll(List<Project> projects);
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.decorators;
+
+import org.activiti.cloud.modeling.api.Project;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class ProjectDecoratorService {
+
+    private final Map<String, ProjectDecorator> projectDecorators;
+
+    public ProjectDecoratorService(List<ProjectDecorator> projectDecorators) {
+        this.projectDecorators = projectDecorators.stream()
+            .collect(Collectors.toMap(ProjectDecorator::decoratorName, projectDecorator -> projectDecorator));
+    }
+
+    public void decorate(Project project, List<String> decoratorNames) {
+        decorate(decoratorNames, projectDecorator -> projectDecorator.decorate(project));
+    }
+
+    public void decorateAll(List<Project> projects, List<String> decoratorNames) {
+        decorate(decoratorNames, projectDecorator -> projectDecorator.decorateAll(projects));
+    }
+
+    private void decorate(List<String> decoratorNames, Consumer<ProjectDecorator> projectDecoratorConsumer) {
+        decoratorNames.stream()
+            .filter(StringUtils::isNotBlank)
+            .map(String::toLowerCase)
+            .map(projectDecorators::get)
+            .filter(Objects::nonNull)
+            .forEach(projectDecoratorConsumer);
+    }
+
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilter.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.filters;
+
+import java.util.List;
+
+public interface ProjectFilter {
+
+    String filterName();
+
+    List<String> getFilterIds();
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilterService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilterService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.filters;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ProjectFilterService {
+
+    private final Map<String, ProjectFilter> projectFilters;
+
+    public ProjectFilterService(List<ProjectFilter> projectFilters) {
+        this.projectFilters = projectFilters.stream()
+            .collect(Collectors.toMap(ProjectFilter::filterName, projectFilter -> projectFilter));
+    }
+
+    public List<String> getFilterIds(List<String> filterNames) {
+        List<List<String>> allFilters = filterNames.stream()
+            .filter(StringUtils::isNotBlank)
+            .map(String::toLowerCase)
+            .map(projectFilters::get)
+            .map(getFilterIds())
+            .collect(Collectors.toList());
+
+        switch (allFilters.size()) {
+            case 0:
+                return Collections.emptyList();
+            case 1:
+                return allFilters.get(0);
+            default:
+                return intersection(allFilters);
+        }
+    }
+
+    private Function<ProjectFilter, List<String>> getFilterIds() {
+        return projectFilter -> projectFilter == null ? Collections.emptyList() : projectFilter.getFilterIds();
+    }
+
+    private List<String> intersection(List<List<String>> allFilters) {
+        List<String> intersection = new ArrayList<>(allFilters.get(0));
+        for (List<String> filteredProjects : allFilters.subList(1, allFilters.size())) {
+            intersection.retainAll(filteredProjects);
+        }
+        return intersection;
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -15,24 +15,6 @@
  */
 package org.activiti.cloud.services.modeling.service;
 
-import static java.util.Arrays.asList;
-import static org.activiti.cloud.services.common.util.FileUtils.resourceAsStream;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.activiti.bpmn.model.UserTask;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ProcessModelType;
@@ -52,6 +34,26 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.activiti.cloud.services.common.util.FileUtils.resourceAsStream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ProjectServiceImplTest {
@@ -280,7 +282,7 @@ public class ProjectServiceImplTest {
     void should_findProjectRepresentationById() {
         ProjectImpl givenProject = new ProjectImpl("projectId", "name");
         when(projectRepository.findProjectById("projectId")).thenReturn(Optional.of(givenProject));
-        Optional<Project> foundProjectOptional = projectService.findProjectRepresentationById("projectId");
+        Optional<Project> foundProjectOptional = projectService.findProjectRepresentationById("projectId", null);
         assertThat(foundProjectOptional.get()).isEqualTo(givenProject);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -282,7 +282,7 @@ public class ProjectServiceImplTest {
     void should_findProjectRepresentationById() {
         ProjectImpl givenProject = new ProjectImpl("projectId", "name");
         when(projectRepository.findProjectById("projectId")).thenReturn(Optional.of(givenProject));
-        Optional<Project> foundProjectOptional = projectService.findProjectRepresentationById("projectId", null);
+        Optional<Project> foundProjectOptional = projectService.findProjectById("projectId", null);
         assertThat(foundProjectOptional.get()).isEqualTo(givenProject);
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorServiceTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorServiceTest.java
@@ -20,7 +20,9 @@ import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.modeling.api.impl.ProjectImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class ProjectDecoratorServiceTest {
 
     @Mock

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorServiceTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/decorators/ProjectDecoratorServiceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.decorators;
+
+import org.activiti.cloud.modeling.api.Project;
+import org.activiti.cloud.modeling.api.impl.ProjectImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProjectDecoratorServiceTest {
+
+    @Mock
+    ProjectDecorator projectDecorator1;
+    @Mock
+    ProjectDecorator projectDecorator2;
+
+    ProjectDecoratorService projectDecoratorService;
+
+    @BeforeEach
+    void setUp() {
+        when(projectDecorator1.decoratorName()).thenReturn("decorator1-name");
+        when(projectDecorator2.decoratorName()).thenReturn("decorator2-name");
+        projectDecoratorService = new ProjectDecoratorService(List.of(projectDecorator1, projectDecorator2));
+    }
+
+    @Test
+    void should_decorateProjectsWithAllDecorators() {
+        List<Project> projects = List.of(new ProjectImpl());
+        projectDecoratorService.decorateAll(projects, List.of("decorator1-name", "decorator2-name"));
+        verify(projectDecorator1).decorateAll(eq(projects));
+        verify(projectDecorator2).decorateAll(eq(projects));
+    }
+
+    @Test
+    void should_decorateProjectsWithOneDecorator() {
+        List<Project> projects = List.of(new ProjectImpl());
+        projectDecoratorService.decorateAll(projects, List.of("decorator1-name"));
+        verify(projectDecorator1).decorateAll(eq(projects));
+        verify(projectDecorator2, never()).decorateAll(any());
+    }
+
+    @Test
+    void should_notDecorateProjects_when_differentDecoratorName() {
+        List<Project> projects = List.of(new ProjectImpl());
+        projectDecoratorService.decorateAll(projects, List.of("other-name"));
+        verify(projectDecorator1, never()).decorateAll(any());
+        verify(projectDecorator2, never()).decorateAll(any());
+    }
+
+    @Test
+    void should_decorateSingleProjectWithAllDecorators() {
+        Project project = new ProjectImpl();
+        projectDecoratorService.decorate(project, List.of("decorator1-name", "decorator2-name"));
+        verify(projectDecorator1).decorate(eq(project));
+        verify(projectDecorator2).decorate(eq(project));
+    }
+
+    @Test
+    void should_decorateSingleProjectWithOneDecorator() {
+        Project project = new ProjectImpl();
+        projectDecoratorService.decorate(project, List.of("decorator1-name"));
+        verify(projectDecorator1).decorate(eq(project));
+        verify(projectDecorator2, never()).decorate(any());
+    }
+
+    @Test
+    void should_notDecorateSingleProject_when_differentDecoratorName() {
+        Project project = new ProjectImpl();
+        projectDecoratorService.decorate(project, List.of("other-name"));
+        verify(projectDecorator1, never()).decorate(any());
+        verify(projectDecorator2, never()).decorate(any());
+    }
+
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilterServiceTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/filters/ProjectFilterServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.filters;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProjectFilterServiceTest {
+    private static final String EXAMPLE_NAME = "example";
+    private static final String WRONG_NAME = "wrongfilter";
+    private static final List<String> ONE_TWO_PROJECT_IDS = List.of("1", "2");
+    private static final List<String> ONE_PROJECT_ID = List.of("1");
+
+    @Test
+    void should_getFilteredIds() {
+        final ProjectFilter projectFilter = getProjectFilter(EXAMPLE_NAME, ONE_TWO_PROJECT_IDS);
+        final ProjectFilterService projectFilterService = new ProjectFilterService(List.of(projectFilter));
+
+        List<String> filteredProjectIds = projectFilterService.getFilterIds(List.of(EXAMPLE_NAME));
+
+        assertThat(filteredProjectIds).isEqualTo(ONE_TWO_PROJECT_IDS);
+    }
+
+    @Test
+    void should_getEmptyList_when_noFiltersMatch() {
+        final ProjectFilter projectFilter = getProjectFilter(EXAMPLE_NAME, ONE_TWO_PROJECT_IDS);
+        final ProjectFilterService projectFilterService = new ProjectFilterService(List.of(projectFilter));
+
+        List<String> filteredProjectIds = projectFilterService.getFilterIds(List.of(WRONG_NAME));
+
+        assertThat(filteredProjectIds.isEmpty()).isTrue();
+    }
+
+    @Test
+    void should_getEmptyList_when_someFiltersDontMatch() {
+        final ProjectFilter projectFilter = getProjectFilter(EXAMPLE_NAME, ONE_TWO_PROJECT_IDS);
+        final ProjectFilterService projectFilterService = new ProjectFilterService(List.of(projectFilter));
+
+        List<String> filteredProjectIds = projectFilterService.getFilterIds(List.of(EXAMPLE_NAME, WRONG_NAME));
+
+        assertThat(filteredProjectIds.isEmpty()).isTrue();
+    }
+
+    @Test
+    void should_getIntersectionOfResults_when_multipleFilters() {
+        final ProjectFilter projectFilterOne = getProjectFilter("one", ONE_PROJECT_ID);
+        final ProjectFilter projectFilterOneTwo = getProjectFilter("onetwo", ONE_TWO_PROJECT_IDS);
+        final ProjectFilterService projectFilterService = new ProjectFilterService(List.of(projectFilterOne, projectFilterOneTwo));
+
+        List<String> filteredProjectIds = projectFilterService.getFilterIds(List.of("one", "onetwo"));
+
+        assertThat(filteredProjectIds).isEqualTo(ONE_PROJECT_ID);
+    }
+
+    private ProjectFilter getProjectFilter(String filterName, List<String> result) {
+        return new ProjectFilter() {
+            @Override
+            public String filterName() {
+                return filterName;
+            }
+
+            @Override
+            public List<String> getFilterIds() {
+                return result;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4035

In order to extend the functionality of retrieving projects it is needed to add a new request param (`include={included-value-name}`) to already existing endpoints in ProjectController, e.g.
`/v1/projects?include={included-value-name}`
`/v1/projects/{project-id}?include={included-value-name}`