### PR TITLE
AAE-11396 fix random test failure SignalAuditProducerIT

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -41,7 +41,6 @@ import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.SignalRestTemplate;
 import org.activiti.engine.RuntimeService;
-import org.activiti.engine.runtime.ProcessInstance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,14 +85,11 @@ public class SignalAuditProducerIT {
 
     @AfterEach
     public void cleanUp() {
-        List<String> processInstanceIds = runtimeService.createProcessInstanceQuery()
-            .list()
-            .stream()
-            .map(ProcessInstance::getProcessInstanceId)
-            .collect(Collectors.toList());
+        String processInstanceId = runtimeService.createProcessInstanceQuery()
+            .singleResult()
+            .getProcessInstanceId();
 
-        processInstanceIds.forEach(processInstanceId -> runtimeService
-            .deleteProcessInstance(processInstanceId, "clean up"));
+       runtimeService.deleteProcessInstance(processInstanceId, "clean up");
     }
 
     @Test


### PR DESCRIPTION
Change the test to make more clear what is failing in case of random failure.

- Move the clean up of processes instances outside the `await` 
- Make sure that only 1 processInstances exist when executing `testProcessExecutionWithThrowSignal`