### PR TITLE
fix: Update service task status in Query to STARTED on IntegrationRequestedEvent

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandler.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.events.handlers;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent.IntegrationEvents;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.CloudIntegrationContext.IntegrationContextStatus;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
@@ -68,7 +69,11 @@ public class IntegrationRequestedEventHandler extends BaseIntegrationEventHandle
         entity.setStatus(IntegrationContextStatus.INTEGRATION_REQUESTED);
         entity.setInBoundVariables(integrationEvent.getEntity().getInBoundVariables());
 
-        ServiceTaskEntity serviceTaskEntity = entityManager.getReference(ServiceTaskEntity.class, entityId);
+        ServiceTaskEntity serviceTaskEntity = entityManager.find(ServiceTaskEntity.class, entityId);
+        serviceTaskEntity.setStatus(CloudBPMNActivity.BPMNActivityStatus.STARTED);
+        serviceTaskEntity.setStartedDate(new Date(event.getTimestamp()));
+        serviceTaskEntity.setCompletedDate(null);
+
         entity.setServiceTask(serviceTaskEntity);
 
         entityManager.persist(entity);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/events/handlers/IntegrationRequestedEventHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.events.handlers;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
+import org.activiti.cloud.api.process.model.CloudBPMNActivity;
+import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
+import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationRequestedEventImpl;
+import org.activiti.cloud.services.query.model.IntegrationContextEntity;
+import org.activiti.cloud.services.query.model.ServiceTaskEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityManager;
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationRequestedEventHandlerTest {
+
+    @InjectMocks
+    private IntegrationRequestedEventHandler handler;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Test
+    void testIntegrationRequestedEventShouldUpdateServiceTaskStatusToStarted() {
+        //given
+        CloudIntegrationRequestedEvent event = createIntegrationRequestedEvent();
+        String entityId = IntegrationContextEntity.IdBuilderHelper.from(event.getEntity());
+
+        ServiceTaskEntity serviceTaskEntity = mock(ServiceTaskEntity.class);
+        IntegrationContextEntity integrationContextEntity = mock(IntegrationContextEntity.class);
+
+        given(entityManager.find(IntegrationContextEntity.class, entityId)).willReturn(integrationContextEntity);
+        given(entityManager.find(ServiceTaskEntity.class, entityId)).willReturn(serviceTaskEntity);
+
+        //when
+        handler.handle(event);
+
+        //then
+        verify(serviceTaskEntity).setStatus(eq(CloudBPMNActivity.BPMNActivityStatus.STARTED));
+        verify(serviceTaskEntity).setStartedDate(any(Date.class));
+        verify(serviceTaskEntity).setCompletedDate(eq(null));
+
+        verify(entityManager).persist(integrationContextEntity);
+
+    }
+
+    private CloudIntegrationRequestedEvent createIntegrationRequestedEvent() {
+        IntegrationContext integrationContext = new IntegrationContextImpl() {{
+            setClientId("clientId");
+            setExecutionId("executionId");
+            setProcessInstanceId("processInstanceId");
+        }};
+
+        return new CloudIntegrationRequestedEventImpl(integrationContext);
+    }
+}


### PR DESCRIPTION
The service task status will be updated to STARTED after IntegrationRequestedEvent is emitted and handled by Query Service.

Part of https://github.com/Activiti/Activiti/issues/4056