### PR TITLE
Upgrade xstream to v.1.4.20

### DIFF
--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -44,7 +44,7 @@
     <logstash.version>7.0.1</logstash.version>
     <springdoc.version>1.6.9</springdoc.version>
     <swagger.version>2.2.1</swagger.version>
-    <xstream.version>1.4.19</xstream.version>
+    <xstream.version>1.4.20</xstream.version>
     <json-unit.version>2.32.0</json-unit.version>
     <jsonwebtoken.version>0.9.1</jsonwebtoken.version>
   </properties>


### PR DESCRIPTION
This PR closes Activiti/Activiti#4201 upgrading `xstream` to version `1.4.20`.

The upgrade will mitigate the risks related to:
- CVE-2022-40151
- CVE-2022-41966