### PR TITLE
test(MQServiceTaskIT): add should replay running service task integration test

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MQServiceTaskErrorRecoverProcess.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MQServiceTaskErrorRecoverProcess.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
 
     <bpmn2:process id="MQServiceTaskErrorRecoverProcess" name="MQServiceTaskProcess">
 
@@ -10,7 +10,7 @@
 
         <bpmn2:sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="userTask"/>
 
-        <bpmn2:userTask id="userTask" name="Schedule meeting after service"/>
+        <bpmn2:userTask id="userTask" name="Schedule meeting after service" activiti:assignee="hruser"/>
         <bpmn2:sequenceFlow id="flow3" sourceRef="userTask" targetRef="end"/>
 
         <bpmn2:endEvent id="end"/>


### PR DESCRIPTION
This PR adds integration test to ensure users can trigger replay for service tasks in started state in case when the integration result message has not been received by process runtime to complete the execution. 