### PR TITLE
AAE-11424 load ClientCredentialsAuthConfiguration only if required

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
@@ -18,7 +18,9 @@ package org.activiti.cloud.security.feign.configuration;
 import org.activiti.cloud.security.feign.ClientCredentialsAuthRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
@@ -28,6 +30,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 @Configuration
+@Conditional(ClientsConfiguredCondition.class)
 public class ClientCredentialsAuthConfiguration {
 
     @Bean


### PR DESCRIPTION
Load ClientCredentialsAuthConfiguration only if exists a cliient configuration. 
This will avoid missing bean exception when this configuration is not required (e.g in DeploymentServiceCli) .

Github issue: https://github.com/Activiti/Activiti/issues/4163