### PR TITLE
fix: optimize audit events handling by timestamp 

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
@@ -100,6 +100,9 @@ public class QueryEventHandlerContextOptimizer {
                        Map.entry(CloudProcessCompletedEventImpl.class, 16),
                        Map.entry(CloudProcessCancelledEventImpl.class, 16));
 
+    private Comparator<CloudRuntimeEvent<?,?>> byTimestamp = Comparator.comparingLong(CloudRuntimeEvent::getTimestamp);
+    private Comparator<CloudRuntimeEvent<?,?>> byEventClass = Comparator.comparing(event -> Optional.ofNullable(order.get(event.getClass()))
+                                                                                                    .orElseGet(() -> order.get(CloudRuntimeEvent.class)));
     private final EntityManager entityManager;
 
     public QueryEventHandlerContextOptimizer(EntityManager entityManager) {
@@ -137,8 +140,7 @@ public class QueryEventHandlerContextOptimizer {
             });
 
         return events.stream()
-                     .sorted(Comparator.comparing(event -> Optional.ofNullable(order.get(event.getClass()))
-                                                                   .orElseGet(() -> order.get(CloudRuntimeEvent.class))))
+                     .sorted(byEventClass.thenComparing(byTimestamp))
                      .collect(Collectors.toList());
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
@@ -33,6 +33,7 @@ import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEve
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessUpdatedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudSequenceFlowTakenEventImpl;
 import org.activiti.cloud.api.task.model.events.CloudTaskRuntimeEvent;
@@ -75,6 +76,7 @@ public class QueryEventHandlerContextOptimizer {
                        Map.entry(CloudProcessCreatedEventImpl.class, 0),
                        Map.entry(CloudProcessStartedEventImpl.class, 1),
                        Map.entry(CloudProcessUpdatedEventImpl.class, 1),
+                       Map.entry(CloudProcessSuspendedEventImpl.class, 1),
                        Map.entry(CloudSequenceFlowTakenEventImpl.class, 2),
                        Map.entry(CloudBPMNActivityStartedEventImpl.class, 3),
                        Map.entry(CloudIntegrationRequestedEventImpl.class, 4),

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizerTest.java
@@ -168,5 +168,68 @@ class QueryEventHandlerContextOptimizerTest {
                                            cloudIntegrationErrorReceivedEvent);
     }
 
+    @Test
+    void optimizeEventsByTimestamp() throws InterruptedException {
+        //given
+        CloudIntegrationRequestedEventImpl cloudIntegrationRequestedEvent1 = new CloudIntegrationRequestedEventImpl();
+        CloudIntegrationResultReceivedEventImpl cloudIntegrationResultReceivedEvent1 = new CloudIntegrationResultReceivedEventImpl();
+        CloudIntegrationErrorReceivedEvent cloudIntegrationErrorReceivedEvent1 = new CloudIntegrationErrorReceivedEventImpl();
+        CloudSequenceFlowTakenEventImpl cloudSequenceFlowTakenEvent1 = new CloudSequenceFlowTakenEventImpl();
+        CloudBPMNActivityStartedEventImpl cloudBPMNActivityStartedEvent1 = new CloudBPMNActivityStartedEventImpl();
+        CloudBPMNActivityCompletedEventImpl cloudBPMNActivityCompletedEvent1 = new CloudBPMNActivityCompletedEventImpl();
+        CloudBPMNActivityCancelledEvent cloudBPMNActivityCancelledEvent1 = new CloudBPMNActivityCancelledEventImpl();
+        CloudBPMNSignalReceivedEvent cloudBPMNSignalReceivedEvent1 = new CloudBPMNSignalReceivedEventImpl();
+
+        Thread.sleep(10);
+
+        CloudIntegrationRequestedEventImpl cloudIntegrationRequestedEvent2 = new CloudIntegrationRequestedEventImpl();
+        CloudIntegrationResultReceivedEventImpl cloudIntegrationResultReceivedEvent2 = new CloudIntegrationResultReceivedEventImpl();
+        CloudIntegrationErrorReceivedEvent cloudIntegrationErrorReceivedEvent2 = new CloudIntegrationErrorReceivedEventImpl();
+        CloudSequenceFlowTakenEventImpl cloudSequenceFlowTakenEvent2 = new CloudSequenceFlowTakenEventImpl();
+        CloudBPMNActivityStartedEventImpl cloudBPMNActivityStartedEvent2 = new CloudBPMNActivityStartedEventImpl();
+        CloudBPMNActivityCompletedEventImpl cloudBPMNActivityCompletedEvent2 = new CloudBPMNActivityCompletedEventImpl();
+        CloudBPMNActivityCancelledEvent cloudBPMNActivityCancelledEvent2 = new CloudBPMNActivityCancelledEventImpl();
+        CloudBPMNSignalReceivedEvent cloudBPMNSignalReceivedEvent2 = new CloudBPMNSignalReceivedEventImpl();
+
+        List<CloudRuntimeEvent<?,?>> events = Arrays.asList(
+            cloudIntegrationRequestedEvent2,
+            cloudIntegrationRequestedEvent1,
+            cloudSequenceFlowTakenEvent2,
+            cloudSequenceFlowTakenEvent1,
+            cloudBPMNActivityStartedEvent2,
+            cloudBPMNActivityStartedEvent1,
+            cloudIntegrationResultReceivedEvent2,
+            cloudIntegrationResultReceivedEvent1,
+            cloudIntegrationErrorReceivedEvent2,
+            cloudIntegrationErrorReceivedEvent1,
+            cloudBPMNActivityCompletedEvent2,
+            cloudBPMNActivityCompletedEvent1,
+            cloudBPMNActivityCancelledEvent2,
+            cloudBPMNActivityCancelledEvent1,
+            cloudBPMNSignalReceivedEvent2,
+            cloudBPMNSignalReceivedEvent1
+        );
+
+        //when
+        List<CloudRuntimeEvent<?,?>> result = subject.optimize(events);
+
+        //then
+        assertThat(result).containsExactly(cloudSequenceFlowTakenEvent1,
+                                           cloudSequenceFlowTakenEvent2,
+                                           cloudBPMNActivityStartedEvent1,
+                                           cloudBPMNActivityStartedEvent2,
+                                           cloudIntegrationRequestedEvent1,
+                                           cloudIntegrationRequestedEvent2,
+                                           cloudBPMNSignalReceivedEvent1,
+                                           cloudBPMNSignalReceivedEvent2,
+                                           cloudBPMNActivityCompletedEvent1,
+                                           cloudBPMNActivityCancelledEvent1,
+                                           cloudBPMNActivityCompletedEvent2,
+                                           cloudBPMNActivityCancelledEvent2,
+                                           cloudIntegrationResultReceivedEvent1,
+                                           cloudIntegrationErrorReceivedEvent1,
+                                           cloudIntegrationResultReceivedEvent2,
+                                           cloudIntegrationErrorReceivedEvent2);
+    }
 
 }


### PR DESCRIPTION
This PR add secondary sort by timestamp in EventHandlerOptimizer to ensure chronological handling order by event type to make sure that the semantical order is the right one, and in case of same value we order by timestamp