### PR TITLE
Increase audit event type column size

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/11-alter.oracle.schema.7.8.0.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/11-alter.oracle.schema.7.8.0.sql
@@ -1,0 +1,2 @@
+alter table audit_event
+  modify column type varchar(63) not null;

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/11-alter.pg.schema.7.8.0.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/11-alter.pg.schema.7.8.0.sql
@@ -1,0 +1,2 @@
+alter table audit_event
+  alter column type type varchar(63);

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
@@ -1,7 +1,7 @@
 create sequence audit_sequence start with 1 increment by 50;
 create table audit_event
 (
-    type                       varchar(31) not null,
+    type                       varchar(63) not null,
     id                         bigint      not null,
     app_name                   varchar(255),
     app_version                varchar(255),

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
@@ -95,6 +95,15 @@
              stripComments="true"/>
   </changeSet>
 
+  <changeSet author="activiti-audit" id="alter11-oracle-schema-7.8.0" dbms="oracle">
+    <sqlFile dbms="oracle"
+             encoding="utf8"
+             path="changelog/11-alter.oracle.schema.7.8.0.sql"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+
   <changeSet author="activiti-audit"
              id="initial-schema-m3" dbms="postgresql">
     <preConditions onFail="CONTINUE">
@@ -192,6 +201,15 @@
     <sqlFile dbms="postgresql"
              encoding="utf8"
              path="changelog/10-alter.pg.schema.7.5.0.sql"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="activiti-audit" id="alter11-schema-7.8.0" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+             encoding="utf8"
+             path="changelog/11-alter.pg.schema.7.8.0.sql"
              relativeToChangelogFile="true"
              splitStatements="true"
              stripComments="true"/>

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -44,6 +44,8 @@ import org.activiti.api.runtime.model.impl.BPMNTimerImpl;
 import org.activiti.api.runtime.model.impl.DeploymentImpl;
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.api.runtime.model.impl.MessageSubscriptionImpl;
+import org.activiti.api.runtime.model.impl.ProcessCandidateStarterGroupImpl;
+import org.activiti.api.runtime.model.impl.ProcessCandidateStarterUserImpl;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
@@ -78,6 +80,10 @@ import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationRequeste
 import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationResultReceivedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudMessageSubscriptionCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterGroupAddedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterGroupRemovedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterUserAddedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterUserRemovedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
@@ -901,6 +907,18 @@ public class AuditServiceIT {
         List<CloudRuntimeEvent> testEvents = new ArrayList<>();
 
         testEvents.add(new CloudProcessDeployedEventImpl(buildDefaultProcessDefinition()));
+
+        testEvents.add(new CloudProcessCandidateStarterUserAddedEventImpl("CloudProcessCandidateStarterUserAddedEventImpl",
+            System.currentTimeMillis(), new ProcessCandidateStarterUserImpl("pid", "uid")));
+
+        testEvents.add(new CloudProcessCandidateStarterUserRemovedEventImpl("CloudProcessCandidateStarterUserRemovedEventImpl",
+            System.currentTimeMillis(), new ProcessCandidateStarterUserImpl("pid", "uid")));
+
+        testEvents.add(new CloudProcessCandidateStarterGroupAddedEventImpl("CloudProcessCandidateStarterGroupAddedEventId",
+            System.currentTimeMillis(), new ProcessCandidateStarterGroupImpl("pid", "gid")));
+
+        testEvents.add(new CloudProcessCandidateStarterGroupRemovedEventImpl("CloudProcessCandidateStarterGroupRemovedEventImpl",
+            System.currentTimeMillis(), new ProcessCandidateStarterGroupImpl("pid", "gid")));
 
         BPMNActivityImpl bpmnActivityCancelled = new BPMNActivityImpl();
         bpmnActivityCancelled.setElementId("elementId");


### PR DESCRIPTION
fixes issue when trying to insert candidate starters events

`Caused by: org.h2.jdbc.JdbcBatchUpdateException: Value too long for column "TYPE VARCHAR(31)": "'ProcessCandidateStarterGroupAddedEvent' (38)"; SQL statement:
insert into audit_event (entity_id, event_id, event_type, message_id, sequence_number, timestamp, candidate_starter_user, type, id) values (?, ?, ?, ?, ?, ?, ?, 'ProcessCandidateStarterGroupAddedEvent', ?) [22001-200] `