### PR TITLE
AAE-10482 use client credentials when contacting keycloak

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.identity.keycloak.client;
 
 import feign.Headers;
 import java.util.List;
+import org.activiti.cloud.security.feign.configuration.ClientCredentialsAuthConfiguration;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakClientRepresentation;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakGroup;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakRoleMapping;
@@ -29,13 +30,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(value = "keycloak", url = "${keycloak.auth-server-url}/admin/realms/${keycloak.realm}/")
+@FeignClient(value = "keycloak",
+    url = "${keycloak.auth-server-url}/admin/realms/${keycloak.realm}/",
+    configuration = ClientCredentialsAuthConfiguration.class)
 public interface KeycloakClient {
 
     @RequestMapping(method = RequestMethod.GET, value = "/users")
     @Headers("Content-Type: application/json")
     List<KeycloakUser> searchUsers(@RequestParam(value = "search") String search,
-        @RequestParam(value = "first") Integer first, @RequestParam(value = "max") Integer max);
+                                   @RequestParam(value = "first") Integer first, @RequestParam(value = "max") Integer max);
 
     @RequestMapping(method = RequestMethod.GET, value = "/users/{id}/role-mappings/realm/composite")
     @Headers("Content-Type: application/json")
@@ -50,7 +53,7 @@ public interface KeycloakClient {
     @RequestMapping(method = RequestMethod.GET, value = "/groups")
     @Headers("Content-Type: application/json")
     List<KeycloakGroup> searchGroups(@RequestParam(value = "search") String search,
-        @RequestParam(value = "first") Integer first, @RequestParam(value = "max") Integer max);
+                                     @RequestParam(value = "first") Integer first, @RequestParam(value = "max") Integer max);
 
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{id}/role-mappings/realm/composite")
     @Headers("Content-Type: application/json")
@@ -66,12 +69,12 @@ public interface KeycloakClient {
     @RequestMapping(method = RequestMethod.GET, value = "/users/{id}/role-mappings/clients/{client}/composite")
     @Headers("Content-Type: application/json")
     List<KeycloakRoleMapping> getUserClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("client") String client);
+                                                       @PathVariable("client") String client);
 
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{id}/role-mappings/clients/{client}/composite")
     @Headers("Content-Type: application/json")
     List<KeycloakRoleMapping> getGroupClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("client") String client);
+                                                        @PathVariable("client") String client);
 
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles")
     @Headers("Content-Type: application/json")
@@ -80,21 +83,21 @@ public interface KeycloakClient {
     @RequestMapping(method = RequestMethod.POST, value = "/users/{id}/role-mappings/clients/{client}")
     @Headers("Content-Type: application/json")
     List<KeycloakRoleMapping> addUserClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
+                                                       @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
 
     @RequestMapping(method = RequestMethod.POST, value = "/groups/{id}/role-mappings/clients/{client}")
     @Headers("Content-Type: application/json")
     List<KeycloakRoleMapping> addGroupClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
+                                                        @PathVariable("client") String client, @RequestBody List<KeycloakRoleMapping> roles);
 
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles/{role-name}/users")
     @Headers("Content-Type: application/json")
     List<KeycloakUser> getUsersClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("role-name") String roleName);
+                                                 @PathVariable("role-name") String roleName);
 
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles/{role-name}/groups")
     @Headers("Content-Type: application/json")
     List<KeycloakGroup> getGroupsClientRoleMapping(@PathVariable("id") String id,
-        @PathVariable("role-name") String roleName);
+                                                   @PathVariable("role-name") String roleName);
 
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/resources/keycloak-client.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/resources/keycloak-client.properties
@@ -1,6 +1,6 @@
 activiti.cloud.services.oauth2.iam-name=keycloak
 
-spring.security.oauth2.client.registration.keycloak.client-id=${activiti.keycloak.client-id}
+spring.security.oauth2.client.registration.keycloak.client-id=${activity.keycloak.client-id}
 spring.security.oauth2.client.registration.keycloak.client-secret=${activiti.keycloak.client-secret}
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=${activiti.keycloak.grant-type}
 spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/resources/keycloak-client.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/resources/keycloak-client.properties
@@ -1,6 +1,6 @@
 activiti.cloud.services.oauth2.iam-name=keycloak
 
