### PR TITLE
Remove endpoints for creating and starting a created process instance

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -15,7 +15,8 @@
  */
 package org.activiti.cloud.services.rest.api;
 
-import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
@@ -35,8 +36,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 public interface ProcessInstanceController {
 
     @GetMapping("/v1/process-instances")
@@ -45,13 +44,6 @@ public interface ProcessInstanceController {
 
     @PostMapping(path = "/v1/process-instances", consumes = APPLICATION_JSON_VALUE)
     EntityModel<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload cmd);
-
-    @PostMapping(value = "/v1/process-instances/{processInstanceId}/start", consumes = APPLICATION_JSON_VALUE)
-    EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable(value = "processInstanceId") String processInstanceId,
-        @RequestBody(required = false) StartProcessPayload payload);
-
-    @PostMapping(value = "/v1/process-instances/create", consumes = APPLICATION_JSON_VALUE)
-    EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload cmd);
 
     @GetMapping(value = "/v1/process-instances/{processInstanceId}")
     EntityModel<CloudProcessInstance> getProcessInstanceById(@PathVariable(value = "processInstanceId") String processInstanceId);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -30,9 +30,11 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
+import static java.util.Collections.emptyList;
+
+import java.nio.charset.StandardCharsets;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
-import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
@@ -61,10 +63,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.nio.charset.StandardCharsets;
-
-import static java.util.Collections.emptyList;
 
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -114,21 +112,6 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
         startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
 
         return representationModelAssembler.toModel(processRuntime.start(startProcessPayload));
