### PR TITLE
Updated Spring Cloud to 2021.0.4

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -12,9 +12,8 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Dependencies Parent</name>
   <properties>
-    <spring-cloud.version>2021.0.3</spring-cloud.version>
+    <spring-cloud.version>2021.0.4</spring-cloud.version>
     <testcontainers.version>1.16.3</testcontainers.version>
-    <liquibase.version>4.8.0</liquibase.version>
     <h2.version>1.4.200</h2.version>
     <graphql-java.version>13.0</graphql-java.version>
     <postgresql.version>42.5.0</postgresql.version>
@@ -30,11 +29,6 @@
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.liquibase</groupId>
-        <artifactId>liquibase-core</artifactId>
-        <version>${liquibase.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Updated Spring Cloud to 2021.0.4

Removed Liquibase dependency (supplied by Spring Boot)

Fixes #4115
