### PR TITLE
[AAE-10464] Processes with a dot in the name

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingModelsSteps.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingModelsSteps.java
@@ -23,8 +23,8 @@ import static org.activiti.cloud.modeling.api.process.ServiceTaskActionType.OUTP
 import static org.activiti.cloud.modeling.api.process.VariableMappingType.VALUE;
 import static org.activiti.cloud.modeling.api.process.VariableMappingType.VARIABLE;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_JSON;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.setExtension;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeExtension;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -178,8 +178,8 @@ public class ModelingModelsSteps extends ModelingContextSteps<Model> {
                                  boolean isExtensionType) throws IOException {
         final String fileExtension = isExtensionType ? CONTENT_TYPE_JSON : getModelType(model.getType()).getContentFileExtension();
         final String fileName = isExtensionType ?
-                toJsonFilename(model.getName() + getModelType(model.getType()).getExtensionsFileSuffix()) :
-                setExtension(model.getName(),
+                changeToJsonFilename(model.getName() + getModelType(model.getType()).getExtensionsFileSuffix()) :
+                changeExtension(model.getName(),
                              fileExtension);
         final String resourcePath = model.getType().toLowerCase() + "/" + fileName;
         return new FormData(fileExtension,

--- a/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingProjectsSteps.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingProjectsSteps.java
@@ -40,8 +40,8 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.util.StreamUtils;
 
 import static org.activiti.cloud.acc.modeling.modeling.ProcessExtensions.EXTENSIONS_TASK_NAME;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.setExtension;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeExtension;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.test.asserts.AssertFileContent.assertThatFileContent;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_OK;
@@ -180,17 +180,17 @@ public class ModelingProjectsSteps extends ModelingContextSteps<Project> {
                         .hasContentType(ContentTypeUtils.CONTENT_TYPE_ZIP)
                         .isZip()
                         .hasEntries(
-                                toJsonFilename(currentProject.getName()),
+                                changeToJsonFilename(currentProject.getName()),
                                 modelType.getFolderName() + "/",
-                                modelType.getFolderName() + "/" + toJsonFilename(modelName + modelType.getExtensionsFileSuffix()),
-                                modelType.getFolderName() + "/" + setExtension(modelName,
+                                modelType.getFolderName() + "/" + changeToJsonFilename(modelName + modelType.getExtensionsFileSuffix()),
+                                modelType.getFolderName() + "/" + changeExtension(modelName,
                                                                                modelType.getContentFileExtension())
                         )
-                        .hasJsonContentSatisfying(toJsonFilename(currentProject.getName()),
+                        .hasJsonContentSatisfying(changeToJsonFilename(currentProject.getName()),
                                                   jsonContent -> jsonContent
                                                           .node("name").isEqualTo(currentProject.getName()))
                         .hasJsonContentSatisfying(
-                                modelType.getFolderName() + "/" + toJsonFilename(modelName + modelType.getExtensionsFileSuffix()),
+                                modelType.getFolderName() + "/" + changeToJsonFilename(modelName + modelType.getExtensionsFileSuffix()),
                                 jsonContent -> {
                                     jsonContent.node("id").matches(startsWith("process-"));
                                     jsonContent.node("name").isEqualTo(modelName);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -67,8 +67,6 @@ import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_T
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.JSON;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.isJsonContentType;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.removeExtension;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeExtension;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.setExtension;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -67,6 +67,8 @@ import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_T
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.JSON;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.isJsonContentType;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.removeExtension;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeExtension;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.setExtension;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
@@ -65,7 +65,7 @@ import java.util.stream.Stream;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.JSON;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.getContentTypeByPath;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.removeExtension;
-import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.modeling.service.ModelTypeComparators.MODEL_JSON_FILE_TYPE_COMPARATOR;
 import static org.activiti.cloud.services.modeling.service.ModelTypeComparators.MODEL_TYPE_COMPARATOR;
 
@@ -216,7 +216,7 @@ public class ProjectServiceImpl implements ProjectService {
         ProjectDescriptor projectDescriptor = buildDescriptor(project);
 
         ZipBuilder zipBuilder = new ZipBuilder(project.getName())
-                .appendFile(descriptorJsonConverter.convertToJsonBytes(projectDescriptor), toJsonFilename(project.getName()));
+                .appendFile(descriptorJsonConverter.convertToJsonBytes(projectDescriptor), changeToJsonFilename(project.getName()));
 
         modelService.getAllModels(project).forEach(model -> modelTypeService.findModelTypeByName(model.getType()).map(ModelType::getFolderName).ifPresent(folderName -> {
             zipBuilder.appendFolder(folderName)

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ContentTypeUtils.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ContentTypeUtils.java
@@ -19,7 +19,6 @@ import static java.util.Collections.singletonMap;
 import static org.springframework.boot.web.server.MimeMappings.DEFAULT;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -118,7 +117,6 @@ public final class ContentTypeUtils {
 
         return Optional.ofNullable(extension)
             .map(ContentTypeUtils::fullExtension)
-            .filter(Objects::nonNull)
             .filter(ext -> !filename.endsWith(ext))
             .map(fullExtension -> removeExtension(filename) + fullExtension)
             .orElse(filename);

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ContentTypeUtils.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ContentTypeUtils.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singletonMap;
 import static org.springframework.boot.web.server.MimeMappings.DEFAULT;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -89,10 +90,35 @@ public final class ContentTypeUtils {
             JSON);
     }
 
+    public static String changeToJsonFilename(String filename) {
+        return changeExtension(filename,
+            JSON);
+    }
+
     public static String setExtension(String filename,
         String extension) {
+
+        if (filename == null) {
+            return null;
+        }
+
         return Optional.ofNullable(extension)
             .map(ContentTypeUtils::fullExtension)
+            .filter(ext -> !filename.endsWith(ext))
+            .map(fullExtension -> filename + fullExtension)
+            .orElse(filename);
+    }
+
+    public static String changeExtension(String filename,
+        String extension) {
+
+        if (filename == null) {
+            return null;
+        }
+
+        return Optional.ofNullable(extension)
+            .map(ContentTypeUtils::fullExtension)
+            .filter(Objects::nonNull)
             .filter(ext -> !filename.endsWith(ext))
             .map(fullExtension -> removeExtension(filename) + fullExtension)
             .orElse(filename);
@@ -100,6 +126,11 @@ public final class ContentTypeUtils {
 
     public static String removeExtension(String filename,
         String extension) {
+
+        if (filename == null) {
+            return null;
+        }
+
         return Optional.ofNullable(extension)
             .map(ContentTypeUtils::fullExtension)
             .filter(filename::endsWith)

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/util/ContentTypeUtilsTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/util/ContentTypeUtilsTest.java
@@ -15,8 +15,10 @@
  */
 package org.activiti.cloud.services.common.util;
 
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.changeToJsonFilename;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.getExtension;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.removeExtension;
+import static org.activiti.cloud.services.common.util.ContentTypeUtils.toJsonFilename;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test ;
@@ -55,6 +57,23 @@ public class ContentTypeUtilsTest {
         assertThat(removeExtension("a\\b\\c")).isEqualTo("a\\b\\c");
         assertThat(removeExtension("C:\\temp\\foo.bar\\README")).isEqualTo("C:\\temp\\foo.bar\\README");
         assertThat(removeExtension("../filename.ext")).isEqualTo("../filename");
+    }
+
+
+    @Test
+    public void testToJsonFilename() {
+        assertThat(toJsonFilename(null)).isEqualTo(null);
+        assertThat(toJsonFilename("file")).isEqualTo("file.json");
+        assertThat(toJsonFilename("file.json")).isEqualTo("file.json");
+        assertThat(toJsonFilename("file.v1")).isEqualTo("file.v1.json");
+    }
+
+    @Test
+    public void testChangeToJsonFilename() {
+        assertThat(changeToJsonFilename(null)).isEqualTo(null);
+        assertThat(changeToJsonFilename("file")).isEqualTo("file.json");
+        assertThat(changeToJsonFilename("file.json")).isEqualTo("file.json");
+        assertThat(changeToJsonFilename("file.v1")).isEqualTo("file.json");
     }
 
 }


### PR DESCRIPTION
This PR contains a refactoring of `ContentTypeUtils` consisting of separating the responsibilities of changing a filename extension and adding an extension to a name from `setExtension` respectively to methods: `changeExtensions` and `setExtensions`. As a consequence, also `toJsonExtension` has been reworked.

The version of `ModelServiceImpl` in the PR uses the methods for adding an extensions, allowing the export of processes whose name contains one or more '.'.