-    }
-
-    @Override
-    public EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable String processInstanceId,
-                                                                 @RequestBody(required = false) StartProcessPayload startProcessPayload) {
-        if (startProcessPayload == null) {
-            startProcessPayload = ProcessPayloadBuilder.start().build();
-        }
-        startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
-        return representationModelAssembler.toModel(processRuntime.startCreatedProcess(processInstanceId, startProcessPayload));
-    }
-
-    @Override
-    public EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload createProcessInstancePayload) {
-        return representationModelAssembler.toModel(processRuntime.create(createProcessInstancePayload));
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -15,12 +15,33 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.ProcessInstanceMeta;
 import org.activiti.api.process.model.builders.MessagePayloadBuilder;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
-import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
@@ -60,30 +81,6 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -166,28 +163,6 @@ public class ProcessInstanceControllerImplIT {
                                      .contentType(APPLICATION_JSON)
                                      .content(mapper.writeValueAsString(cmd)))
                 .andExpect(status().isOk());
-    }
-
-    @Test
-    public void createProcess() throws Exception {
-        CreateProcessInstancePayload cmd = ProcessPayloadBuilder.create().withProcessDefinitionId("1").build();
-        when(processRuntime.create(any(CreateProcessInstancePayload.class))).thenReturn(defaultProcessInstance());
-
-        mockMvc.perform(post("/v1/process-instances/create")
-            .contentType(APPLICATION_JSON)
-            .content(mapper.writeValueAsString(cmd)))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    public void startCreatedProcess() throws Exception {
-        StartProcessPayload payload = ProcessPayloadBuilder.start().withProcessDefinitionId("1").build();
-        when(processRuntime.startCreatedProcess(eq("1"), any(StartProcessPayload.class))).thenReturn(defaultProcessInstance());
-
-        mockMvc.perform(post("/v1/process-instances/{processInstanceId}/start", 1)
-            .contentType(APPLICATION_JSON)
-            .content(mapper.writeValueAsString(payload)))
-            .andExpect(status().isOk());
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -15,6 +15,11 @@
  */
 package org.activiti.cloud.starter.tests.helper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
@@ -41,12 +46,6 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @TestComponent
 public class ProcessInstanceRestTemplate {
@@ -79,20 +78,6 @@ public class ProcessInstanceRestTemplate {
         return startProcess(startProcess);
     }
 
-    private ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionKey,
-                                                              String processDefinitionId,
-                                                              Map<String, Object> variables,
-                                                              String businessKey) {
-
-        CreateProcessInstancePayload startProcess = ProcessPayloadBuilder.create()
-            .withProcessDefinitionId(processDefinitionId)
-            .withProcessDefinitionKey(processDefinitionKey)
-            .withBusinessKey(businessKey)
-            .build();
-
-        return createProcess(startProcess);
-    }
-
     public ResponseEntity<CloudProcessInstance> startProcess(String processDefinitionId) {
 
         return startProcess(processDefinitionId,
@@ -118,22 +103,8 @@ public class ProcessInstanceRestTemplate {
                             businessKey);
     }
 
-    public ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionId,
-                                                             Map<String, Object> variables,
-                                                             String businessKey) {
-
-        return createProcess(null,
-            processDefinitionId,
-            variables,
-            businessKey);
-    }
-
     public ResponseEntity<CloudProcessInstance> startProcess(StartProcessPayload startProcess) {
         return startProcess(PROCESS_INSTANCES_RELATIVE_URL,startProcess);
-    }
-
-    public ResponseEntity<CloudProcessInstance> createProcess(CreateProcessInstancePayload startPayload) {
-        return createProcess(PROCESS_INSTANCES_RELATIVE_URL + "create", startPayload);
     }
 
     public ResponseEntity<CloudProcessInstance> adminStartProcess(StartProcessPayload startProcess) {
@@ -148,22 +119,6 @@ public class ProcessInstanceRestTemplate {
                                           });
     }
 
-    private ResponseEntity<CloudProcessInstance> startCreatedProcessCall(String baseURL) {
-        return testRestTemplate.exchange(baseURL,
-            HttpMethod.POST,
-            new HttpEntity<>(CONTENT_TYPE_HEADER),
-            new ParameterizedTypeReference<CloudProcessInstance>() {
-            });
-    }
-
-    private ResponseEntity<ActivitiErrorMessageImpl> startCreatedProcessCallFail(String baseURL) {
-        return testRestTemplate.exchange(baseURL,
-            HttpMethod.POST,
-            new HttpEntity<>(CONTENT_TYPE_HEADER),
-            new ParameterizedTypeReference<ActivitiErrorMessageImpl>() {
-            });
-    }
-
     private ResponseEntity<CloudProcessInstance> createProcessWithoutCheck(String baseURL, CreateProcessInstancePayload payload) {
         return  testRestTemplate.exchange(baseURL,
             HttpMethod.POST,
@@ -174,31 +129,6 @@ public class ProcessInstanceRestTemplate {
 
     private ResponseEntity<CloudProcessInstance> startProcess(String baseURL, StartProcessPayload startProcess) {
         ResponseEntity<CloudProcessInstance> responseEntity = startProcessWithoutCheck(baseURL, startProcess);
-
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(responseEntity.getBody()).isNotNull();
-        assertThat(responseEntity.getBody().getId()).isNotNull();
-        return responseEntity;
-    }
-
-    public ResponseEntity<CloudProcessInstance> startCreatedProcess(String processInstanceId) {
-        String baseURL = PROCESS_INSTANCES_RELATIVE_URL.concat(processInstanceId).concat("/start");
-        ResponseEntity<CloudProcessInstance> responseEntity = startCreatedProcessCall(baseURL);
-
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(responseEntity.getBody()).isNotNull();
-        assertThat(responseEntity.getBody().getId()).isNotNull();
-        return responseEntity;
-    }
-
-    public ResponseEntity<ActivitiErrorMessageImpl> startCreatedProcessFailing(String processInstanceId) {
-        String baseURL = PROCESS_INSTANCES_RELATIVE_URL.concat(processInstanceId).concat("/start");
-        ResponseEntity<ActivitiErrorMessageImpl> responseEntity = startCreatedProcessCallFail(baseURL);
-        return responseEntity;
-    }
-
-    private ResponseEntity<CloudProcessInstance> createProcess(String baseURL, CreateProcessInstancePayload startProcess) {
-        ResponseEntity<CloudProcessInstance> responseEntity = createProcessWithoutCheck(baseURL, startProcess);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(responseEntity.getBody()).isNotNull();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -15,6 +15,9 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -26,7 +29,6 @@ import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
-import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.converter.util.InputStreamProvider;
 import org.activiti.bpmn.model.BpmnModel;
@@ -52,9 +54,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
@@ -122,80 +121,6 @@ public class ProcessInstanceIT {
         assertThat(returnedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
         assertThat(returnedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
         assertThat(returnedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
-    }
-
-    @Test
-    public void shouldCreateProcessInstanceWithoutStartingIt() {
-        //when
-        ResponseEntity<CloudProcessInstance> entity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
-            null,
-            "business_key");
-
-        //then
-        assertThat(entity).isNotNull();
-        CloudProcessInstance returnedProcInst = entity.getBody();
-        assertThat(returnedProcInst).isNotNull();
-        assertThat(returnedProcInst.getId()).isNotNull();
-        assertThat(returnedProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.CREATED);
-        assertThat(returnedProcInst.getProcessDefinitionId()).contains("SimpleProcess:");
-        assertThat(returnedProcInst.getInitiator()).isNotNull();
-        assertThat(returnedProcInst.getInitiator()).isEqualTo(keycloakTestUser);//will only match if using username not id
-        assertThat(returnedProcInst.getBusinessKey()).isEqualTo("business_key");
-        assertThat(returnedProcInst.getAppName()).isEqualTo(runtimeBundleProperties.getAppName());
-        assertThat(returnedProcInst.getServiceName()).isEqualTo(runtimeBundleProperties.getServiceName());
-        assertThat(returnedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
-        assertThat(returnedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
-        assertThat(returnedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
-    }
-
-    @Test
-    public void shouldStartAnAlreadyCreatedProcess() {
-        //when
-        ResponseEntity<CloudProcessInstance> createdEntity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
-            null,
-            "business_key");
-        CloudProcessInstance createdProcInst = createdEntity.getBody();
-        assertThat(createdProcInst).isNotNull();
-        assertThat(createdProcInst.getId()).isNotNull();
-        assertThat(createdProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.CREATED);
-
-        ResponseEntity<CloudProcessInstance> startedEntity =
-            processInstanceRestTemplate.startCreatedProcess(createdEntity.getBody().getId());
-
-        //then
-        assertThat(startedEntity).isNotNull();
-        assertThat(startedEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        CloudProcessInstance startedProcInst = startedEntity.getBody();
-        assertThat(startedProcInst).isNotNull();
-        assertThat(startedProcInst.getId()).isNotNull();
-        assertThat(startedProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.RUNNING);
-        assertThat(startedProcInst.getProcessDefinitionId()).contains("SimpleProcess:");
-        assertThat(startedProcInst.getInitiator()).isNotNull();
-        assertThat(startedProcInst.getInitiator()).isEqualTo(keycloakTestUser);//will only match if using username not id
-        assertThat(startedProcInst.getBusinessKey()).isEqualTo("business_key");
-        assertThat(startedProcInst.getAppName()).isEqualTo(runtimeBundleProperties.getAppName());
-        assertThat(startedProcInst.getAppVersion()).isEqualTo("1");
-        assertThat(startedProcInst.getServiceName()).isEqualTo(runtimeBundleProperties.getServiceName());
-        assertThat(startedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
-        assertThat(startedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
-        assertThat(startedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
-    }
-
-    @Test
-    public void shouldThrowAnError_when_StartingAnAlreadyStartedProcess() {
-        //when
-        ResponseEntity<CloudProcessInstance> entity = processInstanceRestTemplate.startProcess(processDefinitionIds.get(SIMPLE_PROCESS),
-            null,
-            "business_key");
-
-        //then
-        assertThat(entity).isNotNull();
-
-        CloudProcessInstance startedProcessInstance = entity.getBody();
-        ResponseEntity<ActivitiErrorMessageImpl> failEntity =
-            processInstanceRestTemplate.startCreatedProcessFailing(startedProcessInstance.getId());
-        assertThat(failEntity.getBody().getMessage()).isEqualTo("Process instance " + startedProcessInstance.getId() + " has already been started");
-        assertThat(failEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test


### PR DESCRIPTION
This PR removes the endpoints for creating and starting a previously created Process Instance from RB. In fact, there is already the endpoint: `POST: /v1/process-instances` which creates and starts a Process Instance basing on the payload of the request.

This PR closes Activiti/Activiti#4186.