-spring.security.oauth2.client.registration.keycloak.client-id=${activity.keycloak.client-id}
+spring.security.oauth2.client.registration.keycloak.client-id=${activiti.keycloak.client-id}
 spring.security.oauth2.client.registration.keycloak.client-secret=${activiti.keycloak.client-secret}
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=${activiti.keycloak.grant-type}
 spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
@@ -37,8 +37,7 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
     properties = {
         "keycloak.realm=activiti",
         "keycloak.use-resource-role-mappings=false",
-        "identity.client.cache.cacheExpireAfterWrite=PT5s",
-        "spring.security.oauth2.client.registration.keycloak.client-id=activiti-keycloak"}
+        "identity.client.cache.cacheExpireAfterWrite=PT5s"}
 )
 @ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class KeycloakClientIT {

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
@@ -36,8 +36,9 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
     classes = {KeycloakClientApplication.class},
     properties = {
         "keycloak.realm=activiti",
-        "keycloak.use-resource-role-mappings=false"
-    ,   "identity.client.cache.cacheExpireAfterWrite=PT5s"}
+        "keycloak.use-resource-role-mappings=false",
+        "identity.client.cache.cacheExpireAfterWrite=PT5s",
+        "spring.security.oauth2.client.registration.keycloak.client-id=activiti-keycloak"}
 )
 @ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class KeycloakClientIT {
@@ -183,7 +184,7 @@ public class KeycloakClientIT {
 
     @Test
     public void should_getClients() {
-        List<KeycloakClientRepresentation> clients = keycloakClient.searchClients(null,0, 50);
+        List<KeycloakClientRepresentation> clients = keycloakClient.searchClients(null, 0, 50);
 
         assertThat(clients).extracting("clientId").contains("activiti");
         assertThat(clients).extracting("clientId").contains("activiti-keycloak");
@@ -191,7 +192,7 @@ public class KeycloakClientIT {
 
     @Test
     public void should_getClients_when_paginated() {
-        List<KeycloakClientRepresentation> clientPage1 = keycloakClient.searchClients(null,0, 1);
+        List<KeycloakClientRepresentation> clientPage1 = keycloakClient.searchClients(null, 0, 1);
         assertThat(clientPage1).hasSize(1);
         assertThat(clientPage1).extracting("clientId").contains("account");
 
@@ -252,12 +253,12 @@ public class KeycloakClientIT {
             .findFirst()
             .get();
 
-        assertThat(userHasClientRole(testAdminUserId,clientId,ACTIVITI_ADMIN_ROLE)).isFalse();
+        assertThat(userHasClientRole(testAdminUserId, clientId, ACTIVITI_ADMIN_ROLE)).isFalse();
 
         keycloakClient.addUserClientRoleMapping(testAdminUserId, clientId,
-            List.of(kRoleToAdd));
+                                                List.of(kRoleToAdd));
 
-        assertThat(userHasClientRole(testAdminUserId,clientId,ACTIVITI_ADMIN_ROLE)).isTrue();
+        assertThat(userHasClientRole(testAdminUserId, clientId, ACTIVITI_ADMIN_ROLE)).isTrue();
     }
 
     @Test
@@ -271,12 +272,12 @@ public class KeycloakClientIT {
             .findFirst()
             .get();
 
-        assertThat(groupHasClientRole(hrGroupId,clientId,ACTIVITI_USER_ROLE)).isFalse();
+        assertThat(groupHasClientRole(hrGroupId, clientId, ACTIVITI_USER_ROLE)).isFalse();
 
         keycloakClient.addGroupClientRoleMapping(hrGroupId, clientId,
-            List.of(kRoleToAdd));
+                                                 List.of(kRoleToAdd));
 
-        assertThat(groupHasClientRole(hrGroupId,clientId,ACTIVITI_USER_ROLE)).isTrue();
+        assertThat(groupHasClientRole(hrGroupId, clientId, ACTIVITI_USER_ROLE)).isTrue();
     }
 
     private boolean userHasClientRole(String userId, String clientId, String roleName) {

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/AuthTokenRequestInterceptor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/AuthTokenRequestInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.security.feign;
 
 import feign.RequestInterceptor;

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/AuthTokenRequestInterceptor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/AuthTokenRequestInterceptor.java
@@ -1,0 +1,26 @@
+package org.activiti.cloud.security.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import java.util.Optional;
+
+public interface AuthTokenRequestInterceptor extends RequestInterceptor {
+
+    String AUTHORIZATION = "Authorization";
+    String BEARER = "Bearer";
+
+    Optional<String> getToken();
+
+    @Override
+    default void apply(RequestTemplate template) {
+        getToken()
+            .ifPresent(token -> {
+                template.removeHeader(AUTHORIZATION);
+                template.header(AUTHORIZATION,
+                                String.format("%s %s",
+                                              BEARER,
+                                              token));
+            });
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.security.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+/**
+ * Feign request interceptor for forwarding the bearer token
+ */
+public class ClientCredentialsAuthRequestInterceptor implements RequestInterceptor {
+
+    public static final String BEARER = "Bearer";
+
+    public static final String AUTHORIZATION = "Authorization";
+    private final OAuth2AuthorizedClientManager authorizedClientManager;
+    private final ClientRegistration clientRegistration;
+
+
+    public ClientCredentialsAuthRequestInterceptor(OAuth2AuthorizedClientManager authorizedClientManager,
+                                                   ClientRegistration clientRegistration) {
+        this.authorizedClientManager = authorizedClientManager;
+        this.clientRegistration = clientRegistration;
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        if(AuthorizationGrantType.CLIENT_CREDENTIALS.equals(clientRegistration.getAuthorizationGrantType())) {
+            OAuth2AuthorizeRequest oAuth2AuthorizeRequest = OAuth2AuthorizeRequest
+                .withClientRegistrationId(clientRegistration.getRegistrationId())
+                .principal("activiti")
+                .build();
+
+            OAuth2AuthorizedClient client = authorizedClientManager.authorize(oAuth2AuthorizeRequest);
+            OAuth2AccessToken accessToken = client.getAccessToken();
+
+            template.removeHeader(AUTHORIZATION);
+            template.header(AUTHORIZATION,
+                            String.format("%s %s",
+                                          accessToken.getTokenType().getValue(),
+                                          accessToken.getTokenValue()));
+        }
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/TokenRelayRequestInterceptor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/TokenRelayRequestInterceptor.java
@@ -15,43 +15,22 @@
  */
 package org.activiti.cloud.security.feign;
 
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
+import java.util.Optional;
 import org.activiti.api.runtime.shared.security.SecurityContextTokenProvider;
 
 /**
  * Feign request interceptor for forwarding the bearer token
  */
-public class TokenRelayRequestInterceptor implements RequestInterceptor {
-
-    public static final String BEARER = "Bearer";
-
-    public static final String AUTHORIZATION = "Authorization";
-
-    private final String tokenType;
+public class TokenRelayRequestInterceptor implements AuthTokenRequestInterceptor {
 
     private final SecurityContextTokenProvider securityContextTokenProvider;
 
     public TokenRelayRequestInterceptor(SecurityContextTokenProvider securityContextTokenProvider) {
-        this(securityContextTokenProvider,
-             BEARER);
-    }
-
-    public TokenRelayRequestInterceptor(SecurityContextTokenProvider securityContextTokenProvider,
-                                        String tokenType) {
         this.securityContextTokenProvider = securityContextTokenProvider;
-        this.tokenType = tokenType;
     }
 
     @Override
-    public void apply(RequestTemplate template) {
-        securityContextTokenProvider.getCurrentToken()
-                .ifPresent(token -> {
-                    template.removeHeader(AUTHORIZATION);
-                    template.header(AUTHORIZATION,
-                                    String.format("%s %s",
-                                                  tokenType,
-                                                  token));
-                });
+    public Optional<String> getToken() {
+        return securityContextTokenProvider.getCurrentToken();
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/TokenRelayRequestInterceptor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/TokenRelayRequestInterceptor.java
@@ -47,6 +47,7 @@ public class TokenRelayRequestInterceptor implements RequestInterceptor {
     public void apply(RequestTemplate template) {
         securityContextTokenProvider.getCurrentToken()
                 .ifPresent(token -> {
+                    template.removeHeader(AUTHORIZATION);
                     template.header(AUTHORIZATION,
                                     String.format("%s %s",
                                                   tokenType,

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.security.feign.configuration;
+
+import org.activiti.cloud.security.feign.ClientCredentialsAuthRequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+@Configuration
+public class ClientCredentialsAuthConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ClientCredentialsAuthRequestInterceptor clientCredentialsAuthRequestInterceptor(OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
+                                                                                           ClientRegistrationRepository clientRegistrationRepository,
+                                                                                           ClientRegistration clientRegistration) {
+
+        AuthorizedClientServiceOAuth2AuthorizedClientManager authorizedClientManager =
+            new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, oAuth2AuthorizedClientService);
+
+
+        OAuth2AuthorizedClientProvider authorizedClientProvider =
+            OAuth2AuthorizedClientProviderBuilder.builder()
+                .refreshToken()
+                .clientCredentials()
+                .build();
+
+        authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
+
+        return new ClientCredentialsAuthRequestInterceptor(authorizedClientManager, clientRegistration);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ClientRegistration clientRegistration(ClientRegistrationRepository clientRegistrationRepository,
+                                                 @Value("${activiti.cloud.services.oauth2.iam-name:keycloak}") String clientName) {
+        return clientRegistrationRepository.findByRegistrationId(clientName);
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
@@ -21,8 +21,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptorTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.security.feign;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptorTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/security/feign/ClientCredentialsAuthRequestInterceptorTest.java
@@ -1,0 +1,73 @@
+package org.activiti.cloud.security.feign;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import feign.RequestTemplate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+@ExtendWith(MockitoExtension.class)
+class ClientCredentialsAuthRequestInterceptorTest {
+
+    @Mock
+    private OAuth2AuthorizedClientManager authorizedClientManager;
+    @Mock
+    private ClientRegistration clientRegistration;
+    @Mock
+    private OAuth2AuthorizedClient authorizedClient;
+    @Mock
+    private OAuth2AccessToken accessToken;
+
+    @InjectMocks
+    private ClientCredentialsAuthRequestInterceptor clientCredentialsAuthRequestInterceptor;
+
+    @Test
+    public void shouldSetAuthorizationHeader_whenClientCredentials() {
+        when(clientRegistration.getAuthorizationGrantType()).thenReturn(AuthorizationGrantType.CLIENT_CREDENTIALS);
+        when(clientRegistration.getRegistrationId()).thenReturn("keycloak");
+        when(authorizedClientManager.authorize(any())).thenReturn(authorizedClient);
+        when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+        when(accessToken.getTokenValue()).thenReturn("123");
+
+        RequestTemplate requestTemplate = new RequestTemplate();
+        clientCredentialsAuthRequestInterceptor.apply(requestTemplate);
+        assertThat(requestTemplate.headers()).containsEntry("Authorization", List.of("Bearer 123"));
+    }
+
+    @Test
+    public void shouldSetOnlyOneAuthorizationHeader_whenClientCredentials() {
+        when(clientRegistration.getAuthorizationGrantType()).thenReturn(AuthorizationGrantType.CLIENT_CREDENTIALS);
+        when(clientRegistration.getRegistrationId()).thenReturn("keycloak");
+        when(authorizedClientManager.authorize(any())).thenReturn(authorizedClient);
+        when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+        when(accessToken.getTokenValue()).thenReturn("123");
+
+        RequestTemplate requestTemplate = new RequestTemplate();
+        requestTemplate.header("Authorization", "Bearer 456");
+
+        clientCredentialsAuthRequestInterceptor.apply(requestTemplate);
+        assertThat(requestTemplate.headers()).hasSize(1);
+        assertThat(requestTemplate.headers()).containsEntry("Authorization", List.of("Bearer 123"));
+    }
+
+    @Test
+    public void shouldNotSetAnyHeader_whenIsNotClientCredentials() {
+        when(clientRegistration.getAuthorizationGrantType()).thenReturn(AuthorizationGrantType.PASSWORD);
+
+        RequestTemplate requestTemplate = new RequestTemplate();
+        clientCredentialsAuthRequestInterceptor.apply(requestTemplate);
+        assertThat(requestTemplate.headers()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
KeycloakClient.java uses the propagated token to authenticate against Keycloak. It doesn't work when the invocation happens outside any web context, for instance when the authentication is required from an event consumer.