### PR TITLE
[AAE-10492] variables in admin process definitions 

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestWebMvcAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.activiti.cloud.services.query.rest.ProcessInstanceAdminService;
 import org.activiti.cloud.services.query.rest.ProcessInstanceService;
 import org.activiti.cloud.services.query.rest.QueryLinkRelationProvider;
 import org.activiti.cloud.services.query.rest.TaskControllerHelper;
@@ -213,5 +214,13 @@ public class QueryRestWebMvcAutoConfiguration  {
     ) {
         return new ProcessInstanceService(processInstanceRepository, taskRepository, processInstanceRestrictionService,
             securityPoliciesApplicationService, securityManager, entityFinder);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessInstanceAdminService processInstanceAdminService(ProcessInstanceRepository processInstanceRepository,
+        EntityFinder entityFinder
+    ) {
+        return new ProcessInstanceAdminService(processInstanceRepository, entityFinder);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -67,7 +67,7 @@ public class ProcessInstanceAdminController {
     }
 
     @JsonView(JsonViews.General.class)
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
     public PagedModel<EntityModel<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                   Pageable pageable) {
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -56,7 +56,6 @@ public class ProcessInstanceAdminController {
 
     private AlfrescoPagedModelAssembler<ProcessInstanceEntity> pagedCollectionModelAssembler;
 
-
     @Autowired
     public ProcessInstanceAdminController(ProcessInstanceAdminService processInstanceAdminService,
                                           ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler,
@@ -70,10 +69,9 @@ public class ProcessInstanceAdminController {
     @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
     public PagedModel<EntityModel<CloudProcessInstance>> findAll(@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate,
                                                                   Pageable pageable) {
-
         return pagedCollectionModelAssembler.toModel(pageable,
-                                                  processInstanceAdminService.findAll(predicate, pageable),
-                                                  processInstanceRepresentationModelAssembler);
+            processInstanceAdminService.findAll(predicate, pageable),
+            processInstanceRepresentationModelAssembler);
     }
 
     @JsonView(JsonViews.ProcessVariables.class)
@@ -90,8 +88,7 @@ public class ProcessInstanceAdminController {
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.GET)
     public EntityModel<CloudProcessInstance> findById(@PathVariable String processInstanceId) {
 
-        ProcessInstanceEntity processInstanceEntity = processInstanceAdminService.findById(processInstanceId);
-        return processInstanceRepresentationModelAssembler.toModel(processInstanceEntity);
+        return processInstanceRepresentationModelAssembler.toModel(processInstanceAdminService.findById(processInstanceId));
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.rest;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import org.activiti.cloud.services.query.app.repository.EntityFinder;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.hibernate.Filter;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+public class ProcessInstanceAdminService {
+
+    private final ProcessInstanceRepository processInstanceRepository;
+    private final EntityFinder entityFinder;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public ProcessInstanceAdminService(ProcessInstanceRepository processInstanceRepository,
+        EntityFinder entityFinder){
+        this.processInstanceRepository = processInstanceRepository;
+        this.entityFinder = entityFinder;
+    }
+
+    public Page<ProcessInstanceEntity> findAll(Predicate predicate, Pageable pageable) {
+
+        return processInstanceRepository.findAll(Optional.ofNullable(predicate)
+                .orElseGet(BooleanBuilder::new),
+            pageable);
+
+    }
+
+    @Transactional
+    public Page<ProcessInstanceEntity> findAllWithVariables(Predicate predicate, List<String> variableKeys, Pageable pageable) {
+
+        Session session = entityManager.unwrap(Session.class);
+        Filter filter = session.enableFilter("variablesFilter");
+        filter.setParameterList("variableKeys", variableKeys);
+        Page<ProcessInstanceEntity> processInstanceEntities = findAll(predicate, pageable);
+        // Due to performance issues (e.g. https://github.com/Activiti/Activiti/issues/3139)
+        // we have to explicitly initialize the lazy loaded field to be able to work with disabled Open Session in View
+        processInstanceEntities.forEach(processInstanceEntity -> Hibernate.initialize(processInstanceEntity.getVariables()));
+        return processInstanceEntities;
+
+    }
+
+    public  ProcessInstanceEntity findById(@PathVariable String processInstanceId) {
+
+        return entityFinder.findById(processInstanceRepository,
+            processInstanceId,
+            "Unable to find task for the given id:'" + processInstanceId + "'");
+
+    }
+
+
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 public class ProcessInstanceAdminService {
 
     private final ProcessInstanceRepository processInstanceRepository;
+
     private final EntityFinder entityFinder;
 
     @PersistenceContext

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -73,7 +73,7 @@ public class TaskAdminController {
     }
 
     @JsonView(JsonViews.General.class)
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
     public PagedModel<EntityModel<QueryCloudTask>> findAll(
         @RequestParam(name = "rootTasksOnly", defaultValue = "false") Boolean rootTasksOnly,
         @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -46,11 +46,11 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(
-        value = "/admin/v1/tasks",
-        produces = {
-                MediaTypes.HAL_JSON_VALUE,
-                MediaType.APPLICATION_JSON_VALUE
-        })
+    value = "/admin/v1/tasks",
+    produces = {
+        MediaTypes.HAL_JSON_VALUE,
+        MediaType.APPLICATION_JSON_VALUE
+    })
 public class TaskAdminController {
 
     private final TaskRepository taskRepository;
@@ -85,13 +85,27 @@ public class TaskAdminController {
                 new StandAloneTaskFilter(standalone)));
     }
 
+    @JsonView(JsonViews.ProcessVariables.class)
+    @RequestMapping(method = RequestMethod.GET, params = "variableKeys")
+    public PagedModel<EntityModel<QueryCloudTask>> findAllWithProcessVariables(
+        @RequestParam(name = "rootTasksOnly", defaultValue = "false") Boolean rootTasksOnly,
+        @RequestParam(name = "standalone", defaultValue = "false") Boolean standalone,
+        @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
+        @RequestParam(value = "variableKeys", required = false, defaultValue = "") List<String> processVariableKeys,
+        VariableSearch variableSearch,
+        Pageable pageable) {
+
+        return taskControllerHelper.findAllWithProcessVariables(predicate, variableSearch, pageable, Arrays.asList(new RootTasksFilter(rootTasksOnly),
+            new StandAloneTaskFilter(standalone)), processVariableKeys);
+    }
+
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{taskId}", method = RequestMethod.GET)
     public EntityModel<QueryCloudTask> findById(@PathVariable String taskId) {
 
         TaskEntity taskEntity = entityFinder.findById(taskRepository,
-                                                      taskId,
-                                                      "Unable to find taskEntity for the given id:'" + taskId + "'");
+            taskId,
+            "Unable to find taskEntity for the given id:'" + taskId + "'");
 
         return taskRepresentationModelAssembler.toModel(taskEntity);
     }
@@ -99,23 +113,23 @@ public class TaskAdminController {
     @RequestMapping(value = "/{taskId}/candidate-users", method = RequestMethod.GET)
     public List<String> getTaskCandidateUsers(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(taskRepository,
-                                                      taskId,
-                                                      "Unable to find taskEntity for the given id:'" + taskId + "'");
+            taskId,
+            "Unable to find taskEntity for the given id:'" + taskId + "'");
 
         return taskEntity.getTaskCandidateUsers() != null ?
-                                      taskEntity.getTaskCandidateUsers().stream().map(TaskCandidateUserEntity::getUserId).collect(Collectors.toList()) :
-                                      null;
+            taskEntity.getTaskCandidateUsers().stream().map(TaskCandidateUserEntity::getUserId).collect(Collectors.toList()) :
+            null;
     }
 
     @RequestMapping(value = "/{taskId}/candidate-groups", method = RequestMethod.GET)
     public List<String> getTaskCandidateGroups(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(taskRepository,
-                                                      taskId,
-                                                      "Unable to find taskEntity for the given id:'" + taskId + "'");
+            taskId,
+            "Unable to find taskEntity for the given id:'" + taskId + "'");
 
         return taskEntity.getTaskCandidateGroups() != null ?
-                                       taskEntity.getTaskCandidateGroups().stream().map(TaskCandidateGroupEntity::getGroupId).collect(Collectors.toList()) :
-                                       null;
+            taskEntity.getTaskCandidateGroups().stream().map(TaskCandidateGroupEntity::getGroupId).collect(Collectors.toList()) :
+            null;
     }
 
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationAdminControllerIT.java
@@ -81,6 +81,9 @@ public class ApplicationAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -88,6 +91,7 @@ public class ApplicationAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ApplicationControllerIT.java
@@ -81,6 +81,9 @@ public class ApplicationControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -88,6 +91,7 @@ public class ApplicationControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminControllerIT.java
@@ -84,6 +84,9 @@ public class ProcessDefinitionAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -91,6 +94,7 @@ public class ProcessDefinitionAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessDefinitionControllerIT.java
@@ -91,6 +91,9 @@ public class ProcessDefinitionControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -98,6 +101,7 @@ public class ProcessDefinitionControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
@@ -134,6 +134,39 @@ public class ProcessInstanceEntityAdminControllerIT {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void findAllWithVariablesShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {
+        //given
+        given(processInstanceRepository.findAll(any(),
+            any(Pageable.class))).willReturn(new PageImpl<>(Collections.singletonList(buildDefaultProcessInstance()),
+            PageRequest.of(1,
+                10),
+            11));
+
+
+        //when
+        mockMvc.perform(get("/admin/v1/process-instances?skipCount=10&maxItems=10&variableKeys=test1&variableKeys=test2")
+                .accept(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    public void findAllWithVariablesShouldReturnAllResultsUsingHalWhenMediaTypeIsApplicationHalJson() throws Exception {
+        //given
+        given(processInstanceRepository.findAll(any(), any(Pageable.class)))
+            .willReturn(new PageImpl<>(Collections.singletonList(buildDefaultProcessInstance()),
+                PageRequest.of(1, 10),
+                11));
+
+
+        //when
+        mockMvc.perform(get("/admin/v1/process-instances?page=1&size=10&variableKeys=test1&variableKeys=test2")
+                .accept(MediaTypes.HAL_JSON_VALUE))
+            //then
+            .andExpect(status().isOk());
+    }
+
 
     private ProcessInstanceEntity buildDefaultProcessInstance() {
         return new ProcessInstanceEntity("My-app", "My-app", "1", null, null,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
@@ -70,6 +70,9 @@ public class ProcessInstanceEntityAdminControllerIT {
     private MockMvc mockMvc;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceRepository processInstanceRepository;
 
     @MockBean
@@ -133,40 +136,6 @@ public class ProcessInstanceEntityAdminControllerIT {
                 //then
                 .andExpect(status().isOk());
     }
-
-    @Test
-    public void findAllWithVariablesShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {
-        //given
-        given(processInstanceRepository.findAll(any(),
-            any(Pageable.class))).willReturn(new PageImpl<>(Collections.singletonList(buildDefaultProcessInstance()),
-            PageRequest.of(1,
-                10),
-            11));
-
-
-        //when
-        mockMvc.perform(get("/admin/v1/process-instances?skipCount=10&maxItems=10&variableKeys=test1&variableKeys=test2")
-                .accept(MediaType.APPLICATION_JSON))
-            //then
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    public void findAllWithVariablesShouldReturnAllResultsUsingHalWhenMediaTypeIsApplicationHalJson() throws Exception {
-        //given
-        given(processInstanceRepository.findAll(any(), any(Pageable.class)))
-            .willReturn(new PageImpl<>(Collections.singletonList(buildDefaultProcessInstance()),
-                PageRequest.of(1, 10),
-                11));
-
-
-        //when
-        mockMvc.perform(get("/admin/v1/process-instances?page=1&size=10&variableKeys=test1&variableKeys=test2")
-                .accept(MediaTypes.HAL_JSON_VALUE))
-            //then
-            .andExpect(status().isOk());
-    }
-
 
     private ProcessInstanceEntity buildDefaultProcessInstance() {
         return new ProcessInstanceEntity("My-app", "My-app", "1", null, null,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
@@ -94,14 +94,10 @@ public class ProcessInstanceEntityAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
-    private ProcessInstanceAdminService processInstanceAdminService;
-
-    @MockBean
     private EntityManagerFactory entityManagerFactory;
 
     @BeforeEach
     void setUp() {
-        assertThat(processInstanceAdminService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }
 
@@ -113,7 +109,6 @@ public class ProcessInstanceEntityAdminControllerIT {
                 PageRequest.of(1,
                         10),
                 11));
-
 
         //when
         mockMvc.perform(get("/admin/v1/process-instances?skipCount=10&maxItems=10")

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityAdminControllerIT.java
@@ -70,9 +70,6 @@ public class ProcessInstanceEntityAdminControllerIT {
     private MockMvc mockMvc;
 
     @MockBean
-    private ProcessInstanceAdminService processInstanceAdminService;
-
-    @MockBean
     private ProcessInstanceRepository processInstanceRepository;
 
     @MockBean
@@ -97,10 +94,14 @@ public class ProcessInstanceEntityAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private EntityManagerFactory entityManagerFactory;
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksAdminControllerIT.java
@@ -80,6 +80,9 @@ public class ProcessInstanceEntityTasksAdminControllerIT {
     private SecurityPoliciesProperties securityPoliciesProperties;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -87,6 +90,7 @@ public class ProcessInstanceEntityTasksAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityTasksControllerIT.java
@@ -90,6 +90,9 @@ public class ProcessInstanceEntityTasksControllerIT {
     private TaskLookupRestrictionService taskLookupRestrictionService;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -97,6 +100,7 @@ public class ProcessInstanceEntityTasksControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityVariableEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityVariableEntityControllerIT.java
@@ -92,6 +92,9 @@ public class ProcessInstanceEntityVariableEntityControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -99,6 +102,7 @@ public class ProcessInstanceEntityVariableEntityControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelAdminControllerIT.java
@@ -86,6 +86,9 @@ public class ProcessModelAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -93,6 +96,7 @@ public class ProcessModelAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessModelControllerIT.java
@@ -88,6 +88,9 @@ public class ProcessModelControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -95,6 +98,7 @@ public class ProcessModelControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
@@ -110,6 +110,7 @@ public class TaskEntityAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
@@ -76,6 +76,9 @@ public class TaskEntityAdminControllerIT {
     private MockMvc mockMvc;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private TaskRepository taskRepository;
 
     @MockBean
@@ -158,54 +161,6 @@ public class TaskEntityAdminControllerIT {
                 //then
                 .andExpect(status().isOk());
 
-    }
-
-    @Test
-    public void findAllWithProcessVariablesShouldReturnAllResultsUsingAlfrescoMetadataWhenMediaTypeIsApplicationJson() throws Exception {
-        //given
-        AlfrescoPageRequest pageRequest = new AlfrescoPageRequest(11,
-            10,
-            PageRequest.of(0,
-                20));
-
-        given(taskRepository.findAll(any(),
-            eq(pageRequest)))
-            .willReturn(new PageImpl<>(Collections.singletonList(buildDefaultTask()),
-                pageRequest,
-                12));
-
-        //when
-        MvcResult result = mockMvc.perform(get("/admin/v1/tasks?skipCount=11&maxItems=10&variableKeys=test1&variableKeys=test2")
-                .accept(MediaType.APPLICATION_JSON))
-            //then
-            .andExpect(status().isOk())
-            .andReturn();
-
-        assertThatJson(result.getResponse().getContentAsString())
-            .node("list.pagination.skipCount").isEqualTo(11)
-            .node("list.pagination.maxItems").isEqualTo(10)
-            .node("list.pagination.count").isEqualTo(1)
-            .node("list.pagination.hasMoreItems").isEqualTo(false)
-            .node("list.pagination.totalItems").isEqualTo(12);
-    }
-
-    @Test
-    public void findAllWithProcessVariablesShouldReturnAllResultsUsingHalWhenMediaTypeIsApplicationHalJson() throws Exception {
-        //given
-        PageRequest pageRequest = PageRequest.of(1,
-            10);
-
-        given(taskRepository.findAll(any(),
-            eq(pageRequest)))
-            .willReturn(new PageImpl<>(Collections.singletonList(buildDefaultTask()),
-                pageRequest,
-                11));
-
-        //when
-        mockMvc.perform(get("/admin/v1/tasks?page=1&size=10&variableKeys=test1&variableKeys=test2")
-                .accept(MediaTypes.HAL_JSON_VALUE))
-            //then
-            .andExpect(status().isOk());
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityAdminControllerIT.java
@@ -37,7 +37,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityControllerIT.java
@@ -101,6 +101,9 @@ public class TaskEntityControllerIT {
     private SecurityPoliciesProperties securityPoliciesProperties;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -108,6 +111,7 @@ public class TaskEntityControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
@@ -92,6 +92,9 @@ public class TaskEntityDeleteControllerIT {
     private TaskLookupRestrictionService taskLookupRestrictionService;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -99,6 +102,7 @@ public class TaskEntityDeleteControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityVariableEntityControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityVariableEntityControllerIT.java
@@ -92,6 +92,9 @@ public class TaskEntityVariableEntityControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -99,6 +102,7 @@ public class TaskEntityVariableEntityControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/VariableEntityAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/VariableEntityAdminControllerIT.java
@@ -87,6 +87,9 @@ public class VariableEntityAdminControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockBean
     private ProcessInstanceService processInstanceService;
 
     @MockBean
@@ -94,6 +97,7 @@ public class VariableEntityAdminControllerIT {
 
     @BeforeEach
     void setUp() {
+        assertThat(processInstanceAdminService).isNotNull();
         assertThat(processInstanceService).isNotNull();
         assertThat(entityManagerFactory).isNotNull();
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/BaseProcessDefinitionService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/BaseProcessDefinitionService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core;
+
+import java.util.List;
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
+
+public abstract class BaseProcessDefinitionService {
+
+    private final List<ProcessDefinitionDecorator> processDefinitionDecorators;
+
+    public BaseProcessDefinitionService(List<ProcessDefinitionDecorator> processDefinitionDecorators){
+        this.processDefinitionDecorators = processDefinitionDecorators;
+    }
+
+    public abstract Page<ProcessDefinition> getProcessDefinitions(Pageable pageable, List<String> include);
+
+    protected ExtendedCloudProcessDefinition decorateAll(ProcessDefinition processDefinition, List<String> include) {
+        ExtendedCloudProcessDefinition decoratedProcessDefinition = new CloudProcessDefinitionImpl(processDefinition);
+        for (String param : include) {
+            decoratedProcessDefinition = decorate(decoratedProcessDefinition, param);
+        }
+        return decoratedProcessDefinition;
+    }
+
+    protected ExtendedCloudProcessDefinition decorate(ExtendedCloudProcessDefinition processDefinition, String includeParam) {
+        return processDefinitionDecorators.stream()
+            .filter(decorator -> decorator.applies(includeParam))
+            .findFirst()
+            .map(decorator -> decorator.decorate(processDefinition))
+            .orElse(processDefinition);
+    }
+
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionAdminService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionAdminService.java
@@ -20,8 +20,6 @@ import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.runtime.shared.query.Pageable;
-import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
-import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
 import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
 
 public class ProcessDefinitionAdminService extends BaseProcessDefinitionService {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionAdminService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionAdminService.java
@@ -15,27 +15,25 @@
  */
 package org.activiti.cloud.services.core;
 
+import java.util.List;
 import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.api.process.runtime.ProcessRuntime;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.runtime.shared.query.Pageable;
 import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
 import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
 
-import java.util.List;
+public class ProcessDefinitionAdminService extends BaseProcessDefinitionService {
+    private final ProcessAdminRuntime processAdminRuntime;
 
-public class ProcessDefinitionService extends BaseProcessDefinitionService {
-
-    private final ProcessRuntime processRuntime;
-
-    public ProcessDefinitionService(ProcessRuntime processRuntime, List<ProcessDefinitionDecorator> processDefinitionDecorators) {
+    public ProcessDefinitionAdminService(ProcessAdminRuntime processAdminRuntime, List<ProcessDefinitionDecorator> processDefinitionDecorators) {
         super(processDefinitionDecorators);
-        this.processRuntime = processRuntime;
+        this.processAdminRuntime = processAdminRuntime;
     }
 
     public Page<ProcessDefinition> getProcessDefinitions(Pageable pageable, List<String> include) {
-        Page<ProcessDefinition> processDefinitions = processRuntime.processDefinitions(pageable);
+        Page<ProcessDefinition> processDefinitions = processAdminRuntime.processDefinitions(pageable);
         processDefinitions.getContent().replaceAll(processDefinition -> super.decorateAll(processDefinition, include));
         return processDefinitions;
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.activiti.api.model.shared.Payload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.services.core.ProcessDefinitionAdminService;
 import org.activiti.cloud.services.core.ProcessDefinitionService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.ProcessVariableDateConverter;
@@ -242,4 +243,10 @@ public class ServicesCoreAutoConfiguration {
         return new ProcessDefinitionService(processRuntime, processDefinitionDecorators);
     }
 
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionAdminService processDefinitionAdminService(ProcessAdminRuntime processAdminRuntime,
+        List<ProcessDefinitionDecorator> processDefinitionDecorators) {
+        return new ProcessDefinitionAdminService(processAdminRuntime, processDefinitionDecorators);
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDefinitionAdminServiceTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDefinitionAdminServiceTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.VariableDefinition;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
+
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
+import org.activiti.api.runtime.model.impl.VariableDefinitionImpl;
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.api.process.model.impl.CloudProcessDefinitionImpl;
+import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
+import org.activiti.runtime.api.query.impl.PageImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProcessDefinitionAdminServiceTest {
+
+    private final ProcessAdminRuntime processAdminRuntime = Mockito.mock(ProcessAdminRuntime.class);
+    private final ProcessDefinitionDecorator processDefinitionDecorator = Mockito.mock(ProcessDefinitionDecorator.class);
+
+    private final ProcessDefinitionAdminService processDefinitionAdminService =
+        new ProcessDefinitionAdminService(processAdminRuntime, List.of(processDefinitionDecorator));
+
+    @Test
+    void should_getProcessDefinitionsWithVariables_whenIncludeVariablesParameterPresent() {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId("id");
+        ArrayList<ProcessDefinition> processDefinitions = new ArrayList<>();
+        processDefinitions.add(processDefinition);
+        when(processAdminRuntime.processDefinitions(any()))
+            .thenReturn(new PageImpl<>(processDefinitions, 1));
+
+        VariableDefinitionImpl variableDefinition = new VariableDefinitionImpl();
+        when(processDefinitionDecorator.applies("variables")).thenReturn(true);
+        when(processDefinitionDecorator.decorate(argThat(argument -> argument.getId().equals(processDefinition.getId()))))
+            .thenAnswer(call -> {
+                CloudProcessDefinitionImpl cloudProcessDefinition = new CloudProcessDefinitionImpl(processDefinition);
+                cloudProcessDefinition.setVariableDefinitions(List.of(variableDefinition));
+                return cloudProcessDefinition;
+            });
+
+        List<ProcessDefinition> result =
+            processDefinitionAdminService.getProcessDefinitions(Pageable.of(0, 50), List.of("variables")).getContent();
+
+        assertThat(result).hasSize(1);
+        List<VariableDefinition> variableDefinitions = ((ExtendedCloudProcessDefinition) result.get(0)).getVariableDefinitions();
+        assertThat(variableDefinitions).hasSize(1);
+        assertThat(variableDefinitions.get(0)).isEqualTo(variableDefinition);
+        verify(processDefinitionDecorator).decorate(argThat(argument -> argument.getId().equals(processDefinition.getId())));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyIncludeVariables")
+    void should_getProcessDefinitionsWithVariables_whenIncludeVariablesParameterNotPresent(List<String> include) {
+        ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
+        processDefinition.setId("id");
+        ArrayList<ProcessDefinition> processDefinitions = new ArrayList<>();
+        processDefinitions.add(processDefinition);
+        when(processAdminRuntime.processDefinitions(any()))
+            .thenReturn(new PageImpl<>(processDefinitions, 1));
+
+        lenient().when(processDefinitionDecorator.applies("variables")).thenReturn(true);
+
+        List<ProcessDefinition> result =
+            processDefinitionAdminService.getProcessDefinitions(Pageable.of(0, 50), include).getContent();
+
+        assertThat(result).hasSize(1);
+        verify(processDefinitionDecorator, never()).decorate(any());
+    }
+
+    private static Stream<Arguments> emptyIncludeVariables() {
+        return Stream.of(Arguments.of(List.of()), Arguments.of(List.of("")), Arguments.of(List.of("other")));
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionAdminController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessDefinitionAdminController.java
@@ -15,7 +15,9 @@
  */
 package org.activiti.cloud.services.rest.api;
 
-import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedModel;
@@ -23,12 +25,16 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequestMapping(value = "/admin/v1/process-definitions",
         produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface ProcessDefinitionAdminController {
 
     @RequestMapping(method = RequestMethod.GET)
-    PagedModel<EntityModel<CloudProcessDefinition>> getAllProcessDefinitions(Pageable pageable);
+    PagedModel<EntityModel<ExtendedCloudProcessDefinition>> getAllProcessDefinitions(
+        @Parameter(description = "List of values to include in response")
+        @RequestParam(value = "include", required = false) List<String> include,
+        Pageable pageable);
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImpl.java
@@ -27,21 +27,23 @@
  * limitations under the License.
  *
  */
-
 package org.activiti.cloud.services.rest.controllers;
 
+import java.util.List;
 import org.activiti.api.process.model.ProcessDefinition;
-import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
-import org.activiti.cloud.api.process.model.CloudProcessDefinition;
+import org.activiti.cloud.api.process.model.ExtendedCloudProcessDefinition;
+import org.activiti.cloud.services.core.ProcessDefinitionAdminService;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.rest.api.ProcessDefinitionAdminController;
+import org.activiti.cloud.services.rest.assemblers.ExtendedCloudProcessDefinitionRepresentationModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessDefinitionRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -50,29 +52,38 @@ public class ProcessDefinitionAdminControllerImpl implements ProcessDefinitionAd
 
     private final ProcessDefinitionRepresentationModelAssembler representationModelAssembler;
 
-    private final ProcessAdminRuntime processAdminRuntime;
+    private final ExtendedCloudProcessDefinitionRepresentationModelAssembler extendedCloudProcessDefinitionRepresentationModelAssembler;
+
+    private final ProcessDefinitionAdminService processDefinitionAdminService;
 
     private final AlfrescoPagedModelAssembler<ProcessDefinition> pagedCollectionModelAssembler;
 
     private final SpringPageConverter pageConverter;
 
     @Autowired
-    public ProcessDefinitionAdminControllerImpl(ProcessAdminRuntime processAdminRuntime,
-                                                ProcessDefinitionRepresentationModelAssembler representationModelAssembler,
-                                                AlfrescoPagedModelAssembler<ProcessDefinition> pagedCollectionModelAssembler,
-                                                SpringPageConverter pageConverter) {
-        this.processAdminRuntime = processAdminRuntime;
+    public ProcessDefinitionAdminControllerImpl(
+        ProcessDefinitionRepresentationModelAssembler representationModelAssembler,
+        ExtendedCloudProcessDefinitionRepresentationModelAssembler extendedCloudProcessDefinitionRepresentationModelAssembler,
+        AlfrescoPagedModelAssembler<ProcessDefinition> pagedCollectionModelAssembler,
+        SpringPageConverter pageConverter,
+        ProcessDefinitionAdminService processDefinitionAdminService) {
+
         this.representationModelAssembler = representationModelAssembler;
+        this.extendedCloudProcessDefinitionRepresentationModelAssembler = extendedCloudProcessDefinitionRepresentationModelAssembler;
         this.pagedCollectionModelAssembler = pagedCollectionModelAssembler;
         this.pageConverter = pageConverter;
+        this.processDefinitionAdminService = processDefinitionAdminService;
     }
 
     @Override
-    public PagedModel<EntityModel<CloudProcessDefinition>> getAllProcessDefinitions(Pageable pageable) {
-        Page<ProcessDefinition> page = processAdminRuntime.processDefinitions(pageConverter.toAPIPageable(pageable));
+    public PagedModel<EntityModel<ExtendedCloudProcessDefinition>> getAllProcessDefinitions(
+        @RequestParam(required = false, defaultValue = "") List<String> include,
+        Pageable pageable) {
+
+        Page<ProcessDefinition> page = processDefinitionAdminService.getProcessDefinitions(pageConverter.toAPIPageable(pageable), include);
         return pagedCollectionModelAssembler.toModel(pageable,
                 pageConverter.toSpringPage(pageable, page),
-                representationModelAssembler);
+                extendedCloudProcessDefinitionRepresentationModelAssembler);
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
+import java.util.ArrayList;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
@@ -102,6 +103,7 @@ public class ProcessDefinitionAdminControllerImplIT {
     @MockBean
     private ProcessRuntime processRuntime;
 
+
     @BeforeEach
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
@@ -121,7 +123,8 @@ public class ProcessDefinitionAdminControllerImplIT {
         String my_process = "my process";
         String this_is_my_process = "this is my process";
         int version = 1;
-        List<ProcessDefinition> processDefinitionList = Collections.singletonList(buildProcessDefinition(procId,
+        List<ProcessDefinition> processDefinitionList = new ArrayList<>();
+        processDefinitionList.add(buildProcessDefinition(procId,
                 my_process,
                 this_is_my_process,
                 version));
@@ -156,7 +159,8 @@ public class ProcessDefinitionAdminControllerImplIT {
         processDefinition.setDescription("This is my process");
         processDefinition.setVersion(1);
 
-        List<ProcessDefinition> processDefinitionList = Collections.singletonList(processDefinition);
+        List<ProcessDefinition> processDefinitionList = new ArrayList<>();
+        processDefinitionList.add(processDefinition);
         Page<ProcessDefinition> processDefinitionPage = new PageImpl<>(processDefinitionList,
                 11);
         given(processAdminRuntime.processDefinitions(any())).willReturn(processDefinitionPage);


### PR DESCRIPTION
This PR is adding an `include` query param to `/admin/v1/process-definitions` endpoint, which only takes `variables` value at the moment. If it is set in a request, the endpoint returns all the displayable variable definitions for each process definition.
This PR is also adding the `variableKeys` query param to `/admin/v1/process-instances` and `/admin/v1/tasks` as an array of process parameters that allows to see the details of the specified parameters for all the process instances and tasks returned by the endpoints.