### PR TITLE
[AAE-11327] delete entities related to process instance

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.types.Predicate;
 import java.util.Optional;
+import javax.transaction.Transactional;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
@@ -85,6 +86,7 @@ public class ProcessInstanceDeleteController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.DELETE)
+    @Transactional
     public CollectionModel<EntityModel<CloudProcessInstance>> deleteProcessInstances (@QuerydslPredicate(root = ProcessInstanceEntity.class) Predicate predicate) {
 
         Collection<EntityModel<CloudProcessInstance>> result = new ArrayList<>();

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
@@ -17,8 +17,14 @@ package org.activiti.cloud.services.query.rest;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.types.Predicate;
+import java.util.Optional;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
+import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.rest.assembler.ProcessInstanceRepresentationModelAssembler;
@@ -48,12 +54,32 @@ public class ProcessInstanceDeleteController {
 
     private final ProcessInstanceRepository processInstanceRepository;
 
+    private final TaskRepository taskRepository;
+
+    private final VariableRepository variableRepository;
+
+    private final ServiceTaskRepository serviceTaskRepository;
+
+    private final BPMNActivityRepository bpmnActivityRepository;
+
+    private final BPMNSequenceFlowRepository bpmnSequenceFlowRepository;
+
     private ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler;
 
     @Autowired
     public ProcessInstanceDeleteController(ProcessInstanceRepository processInstanceRepository,
-                                           ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler) {
+                                            TaskRepository taskRepository,
+                                            VariableRepository variableRepository,
+                                            ServiceTaskRepository serviceTaskRepository,
+                                            BPMNActivityRepository bpmnActivityRepository,
+                                            BPMNSequenceFlowRepository bpmnSequenceFlowRepository,
+                                            ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler) {
         this.processInstanceRepository = processInstanceRepository;
+        this.taskRepository = taskRepository;
+        this.variableRepository = variableRepository;
+        this.serviceTaskRepository = serviceTaskRepository;
+        this.bpmnActivityRepository = bpmnActivityRepository;
+        this.bpmnSequenceFlowRepository = bpmnSequenceFlowRepository;
         this.processInstanceRepresentationModelAssembler = processInstanceRepresentationModelAssembler;
     }
 
@@ -65,6 +91,12 @@ public class ProcessInstanceDeleteController {
         Iterable <ProcessInstanceEntity> iterable = processInstanceRepository.findAll(predicate);
 
         for(ProcessInstanceEntity entity : iterable){
+            Optional.ofNullable(entity.getTasks()).ifPresent(taskRepository::deleteAll);
+            Optional.ofNullable(entity.getVariables()).ifPresent(variableRepository::deleteAll);
+            Optional.ofNullable(entity.getServiceTasks()).ifPresent(serviceTaskRepository::deleteAll);
+            Optional.ofNullable(entity.getActivities()).ifPresent(bpmnActivityRepository::deleteAll);
+            Optional.ofNullable(entity.getSequenceFlows()).ifPresent(bpmnSequenceFlowRepository::deleteAll);
+
             result.add(processInstanceRepresentationModelAssembler.toModel(entity));
         }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
@@ -15,17 +15,42 @@
  */
 package org.activiti.cloud.services.query.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.querydsl.core.types.Predicate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.persistence.EntityManagerFactory;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.conf.QueryRestWebMvcAutoConfiguration;
+import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
+import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.VariableRepository;
+import org.activiti.cloud.services.query.model.BPMNActivityEntity;
+import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.ProcessVariableEntity;
+import org.activiti.cloud.services.query.model.ServiceTaskEntity;
+import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
@@ -41,21 +66,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-
-import javax.persistence.EntityManagerFactory;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "activiti.rest.enable-deletion=true")
 @TestPropertySource("classpath:application-test.properties")
@@ -98,6 +108,18 @@ public class ProcessInstanceEntityDeleteControllerIT {
     private TaskRepository taskRepository;
 
     @MockBean
+    private VariableRepository variableRepository;
+
+    @MockBean
+    private  ServiceTaskRepository serviceTaskRepository;
+
+    @MockBean
+    private BPMNSequenceFlowRepository bpmnSequenceFlowRepository;
+
+    @MockBean
+    private BPMNActivityRepository bpmnActivityRepository;
+
+    @MockBean
     private EntityManagerFactory entityManagerFactory;
 
     @BeforeEach
@@ -131,11 +153,74 @@ public class ProcessInstanceEntityDeleteControllerIT {
 
     }
 
+    @Test
+    public void deleteProcessInstancesShouldDeleteProcessInstancesAndRelatedEntities() throws Exception{
+        //given
+        ProcessInstanceEntity processInstanceEntity = buildDefaultProcessInstance();
+        List<ProcessInstanceEntity> processInstanceEntities = Collections.singletonList(processInstanceEntity);
+        given(processInstanceRepository.findAll(any(Predicate.class)))
+            .willReturn(processInstanceEntities);
+
+        //when
+        mockMvc.perform(delete("/admin/v1/process-instances")
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON))
+            //then
+            .andExpect(status().isOk());
+
+        verify(taskRepository).deleteAll(processInstanceEntity.getTasks());
+        verify(variableRepository).deleteAll(processInstanceEntity.getVariables());
+        verify(bpmnActivityRepository).deleteAll(processInstanceEntity.getActivities());
+        verify(serviceTaskRepository).deleteAll(processInstanceEntity.getServiceTasks());
+        verify(bpmnSequenceFlowRepository).deleteAll(processInstanceEntity.getSequenceFlows());
+
+        verify(processInstanceRepository).deleteAll(processInstanceEntities);
+    }
+
     private ProcessInstanceEntity buildDefaultProcessInstance() {
-        return new ProcessInstanceEntity("My-app", "My-app", "1", null, null,
+        ProcessInstanceEntity processInstance = new ProcessInstanceEntity("My-app", "My-app", "1", null, null,
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
                 ProcessInstance.ProcessInstanceStatus.RUNNING,
                 new Date());
+        processInstance.setTasks(Set.of(buildDefaultTask()));
+        processInstance.setVariables(Set.of(buildDefaultProcessVariableEntity()));
+        processInstance.setActivities(Set.of(buildDefaultBPMNActivityEntity()));
+        processInstance.setServiceTasks(Arrays.asList(buildDefaulterviceTaskEntity()));
+        processInstance.setSequenceFlows(Arrays.asList(buildDefaultBPMNSequenceFlowEntity()));
+        return processInstance;
+    }
+
+    private TaskEntity buildDefaultTask() {
+        TaskEntity taskEntity = new TaskEntity();
+        taskEntity.setId("My-task");
+        taskEntity.setName("My-task");
+        return taskEntity;
+    }
+
+    private ProcessVariableEntity buildDefaultProcessVariableEntity() {
+        ProcessVariableEntity processVariableEntity = new ProcessVariableEntity();
+        processVariableEntity.setName("My-process-variable");
+        return processVariableEntity;
+    }
+
+    private BPMNActivityEntity buildDefaultBPMNActivityEntity() {
+        BPMNActivityEntity bpmnActivityEntity = new BPMNActivityEntity("My-bpmn-activiti", "My-bpmn-activiti", "1",
+            "My-app", "2");
+        return bpmnActivityEntity;
+    }
+
+    private ServiceTaskEntity buildDefaulterviceTaskEntity() {
+
+        ServiceTaskEntity serviceTaskEntity = new ServiceTaskEntity("My-service-task", "My-service-task", "1",
+            "My-app", "2");
+        serviceTaskEntity.setActivityType("serviceTask");
+        return serviceTaskEntity;
+    }
+
+    private BPMNSequenceFlowEntity buildDefaultBPMNSequenceFlowEntity() {
+        BPMNSequenceFlowEntity bpmnSequenceFlowEntity = new BPMNSequenceFlowEntity("My-sequence-flow", "My-sequence-flow",
+            "1", "My-app", "2");
+        return bpmnSequenceFlowEntity;
     }
 }


### PR DESCRIPTION
This PR extends the functionality of the old endpoint for deleting process instances from query service.
As done in #888 for PROCESS_DELETED event, the new version of the endpoint removes also: tasks, variables, activities, service tasks and sequence flows.