### PR TITLE
AAE-11572 use another conditional check, the previous does not work in RB

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/security/feign/configuration/ClientCredentialsAuthConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.security.feign.configuration;
 
 import org.activiti.cloud.security.feign.ClientCredentialsAuthRequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +31,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 @Configuration
-@Conditional(ClientsConfiguredCondition.class)
+@ConditionalOnBean(OAuth2AuthorizedClientService.class)
 public class ClientCredentialsAuthConfiguration {
 
     @Bean


### PR DESCRIPTION
I don't have to load this interceptor if I don't have any Oauth2 cliente configured. The previous check I was checking configuration properties and it doesn't work in RB.
Github issue: https://github.com/Activiti/Activiti/issues/4163