### PR TITLE
fix(notifications): revert subscription schema changes for engineEvents

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>0.5.1</graphql-jpa-query.version>
+    <graphql-jpa-query.version>0.5.2</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.notifications.graphql.subscriptions;
 
+import com.introproventures.graphql.jpa.query.schema.JavaScalarsWiringPostProcessor;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLScalarType;
@@ -59,11 +60,8 @@ public class GraphQLSubscriptionSchemaBuilder {
                                                             .description("An object scalar")
                                                             .coercing(new ObjectScalar())
                                                             .build())
-                                   .scalar(GraphQLScalarType.newScalar(ExtendedScalars.GraphQLLong)
-                                                            .name("Timestamp")
-                                                            .description("An timestamp long scalar")
-                                                            .build())
-        ;
+                                   .scalar(ExtendedScalars.GraphQLLong)
+                                   .transformer(new JavaScalarsWiringPostProcessor());
     }
 
     private GraphQLSchema buildSchema() {

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/resources/activiti.graphqls
@@ -2,7 +2,7 @@
 # Schemas must have at least a query root type
 #
 scalar ObjectScalar
-scalar Timestamp
+scalar Long
 
 schema {
   query: Query
@@ -69,7 +69,7 @@ enum EngineEventType {
 
 type EngineEvent {
   id : String
-  timestamp : Timestamp
+  timestamp : Long
   serviceName : String
   serviceFullName : String
   serviceVersion : String
@@ -81,7 +81,7 @@ type EngineEvent {
   parentProcessInstanceId : String
   processDefinitionId : String
   processDefinitionKey : String
-  processDefinitionVersion : Int
+  processDefinitionVersion : Long
   businessKey : String
 
   entityId : String


### PR DESCRIPTION
- [x] Update graphql-jpa-query dependencies to 0.5.2
- [x] Revert subscription schema changes to maintain backward compatibility with previous versions