### PR TITLE
fix(AAE-10999): upgrade graphql-java dependency version to 19.2

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -15,7 +15,7 @@
     <spring-cloud.version>2021.0.4</spring-cloud.version>
     <testcontainers.version>1.16.3</testcontainers.version>
     <h2.version>1.4.200</h2.version>
-    <graphql-java.version>13.0</graphql-java.version>
+    <graphql-java.version>19.2</graphql-java.version>
     <postgresql.version>42.5.0</postgresql.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.4.19</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.5.1</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
@@ -15,15 +15,6 @@
  */
 package org.activiti.cloud.services.notifications.graphql.jpa.query;
 
-import javax.persistence.EntityManager;
-
-import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
-import org.activiti.cloud.services.query.model.VariableValue;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.Configuration;
-
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaConfigurer;
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLShemaRegistration;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
@@ -31,6 +22,14 @@ import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilde
 import graphql.GraphQL;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
+import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.VariableValue;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
 
 /**
  * Spring Boot auto configuration of Activiti GraphQL Query Service components
@@ -50,7 +49,11 @@ public class ActivitiGraphQLSchemaAutoConfiguration {
             this.entityManager = entityManager;
 
             JavaScalars.register(VariableValue.class,
-                                 new GraphQLScalarType("VariableValue", "VariableValue type", new JavaScalars.GraphQLObjectCoercing()));
+                                 GraphQLScalarType.newScalar()
+                                                  .name("VariableValue")
+                                                  .description("VariableValue type")
+                                                  .coercing(new JavaScalars.GraphQLObjectCoercing())
+                                                  .build());
         }
 
         @Override

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
@@ -15,16 +15,16 @@
  */
 package org.activiti.cloud.services.notifications.graphql.jpa.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import graphql.Scalars;
+import graphql.scalars.ExtendedScalars;
+import graphql.schema.GraphQLSchema;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-import graphql.Scalars;
-import graphql.schema.GraphQLSchema;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = "spring.data.jpa.repositories.bootstrap-mode=default")
 @TestPropertySource("classpath:application-test.properties")
