### PR TITLE
AAE-11384: re-enable deployAtEnd (reverts 51676fbfa0022edba2c445241a7…

### DIFF
--- a/activiti-cloud-build/pom.xml
+++ b/activiti-cloud-build/pom.xml
@@ -480,7 +480,7 @@ limitations under the License.]]>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
-          <deployAtEnd>false</deployAtEnd>
+          <deployAtEnd>true</deployAtEnd>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
…5aefc942df5a0)

Fixes https://github.com/Activiti/Activiti/issues/4148

I did not find an explanation of why this was disabled on https://github.com/Activiti/activiti-cloud/pull/569 -> changing back to true so that deployment occurs when all the builds have gone through correctly