### PR TITLE
AAE-9993 - Add IdentityHealthService interface

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakHealthService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakHealthService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.identity.keycloak;
+
+import org.activiti.cloud.identity.IdentityHealthService;
+
+public class KeycloakHealthService implements IdentityHealthService {
+
+    private KeycloakUserGroupManager keycloakUserGroupManager;
+
+    public KeycloakHealthService(KeycloakUserGroupManager keycloakUserGroupManager) {
+        this.keycloakUserGroupManager = keycloakUserGroupManager;
+    }
+
+    @Override
+    public boolean isIdentityUp() {
+        return keycloakUserGroupManager.getGroups() != null;
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/config/ActivitiKeycloakAutoConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/config/ActivitiKeycloakAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import org.activiti.cloud.identity.IdentityManagementService;
 import org.activiti.cloud.services.identity.keycloak.ActivitiKeycloakProperties;
 import org.activiti.cloud.services.identity.keycloak.KeycloakClientPrincipalDetailsProvider;
+import org.activiti.cloud.services.identity.keycloak.KeycloakHealthService;
 import org.activiti.cloud.services.identity.keycloak.KeycloakInstanceWrapper;
 import org.activiti.cloud.services.identity.keycloak.KeycloakManagementService;
 import org.activiti.cloud.services.identity.keycloak.KeycloakProperties;
@@ -99,6 +100,12 @@ public class ActivitiKeycloakAutoConfiguration {
                                      .expireAfterWrite(Duration.parse(cacheExpireAfterWrite))
                                      .maximumSize(cacheMaxSize)
                                      .build());
+    }
+
+    @Bean(name = "identityHealthService")
+    @ConditionalOnMissingBean(KeycloakHealthService.class)
+    public KeycloakHealthService keycloakHealthService(KeycloakUserGroupManager keycloakUserGroupManager) {
+        return new KeycloakHealthService(keycloakUserGroupManager);
     }
 
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakHealthServiceTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakHealthServiceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.identity.keycloak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class KeycloakHealthServiceTest {
+
+    @Mock
+    private KeycloakUserGroupManager keycloakUserGroupManager;
+
+    @InjectMocks
+    private KeycloakHealthService keycloakHealthService;
+
+    @Test
+    void should_returnTrue_when_groupsIsNotNull() {
+        when(keycloakUserGroupManager.getGroups()).thenReturn(Collections.emptyList());
+        assertThat(keycloakHealthService.isIdentityUp()).isTrue();
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityHealthService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityHealthService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.identity;
+
+public interface IdentityHealthService {
+
+    boolean isIdentityUp();
+}


### PR DESCRIPTION
In order to differentiate the behaviour of the Keycloak and HxP health indicator, I added the interface `IdentityHealthService` and moved the checks we do for Keyclaok in `KeycloakHealthService` (implementation of the interface)

Required by: 
https://github.com/Alfresco/alfresco-process/pull/1021