### PR TITLE
Validator for Script Tasks with no catch error boundary

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelValidationError;
@@ -741,7 +742,26 @@ public class ModelValidationControllerIT {
     }
 
     @Test
-    public void should_returnStatusNoContent_when_validatingProcessWithServiceTaskImplementationSetToScriptAction() throws Exception {
+    public void should_throwSemanticModelValidationException_when_validatingProcessWithServiceTaskImplementationSetToScriptActionWithCatchBoundary()
+        throws Exception {
+        byte[] validContent = resourceAsByteArray("process/script-implementation-service-task-with-catch-boundary.bpmn20.xml");
+        MockMultipartFile file = new MockMultipartFile("file",
+            "process.xml",
+            CONTENT_TYPE_XML,
+            validContent);
+        Model processModel = createModel(validContent);
+
+        ResultActions resultActions = mockMvc
+            .perform(multipart("/v1/models/{model_id}/validate",
+                processModel.getId())
+                .file(file));
+
+        resultActions.andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void should_throwSemanticModelValidationException_when_validatingProcessWithServiceTaskImplementationSetToScriptActionWithNoCatchBoundary()
+            throws Exception {
         byte[] validContent = resourceAsByteArray("process/script-implementation-service-task.bpmn20.xml");
         MockMultipartFile file = new MockMultipartFile("file",
                                                        "process.xml",
@@ -753,8 +773,19 @@ public class ModelValidationControllerIT {
                 .perform(multipart("/v1/models/{model_id}/validate",
                                    processModel.getId())
                                  .file(file));
+        assertThat(resultActions.andReturn().getResponse().getErrorMessage())
+            .contains("The service implementation on service 'ServiceTask_1qr4ad0' might fail silently");
 
-        resultActions.andExpect(status().isNoContent());
+        final Exception resolvedException = resultActions.andReturn().getResolvedException();
+        assertThat(resolvedException).isInstanceOf(SemanticModelValidationException.class);
+
+        SemanticModelValidationException semanticModelValidationException = (SemanticModelValidationException)resolvedException;
+        assertThat(semanticModelValidationException.getValidationErrors())
+            .hasSize(1)
+            .extracting(ModelValidationError::getProblem,
+                ModelValidationError::getDescription, ModelValidationError::isWarning)
+            .containsOnly(tuple("Missing Catch Error boundary event",
+                    "The service implementation on service 'ServiceTask_1qr4ad0' might fail silently", true));
     }
 
     @Test

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
@@ -742,7 +742,7 @@ public class ModelValidationControllerIT {
     }
 
     @Test
-    public void should_throwSemanticModelValidationException_when_validatingProcessWithServiceTaskImplementationSetToScriptActionWithCatchBoundary()
+    public void should_returnStatusNoContent_when_validatingProcessWithServiceTaskImplementationSetToScriptActionWithCatchBoundary()
         throws Exception {
         byte[] validContent = resourceAsByteArray("process/script-implementation-service-task-with-catch-boundary.bpmn20.xml");
         MockMultipartFile file = new MockMultipartFile("file",

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/script-implementation-service-task-with-catch-boundary.bpmn20.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/resources/process/script-implementation-service-task-with-catch-boundary.bpmn20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89" name="invalid-service" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1tdfy8m</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="ServiceTask_1qr4ad0" implementation="script.EXECUTE">
+      <bpmn2:incoming>SequenceFlow_1tdfy8m</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0co3bqk</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1tdfy8m" sourceRef="StartEvent_1" targetRef="ServiceTask_1qr4ad0" />
+    <bpmn2:endEvent id="EndEvent_0jn62e8">
+      <bpmn2:incoming>SequenceFlow_0co3bqk</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0co3bqk" sourceRef="ServiceTask_1qr4ad0" targetRef="EndEvent_0jn62e8" />
+    <bpmn2:boundaryEvent id="IntermediateThrowEvent_1myg8v9" attachedToRef="ServiceTask_1qr4ad0">
+      <bpmn2:errorEventDefinition id="ErrorEventDefinition_0ohujee" />
+    </bpmn2:boundaryEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process-2f28d4d7-d2ff-4685-a750-2cbc87377f89">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1qr4ad0_di" bpmnElement="ServiceTask_1qr4ad0">
+        <dc:Bounds x="511" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tdfy8m_di" bpmnElement="SequenceFlow_1tdfy8m">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="511" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0jn62e8_di" bpmnElement="EndEvent_0jn62e8">
+        <dc:Bounds x="674" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0co3bqk_di" bpmnElement="SequenceFlow_0co3bqk">
+        <di:waypoint x="611" y="258" />
+        <di:waypoint x="674" y="258" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -17,35 +17,36 @@ package org.activiti.cloud.services.modeling.validation;
 
 import java.util.List;
 import java.util.Set;
-
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.ProcessModelType;
 import org.activiti.cloud.modeling.api.process.Extensions;
 import org.activiti.cloud.modeling.converter.JsonConverter;
 import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConverter;
 import org.activiti.cloud.services.modeling.converter.ProcessModelContentConverter;
+import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionMessageMappingValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionsModelValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionsProcessVariablesValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionsTaskMappingsValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionsValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.TaskMappingsServiceTaskImplementationValidator;
 import org.activiti.cloud.services.modeling.validation.extensions.TaskMappingsValidator;
-import org.activiti.cloud.services.modeling.validation.extensions.ProcessExtensionMessageMappingValidator;
+import org.activiti.cloud.services.modeling.validation.process.BpmnCommonModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelCallActivityValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelEngineValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelNameValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelSequenceFlowValidator;
+import org.activiti.cloud.services.modeling.validation.process.BpmnModelServiceTaskCatchBoundaryValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelServiceTaskImplementationValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelUniqueIdValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelUserTaskAssigneeValidator;
-import org.activiti.cloud.services.modeling.validation.process.BpmnCommonModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.BpmnModelValidator;
 import org.activiti.cloud.services.modeling.validation.process.EndEventIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.FlowElementsExtractor;
 import org.activiti.cloud.services.modeling.validation.process.FlowNodeFlowsValidator;
 import org.activiti.cloud.services.modeling.validation.process.IntermediateFlowNodeIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.process.ProcessModelValidator;
+import org.activiti.cloud.services.modeling.validation.process.ServiceTaskImplementationType;
 import org.activiti.cloud.services.modeling.validation.process.StartEventIncomingOutgoingFlowValidator;
 import org.activiti.cloud.services.modeling.validation.project.ProjectConsistencyValidator;
 import org.activiti.cloud.services.modeling.validation.project.ProjectNameValidator;
@@ -164,6 +165,18 @@ public class ProcessModelValidatorConfiguration {
         ConnectorModelContentConverter connectorModelContentConverter, FlowElementsExtractor flowElementsExtractor) {
         return new BpmnModelServiceTaskImplementationValidator(connectorModelType,
                                                                connectorModelContentConverter, flowElementsExtractor);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BpmnModelServiceTaskCatchBoundaryValidator bpmnModelServiceTaskBoundaryValidator(ConnectorModelType connectorModelType,
+        ConnectorModelContentConverter connectorModelContentConverter, FlowElementsExtractor flowElementsExtractor) {
+
+        ServiceTaskImplementationType[] serviceTaskImplementationTypes = new ServiceTaskImplementationType[] {
+            ServiceTaskImplementationType.SCRIPT_TASK
+        };
+        return new BpmnModelServiceTaskCatchBoundaryValidator(connectorModelType, connectorModelContentConverter, flowElementsExtractor,
+            serviceTaskImplementationTypes);
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -169,14 +169,11 @@ public class ProcessModelValidatorConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BpmnModelServiceTaskCatchBoundaryValidator bpmnModelServiceTaskBoundaryValidator(ConnectorModelType connectorModelType,
-        ConnectorModelContentConverter connectorModelContentConverter, FlowElementsExtractor flowElementsExtractor) {
-
+    public BpmnModelServiceTaskCatchBoundaryValidator bpmnModelServiceTaskBoundaryValidator(FlowElementsExtractor flowElementsExtractor) {
         ServiceTaskImplementationType[] serviceTaskImplementationTypes = new ServiceTaskImplementationType[] {
             ServiceTaskImplementationType.SCRIPT_TASK
         };
-        return new BpmnModelServiceTaskCatchBoundaryValidator(connectorModelType, connectorModelContentConverter, flowElementsExtractor,
-            serviceTaskImplementationTypes);
+        return new BpmnModelServiceTaskCatchBoundaryValidator(flowElementsExtractor, serviceTaskImplementationTypes);
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.modeling.validation.process;
+
+import static java.lang.String.format;
+import static org.springframework.util.StringUtils.isEmpty;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.ErrorEventDefinition;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.cloud.modeling.api.ConnectorModelType;
+import org.activiti.cloud.modeling.api.Model;
+import org.activiti.cloud.modeling.api.ModelValidationError;
+import org.activiti.cloud.modeling.api.ValidationContext;
+import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConverter;
+import org.activiti.cloud.services.modeling.converter.ConnectorModelFeature;
+
+/**
+ * Implementation of {@link BpmnCommonModelValidator} for validating service task boundaries
+ */
+public class BpmnModelServiceTaskCatchBoundaryValidator implements BpmnCommonModelValidator {
+
+    public static final String MISSING_BOUNDARY_WARNING = "Missing Catch Error boundary event";
+    public static final String INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION = "The service implementation on service '%s' might fail silently";
+    public static final String SERVICE_TASK_VALIDATOR_NAME = "BPMN service task catch boundary validator";
+
+    private final ConnectorModelType connectorModelType;
+
+    private final ConnectorModelContentConverter connectorModelContentConverter;
+    private final FlowElementsExtractor flowElementsExtractor;
+
+    private final ServiceTaskImplementationType[] serviceTaskImplementationTypes;
+
+    public BpmnModelServiceTaskCatchBoundaryValidator(ConnectorModelType connectorModelType,
+        ConnectorModelContentConverter connectorModelContentConverter,
+        FlowElementsExtractor flowElementsExtractor,
+        ServiceTaskImplementationType[] serviceTaskImplementationTypes) {
+        this.connectorModelType = connectorModelType;
+        this.connectorModelContentConverter = connectorModelContentConverter;
+        this.flowElementsExtractor = flowElementsExtractor;
+        this.serviceTaskImplementationTypes = Optional.ofNullable(serviceTaskImplementationTypes)
+            .orElse(new ServiceTaskImplementationType[0]);
+    }
+
+    @Override
+    public Stream<ModelValidationError> validate(BpmnModel bpmnModel,
+        ValidationContext validationContext) {
+
+        return flowElementsExtractor.extractFlowElements(bpmnModel, ServiceTask.class).stream()
+            .filter(serviceTask -> serviceTask.getImplementation() != null)
+            .map(serviceTask -> validateServiceTaskBoundary(serviceTask))
+            .filter(Optional::isPresent)
+            .map(Optional::get);
+    }
+
+    private String concatNameAndAction(ConnectorModelFeature connectorModelFeature,
+        Model model) {
+        return isEmpty(connectorModelFeature) && isEmpty(connectorModelFeature.getName()) ?
+            model.getName() :
+            model.getName() + "." + connectorModelFeature.getName();
+    }
+
+    private Optional<ModelValidationError> validateServiceTaskBoundary(ServiceTask serviceTask) {
+        if (requiresBoundary(serviceTask)) {
+            return Optional.of(
+                new ModelValidationError(MISSING_BOUNDARY_WARNING,
+                    format(INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION,
+                        serviceTask.getId()), SERVICE_TASK_VALIDATOR_NAME, true));
+        }
+
+        return Optional.<ModelValidationError>empty();
+    }
+
+    private boolean requiresBoundary(ServiceTask serviceTask) {
+        return Arrays.stream(serviceTaskImplementationTypes)
+            .anyMatch(serviceImplementation ->
+                serviceTask.getImplementation().startsWith(serviceImplementation.getPrefix()) &&
+                    (
+                        serviceTask.getBoundaryEvents() == null ||
+                            !hasBoundaryErrorEvent(serviceTask.getBoundaryEvents())
+                    )
+            );
+    }
+
+    private boolean hasBoundaryErrorEvent(List<BoundaryEvent> boundaryEvents) {
+        return boundaryEvents.stream().anyMatch(boundaryEvent ->
+            boundaryEvent.getEventDefinitions().stream().anyMatch(eventDefinition ->
+                ErrorEventDefinition.class.isInstance(eventDefinition)
+            )
+        );
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidator.java
@@ -16,7 +16,6 @@
 package org.activiti.cloud.services.modeling.validation.process;
 
 import static java.lang.String.format;
-import static org.springframework.util.StringUtils.isEmpty;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,12 +25,8 @@ import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.ErrorEventDefinition;
 import org.activiti.bpmn.model.ServiceTask;
-import org.activiti.cloud.modeling.api.ConnectorModelType;
-import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
-import org.activiti.cloud.services.modeling.converter.ConnectorModelContentConverter;
-import org.activiti.cloud.services.modeling.converter.ConnectorModelFeature;
 
 /**
  * Implementation of {@link BpmnCommonModelValidator} for validating service task boundaries
@@ -42,19 +37,12 @@ public class BpmnModelServiceTaskCatchBoundaryValidator implements BpmnCommonMod
     public static final String INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION = "The service implementation on service '%s' might fail silently";
     public static final String SERVICE_TASK_VALIDATOR_NAME = "BPMN service task catch boundary validator";
 
-    private final ConnectorModelType connectorModelType;
-
-    private final ConnectorModelContentConverter connectorModelContentConverter;
     private final FlowElementsExtractor flowElementsExtractor;
 
     private final ServiceTaskImplementationType[] serviceTaskImplementationTypes;
 
-    public BpmnModelServiceTaskCatchBoundaryValidator(ConnectorModelType connectorModelType,
-        ConnectorModelContentConverter connectorModelContentConverter,
-        FlowElementsExtractor flowElementsExtractor,
+    public BpmnModelServiceTaskCatchBoundaryValidator(FlowElementsExtractor flowElementsExtractor,
         ServiceTaskImplementationType[] serviceTaskImplementationTypes) {
-        this.connectorModelType = connectorModelType;
-        this.connectorModelContentConverter = connectorModelContentConverter;
         this.flowElementsExtractor = flowElementsExtractor;
         this.serviceTaskImplementationTypes = Optional.ofNullable(serviceTaskImplementationTypes)
             .orElse(new ServiceTaskImplementationType[0]);
@@ -69,13 +57,6 @@ public class BpmnModelServiceTaskCatchBoundaryValidator implements BpmnCommonMod
             .map(serviceTask -> validateServiceTaskBoundary(serviceTask))
             .filter(Optional::isPresent)
             .map(Optional::get);
-    }
-
-    private String concatNameAndAction(ConnectorModelFeature connectorModelFeature,
-        Model model) {
-        return isEmpty(connectorModelFeature) && isEmpty(connectorModelFeature.getName()) ?
-            model.getName() :
-            model.getName() + "." + connectorModelFeature.getName();
     }
 
     private Optional<ModelValidationError> validateServiceTaskBoundary(ServiceTask serviceTask) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
@@ -94,7 +94,7 @@ public class BpmnModelServiceTaskCatchBoundaryValidatorTest {
         final Stream<ModelValidationError> validationResult = validator.validate(model, validationContext);
 
         //then
-        assertThat(validator.validate(model, validationContext))
+        assertThat(validationResult)
             .extracting(ModelValidationError::getProblem,
                 ModelValidationError::getDescription,
                 ModelValidationError::getValidatorSetName,

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
@@ -60,7 +60,7 @@ public class BpmnModelServiceTaskCatchBoundaryValidatorTest {
     }
 
     @Test
-    public void should_returnError_when_taskIsScriptWithNoErrorBoundaryEvent() {
+    public void should_returnWarning_when_taskIsScriptWithNoErrorBoundaryEvent() {
         //given
         ServiceTask serviceTask = buildServiceTask("script.EXECUTE", Arrays.asList(buildSignalBoundaryEvent()));
         BpmnModel model = new BpmnModel();
@@ -82,7 +82,7 @@ public class BpmnModelServiceTaskCatchBoundaryValidatorTest {
 
 
     @Test
-    public void should_returnError_when_scriptHasNoBoundaryEvent() {
+    public void should_returnWarning_when_scriptHasNoBoundaryEvent() {
         //given
         ServiceTask serviceTask = buildServiceTask("script.EXECUTE", Collections.emptyList());
         BpmnModel model = new BpmnModel();

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelServiceTaskCatchBoundaryValidatorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.modeling.validation.process;
+
+import static java.lang.String.format;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.ErrorEventDefinition;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.cloud.modeling.api.ModelValidationError;
+import org.activiti.cloud.modeling.api.ValidationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BpmnModelServiceTaskCatchBoundaryValidatorTest {
+
+    private BpmnModelServiceTaskCatchBoundaryValidator validator;
+
+    @Mock
+    private ValidationContext validationContext;
+
+    @Mock
+    private FlowElementsExtractor flowElementsExtractor;
+
+    @BeforeEach
+    public void setUp(){
+        ServiceTaskImplementationType[] serviceTaskImplementationTypes = new ServiceTaskImplementationType[]{ServiceTaskImplementationType.SCRIPT_TASK};
+        validator = new BpmnModelServiceTaskCatchBoundaryValidator(flowElementsExtractor, serviceTaskImplementationTypes);
+    }
+
+    @Test
+    public void should_returnError_when_taskIsScriptWithNoErrorBoundaryEvent() {
+        //given
+        ServiceTask serviceTask = buildServiceTask("script.EXECUTE", Arrays.asList(buildSignalBoundaryEvent()));
+        BpmnModel model = new BpmnModel();
+
+        //when
+        given(flowElementsExtractor.extractFlowElements(model, ServiceTask.class))
+            .willReturn(singleton(serviceTask));
+
+        //then
+        assertThat(validator.validate(model, validationContext))
+            .extracting(ModelValidationError::getProblem,
+                ModelValidationError::getDescription,
+                ModelValidationError::getValidatorSetName,
+                ModelValidationError::isWarning)
+            .contains(tuple(BpmnModelServiceTaskCatchBoundaryValidator.MISSING_BOUNDARY_WARNING,
+                format(BpmnModelServiceTaskCatchBoundaryValidator.INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION, serviceTask.getId()),
+                BpmnModelServiceTaskCatchBoundaryValidator.SERVICE_TASK_VALIDATOR_NAME, true));
+    }
+
+
+    @Test
+    public void should_returnError_when_scriptHasNoBoundaryEvent() {
+        //given
+        ServiceTask serviceTask = buildServiceTask("script.EXECUTE", Collections.emptyList());
+        BpmnModel model = new BpmnModel();
+
+        given(flowElementsExtractor.extractFlowElements(model, ServiceTask.class))
+            .willReturn(singleton(serviceTask));
+
+        //when
+        final Stream<ModelValidationError> validationResult = validator.validate(model, validationContext);
+
+        //then
+        assertThat(validator.validate(model, validationContext))
+            .extracting(ModelValidationError::getProblem,
+                ModelValidationError::getDescription,
+                ModelValidationError::getValidatorSetName,
+                ModelValidationError::isWarning)
+            .contains(tuple(BpmnModelServiceTaskCatchBoundaryValidator.MISSING_BOUNDARY_WARNING,
+                format(BpmnModelServiceTaskCatchBoundaryValidator.INVALID_SERVICE_IMPLEMENTATION_DESCRIPTION, serviceTask.getId()),
+                BpmnModelServiceTaskCatchBoundaryValidator.SERVICE_TASK_VALIDATOR_NAME, true));
+    }
+
+    @Test
+    public void should_returnEmpty_when_scriptHasErrorBoundary() {
+        //given
+        ServiceTask serviceTask = buildServiceTask("script.EXECUTE", Arrays.asList(buildErrorBoundaryEvent()));
+        BpmnModel model = new BpmnModel();
+
+        given(flowElementsExtractor.extractFlowElements(model, ServiceTask.class))
+            .willReturn(singleton(serviceTask));
+
+        //when
+        final Stream<ModelValidationError> validationResult = validator.validate(model, validationContext);
+
+        //then
+        assertThat(validationResult).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidServiceTaskImplementations")
+    public void should_returnEmpty_when_isNotScript(String implementation) {
+        //given
+        ServiceTask serviceTask = buildServiceTask(implementation, Collections.emptyList());
+        BpmnModel model = new BpmnModel();
+
+        given(flowElementsExtractor.extractFlowElements(model, ServiceTask.class))
+            .willReturn(singleton(serviceTask));
+
+        //when
+        final Stream<ModelValidationError> validationResult = validator.validate(model, validationContext);
+
+        //then
+        assertThat(validationResult).isEmpty();
+    }
+
+    private static Stream<Arguments> provideValidServiceTaskImplementations() {
+        return Stream.of(
+            Arguments.of("email-service.SEND"),
+            Arguments.of("docgen-service.GENERATE"),
+            Arguments.of("content-service.MOVE_FOLDER"),
+            Arguments.of("hxp-content-service.SET_PERMISSION")
+        );
+    }
+
+    private ServiceTask buildServiceTask(String implementation, List<BoundaryEvent> boundaryEvents) {
+        ServiceTask serviceTask = new ServiceTask();
+        serviceTask.setImplementation(implementation);
+        serviceTask.setName("The Service Task");
+        serviceTask.setId(UUID.randomUUID().toString());
+        serviceTask.setBoundaryEvents(boundaryEvents);
+        return serviceTask;
+    }
+
+    private BoundaryEvent buildSignalBoundaryEvent() {
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new SignalEventDefinition()));
+        return boundaryEvent;
+    }
+
+    private BoundaryEvent buildErrorBoundaryEvent() {
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new ErrorEventDefinition()));
+        return boundaryEvent;
+    }
+}


### PR DESCRIPTION
This PR introduces a new validator `BpmnModelServiceTaskCatchBoundaryValidator` that checks if a script task does not contain a catch error boundary. If such a script is present in the process, it returns a warning that informs the user that the script might fail silently.

It solves Activiti/Activiti#4184.