### PR TITLE
fix: add search users by groups support for user search params

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
@@ -17,7 +17,6 @@ package org.activiti.cloud.services.identity.keycloak;
 
 import org.activiti.cloud.identity.GroupSearchParams;
 import org.activiti.cloud.identity.IdentityManagementService;
-import org.activiti.cloud.identity.IdentityService;
 import org.activiti.cloud.identity.UserSearchParams;
 import org.activiti.cloud.identity.exceptions.IdentityInvalidApplicationException;
 import org.activiti.cloud.identity.exceptions.IdentityInvalidGroupException;
@@ -51,10 +50,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class KeycloakManagementService implements IdentityManagementService,
-    IdentityService {
+public class KeycloakManagementService implements IdentityManagementService {
 
     public static final int PAGE_START = 0;
     public static final int PAGE_SIZE = 50;

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
@@ -90,6 +90,7 @@ public class KeycloakManagementService implements IdentityManagementService,
         return groups.stream()
                      .map(this::findUsersByGroupName)
                      .flatMap(Collection::stream)
+                     .distinct()
                      .collect(Collectors.toList());
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
@@ -15,14 +15,6 @@
  */
 package org.activiti.cloud.services.identity.keycloak;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.activiti.cloud.identity.GroupSearchParams;
 import org.activiti.cloud.identity.IdentityManagementService;
 import org.activiti.cloud.identity.IdentityService;
@@ -35,8 +27,8 @@ import org.activiti.cloud.identity.exceptions.IdentityInvalidUserException;
 import org.activiti.cloud.identity.exceptions.IdentityInvalidUserRoleException;
 import org.activiti.cloud.identity.model.Group;
 import org.activiti.cloud.identity.model.Role;
-import org.activiti.cloud.identity.model.SecurityResponseRepresentation;
 import org.activiti.cloud.identity.model.SecurityRequestBodyRepresentation;
+import org.activiti.cloud.identity.model.SecurityResponseRepresentation;
 import org.activiti.cloud.identity.model.User;
 import org.activiti.cloud.identity.model.UserRoles;
 import org.activiti.cloud.services.identity.keycloak.client.KeycloakClient;
@@ -45,11 +37,21 @@ import org.activiti.cloud.services.identity.keycloak.mapper.KeycloakRoleMappingT
 import org.activiti.cloud.services.identity.keycloak.mapper.KeycloakTokenToUserRoles;
 import org.activiti.cloud.services.identity.keycloak.mapper.KeycloakUserToUser;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakClientRepresentation;
-import org.activiti.cloud.services.identity.keycloak.model.KeycloakGroup;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakRoleMapping;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class KeycloakManagementService implements IdentityManagementService,
     IdentityService {
@@ -65,7 +67,9 @@ public class KeycloakManagementService implements IdentityManagementService,
 
     @Override
     public List<User> findUsers(UserSearchParams userSearchParams) {
-        List<User> users= searchUsers(userSearchParams.getSearchKey());
+        List<User> users = ObjectUtils.isEmpty(userSearchParams.getGroups())
+            ? searchUsers(userSearchParams.getSearchKey())
+            : searchUsers(userSearchParams.getGroups());
 
         if(!StringUtils.isEmpty(userSearchParams.getApplication())) {
             return filterUsersInApplicationsScope(users, userSearchParams);
@@ -82,6 +86,13 @@ public class KeycloakManagementService implements IdentityManagementService,
             .collect(Collectors.toList());
     }
 
+    private List<User> searchUsers(Set<String> groups) {
+        return groups.stream()
+                     .map(this::findUsersByGroupName)
+                     .flatMap(Collection::stream)
+                     .collect(Collectors.toList());
+    }
+
     private List<User> filterUsersInRealmScope(List<User> users,
         UserSearchParams userSearchParams) {
 
@@ -92,7 +103,6 @@ public class KeycloakManagementService implements IdentityManagementService,
         return users
             .stream()
             .filter(user -> filterByRoles(usersRolesMapping.get(user.getId()), userSearchParams.getRoles()))
-            .filter(user -> filterByGroups(user, userSearchParams.getGroups()))
             .collect(Collectors.toList());
     }
 
@@ -119,7 +129,6 @@ public class KeycloakManagementService implements IdentityManagementService,
             .stream()
             .filter(user -> filterByApplication(userAppRoles.get(user.getId())))
             .filter(user -> filterByRoles(userAppRoles.get(user.getId()), userSearchParams.getRoles()))
-            .filter(user -> filterByGroups(user, userSearchParams.getGroups()))
             .collect(Collectors.toList());
     }
 
@@ -128,15 +137,6 @@ public class KeycloakManagementService implements IdentityManagementService,
             .collect(Collectors.toMap(
                 User::getId,
                 user -> getUserApplicationRoles(user.getId(), kClientId)));
-    }
-
-    private boolean filterByGroups(User user, Set<String> groups) {
-        return CollectionUtils.isEmpty(groups) || keycloakClient
-            .getUserGroups(user.getId())
-            .stream()
-            .map(KeycloakGroup::getName)
-            .collect(Collectors.toSet())
-            .containsAll(groups);
     }
 
     @Override

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
@@ -15,14 +15,15 @@
  */
 package org.activiti.cloud.identity;
 
-import java.util.List;
-import java.util.Set;
 import org.activiti.cloud.identity.model.Group;
-import org.activiti.cloud.identity.model.SecurityResponseRepresentation;
 import org.activiti.cloud.identity.model.SecurityRequestBodyRepresentation;
+import org.activiti.cloud.identity.model.SecurityResponseRepresentation;
 import org.activiti.cloud.identity.model.User;
 import org.activiti.cloud.identity.model.UserRoles;
 import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  *
@@ -30,7 +31,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * <p>For general purpose you should use {@link org.activiti.cloud.identity.IdentityService}
  *
  */
-public interface IdentityManagementService {
+public interface IdentityManagementService extends IdentityService {
 
   List<User> findUsers(UserSearchParams userSearchParams);
 

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/identity/IdentityManagementServiceTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/identity/IdentityManagementServiceTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.identity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityManagementServiceTest {
+
+    @Test
+    public void should_IdentityServiceCanBeAssignedFromIdentityManagementService() {
+        assertThat(IdentityService.class.isAssignableFrom(IdentityManagementService.class)).isTrue();
+    }
+}


### PR DESCRIPTION
This PR makes use of the optimized find users by group Api and makes IdentityService support with Spring `@Autowired`