@@ -77,7 +77,7 @@ class ActivitiGraphQLSchemaAutoConfigurationTest {
         //then
         assertThat(schema.getQueryType().getFieldDefinition("ProcessVariable")
             .getArgument("id").getType())
-            .isEqualTo(Scalars.GraphQLLong);
+            .isEqualTo(ExtendedScalars.GraphQLLong);
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("ProcessVariable")

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>graphql-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.graphql-java</groupId>
+      <artifactId>graphql-java-extended-scalars</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
     </dependency>

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
@@ -15,15 +15,9 @@
  */
 package org.activiti.cloud.services.notifications.graphql.subscriptions;
 
-import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.Optional;
-
+import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
@@ -31,6 +25,14 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
 import org.springframework.core.io.DefaultResourceLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Optional;
+
+import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 
 public class GraphQLSubscriptionSchemaBuilder {
 
@@ -52,8 +54,17 @@ public class GraphQLSubscriptionSchemaBuilder {
         this.typeRegistry = new SchemaParser().parse(streamReader);
 
         this.wiring = RuntimeWiring.newRuntimeWiring()
-                                   .scalar(new ObjectScalar());
-   }
+                                   .scalar(GraphQLScalarType.newScalar()
+                                                            .name("ObjectScalar")
+                                                            .description("An object scalar")
+                                                            .coercing(new ObjectScalar())
+                                                            .build())
+                                   .scalar(GraphQLScalarType.newScalar(ExtendedScalars.GraphQLLong)
+                                                            .name("Timestamp")
+                                                            .description("An timestamp long scalar")
+                                                            .build())
+        ;
+    }
 
     private GraphQLSchema buildSchema() {
         return new SchemaGenerator().makeExecutableSchema(typeRegistry, wiring.build());

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalar.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalar.java
@@ -15,12 +15,6 @@
  */
 package org.activiti.cloud.services.notifications.graphql.subscriptions;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import graphql.Assert;
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
@@ -37,79 +31,74 @@ import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
-import graphql.schema.GraphQLScalarType;
 
-public class ObjectScalar extends GraphQLScalarType {
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+public class ObjectScalar implements Coercing<Object, Object> {
 
-    public ObjectScalar() {
-        this("ObjectScalar", "An object scalar");
+    @Override
+    public Object serialize(Object input) throws CoercingSerializeException {
+        return input;
     }
 
-    ObjectScalar(String name, String description) {
-        super(name, description, new Coercing<Object, Object>() {
-            @Override
-            public Object serialize(Object input) throws CoercingSerializeException {
-                return input;
-            }
-
-            @Override
-            public Object parseValue(Object input) throws CoercingParseValueException {
-                return input;
-            }
-
-            @Override
-            public Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                return parseLiteral(input, Collections.emptyMap());
-            }
-
-            @Override
-            public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
-                if (!(input instanceof Value)) {
-                    throw new CoercingParseLiteralException(
-                            "Expected AST type 'StringValue' but was '" + input + "'."
-                    );
-                }
-                if (input instanceof NullValue) {
-                    return null;
-                }
-                if (input instanceof FloatValue) {
-                    return ((FloatValue) input).getValue();
-                }
-                if (input instanceof StringValue) {
-                    return ((StringValue) input).getValue();
-                }
-                if (input instanceof IntValue) {
-                    return ((IntValue) input).getValue();
-                }
-                if (input instanceof BooleanValue) {
-                    return ((BooleanValue) input).isValue();
-                }
-                if (input instanceof EnumValue) {
-                    return ((EnumValue) input).getName();
-                }
-                if (input instanceof VariableReference) {
-                    String varName = ((VariableReference) input).getName();
-                    return variables.get(varName);
-                }
-                if (input instanceof ArrayValue) {
-                    List<Value> values = ((ArrayValue) input).getValues();
-                    return values.stream()
-                            .map(v -> parseLiteral(v, variables))
-                            .collect(Collectors.toList());
-                }
-                if (input instanceof ObjectValue) {
-                    List<ObjectField> values = ((ObjectValue) input).getObjectFields();
-                    Map<String, Object> parsedValues = new LinkedHashMap<>();
-                    values.forEach(fld -> {
-                        Object parsedValue = parseLiteral(fld.getValue(), variables);
-                        parsedValues.put(fld.getName(), parsedValue);
-                    });
-                    return parsedValues;
-                }
-                return Assert.assertShouldNeverHappen("We have covered all Value types");
-            }
-        });
+    @Override
+    public Object parseValue(Object input) throws CoercingParseValueException {
+        return input;
     }
 
+    @Override
+    public Object parseLiteral(Object input) throws CoercingParseLiteralException {
+        return parseLiteral(input, Collections.emptyMap());
+    }
+
+    @Override
+    public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
+        if (!(input instanceof Value)) {
+            throw new CoercingParseLiteralException(
+                    "Expected AST type 'StringValue' but was '" + input + "'."
+            );
+        }
+        if (input instanceof NullValue) {
+            return null;
+        }
+        if (input instanceof FloatValue) {
+            return ((FloatValue) input).getValue();
+        }
+        if (input instanceof StringValue) {
+            return ((StringValue) input).getValue();
+        }
+        if (input instanceof IntValue) {
+            return ((IntValue) input).getValue();
+        }
+        if (input instanceof BooleanValue) {
+            return ((BooleanValue) input).isValue();
+        }
+        if (input instanceof EnumValue) {
+            return ((EnumValue) input).getName();
+        }
+        if (input instanceof VariableReference) {
+            String varName = ((VariableReference) input).getName();
+            return variables.get(varName);
+        }
+        if (input instanceof ArrayValue) {
+            List<Value> values = ((ArrayValue) input).getValues();
+            return values.stream()
+                    .map(v -> parseLiteral(v, variables))
+                    .collect(Collectors.toList());
+        }
+        if (input instanceof ObjectValue) {
+            List<ObjectField> values = ((ObjectValue) input).getObjectFields();
+            Map<String, Object> parsedValues = new LinkedHashMap<>();
+            values.forEach(fld -> {
+                Object parsedValue = parseLiteral(fld.getValue(), variables);
+                parsedValues.put(fld.getName(), parsedValue);
+            });
+            return parsedValues;
+        }
+        return Assert.assertShouldNeverHappen("We have covered all Value types");
+    }
 }

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/resources/activiti.graphqls
@@ -2,88 +2,89 @@
 # Schemas must have at least a query root type
 #
 scalar ObjectScalar
+scalar Timestamp
 
 schema {
-    query: Query
-    subscription : Subscription
+  query: Query
+  subscription : Subscription
 }
 
 type Query {
-    hello : String
+  hello : String
 }
 
 type Subscription {
-    engineEvents(
-    	serviceName : [String!],
-    	appName : [String!],
-		eventType: [EngineEventType!],
-    	processDefinitionKey : [String!],
-		processInstanceId : [String!],
-		businessKey : [String!]
-    ) : [EngineEvent]
+  engineEvents(
+    serviceName : [String!],
+    appName : [String!],
+    eventType: [EngineEventType!],
+    processDefinitionKey : [String!],
+    processInstanceId : [String!],
+    businessKey : [String!]
+  ) : [EngineEvent]
 }
 
 enum EngineEventType {
-	PROCESS_STARTED
-	PROCESS_COMPLETED
-	PROCESS_CREATED
-	PROCESS_CANCELLED
-	PROCESS_RESUMED
-	PROCESS_SUSPENDED
-	PROCESS_DEPLOYED
-	PROCESS_UPDATED
-	ACTIVITY_STARTED
-	ACTIVITY_CANCELLED
-	ACTIVITY_COMPLETED
-	VARIABLE_CREATED
-	VARIABLE_UPDATED
-	VARIABLE_DELETED
-	SEQUENCE_FLOW_TAKEN
-	TASK_CREATED
-	TASK_COMPLETED
-	TASK_ASSIGNED
-	TASK_ACTIVATED
-	TASK_SUSPENDED
-	TASK_CANCELLED
-	TASK_UPDATED
-	INTEGRATION_REQUESTED
-	INTEGRATION_RESULT_RECEIVED
-	INTEGRATION_ERROR_RECEIVED
-	TASK_CANDIDATE_USER_ADDED
-	TASK_CANDIDATE_USER_REMOVED
-	TASK_CANDIDATE_GROUP_ADDED
-	TASK_CANDIDATE_GROUP_REMOVED
-	SIGNAL_RECEIVED,
-    TIMER_SCHEDULED,
-    TIMER_FIRED,
-    TIMER_CANCELLED,
-    TIMER_EXECUTED,
-    TIMER_FAILED,
-    TIMER_RETRIES_DECREMENTED,
-    MESSAGE_WAITING,
-    MESSAGE_RECEIVED,
-    MESSAGE_SENT
-    MESSAGE_SUBSCRIPTION_CANCELLED
+  PROCESS_STARTED
+  PROCESS_COMPLETED
+  PROCESS_CREATED
+  PROCESS_CANCELLED
+  PROCESS_RESUMED
+  PROCESS_SUSPENDED
+  PROCESS_DEPLOYED
+  PROCESS_UPDATED
+  ACTIVITY_STARTED
+  ACTIVITY_CANCELLED
+  ACTIVITY_COMPLETED
+  VARIABLE_CREATED
+  VARIABLE_UPDATED
+  VARIABLE_DELETED
+  SEQUENCE_FLOW_TAKEN
+  TASK_CREATED
+  TASK_COMPLETED
+  TASK_ASSIGNED
+  TASK_ACTIVATED
+  TASK_SUSPENDED
+  TASK_CANCELLED
+  TASK_UPDATED
+  INTEGRATION_REQUESTED
+  INTEGRATION_RESULT_RECEIVED
+  INTEGRATION_ERROR_RECEIVED
+  TASK_CANDIDATE_USER_ADDED
+  TASK_CANDIDATE_USER_REMOVED
+  TASK_CANDIDATE_GROUP_ADDED
+  TASK_CANDIDATE_GROUP_REMOVED
+  SIGNAL_RECEIVED,
+  TIMER_SCHEDULED,
+  TIMER_FIRED,
+  TIMER_CANCELLED,
+  TIMER_EXECUTED,
+  TIMER_FAILED,
+  TIMER_RETRIES_DECREMENTED,
+  MESSAGE_WAITING,
+  MESSAGE_RECEIVED,
+  MESSAGE_SENT
+  MESSAGE_SUBSCRIPTION_CANCELLED
 }
 
 type EngineEvent {
-    id : String
-    timestamp : Long
-    serviceName : String
-    serviceFullName : String
-    serviceVersion : String
-    serviceType : String
-    appName : String
-    appVersion : String
+  id : String
+  timestamp : Timestamp
+  serviceName : String
+  serviceFullName : String
+  serviceVersion : String
+  serviceType : String
+  appName : String
+  appVersion : String
 
-    processInstanceId : String
-    parentProcessInstanceId : String
-    processDefinitionId : String
-    processDefinitionKey : String
-    processDefinitionVersion : Long
-    businessKey : String
+  processInstanceId : String
+  parentProcessInstanceId : String
+  processDefinitionId : String
+  processDefinitionKey : String
+  processDefinitionVersion : Int
+  businessKey : String
 
-    entityId : String
-    entity : ObjectScalar
-    eventType : EngineEventType
+  entityId : String
+  entity : ObjectScalar
+  eventType : EngineEventType
 }

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/test/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalarTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/test/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalarTest.java
@@ -15,16 +15,6 @@
  */
 package org.activiti.cloud.services.notifications.graphql.subscriptions;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
 import graphql.language.EnumValue;
@@ -39,11 +29,21 @@ import graphql.language.VariableReference;
 import graphql.schema.Coercing;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ObjectScalarTest {
 
     private Map<String, Object> variables = Collections.singletonMap( "varRef1", "value1");
 
-    private Coercing<?,?> coercing = new ObjectScalar().getCoercing();
+    private Coercing<?,?> coercing = new ObjectScalar();
 
     @SuppressWarnings("serial")
     @Test


### PR DESCRIPTION
Fixes: https://nvd.nist.gov/vuln/detail/CVE-2022-37734

- [x] Update graphql-java version to 19.2
- [x] Update graphql-jpq-query version to 0.5.1
- [x] Port subscription schema wiring to support graphql java 19 extended scalars

Ref: https://github.com/Activiti/Activiti/issues/4122