### PR TITLE
Change set Process Variables API to PUT 

### DIFF
--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessVariablesRuntimeService.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessVariablesRuntimeService.java
@@ -31,7 +31,7 @@ public interface ProcessVariablesRuntimeService {
 
     @RequestLine("PUT /v1/process-instances/{id}/variables")
     @Headers("Content-Type: application/json")
-    ResponseEntity<Void> setVariables(@Param("id") String id,
+    ResponseEntity<Void> updateVariables(@Param("id") String id,
                                       SetProcessVariablesPayload setProcessVariablesPayload);
 
 }

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessVariablesRuntimeService.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/ProcessVariablesRuntimeService.java
@@ -29,7 +29,7 @@ public interface ProcessVariablesRuntimeService {
     @Headers("Accept: application/hal+json;charset=UTF-8")
     CollectionModel<CloudVariableInstance> getVariables(@Param("id") String id);
 
-    @RequestLine("POST /v1/process-instances/{id}/variables")
+    @RequestLine("PUT /v1/process-instances/{id}/variables")
     @Headers("Content-Type: application/json")
     ResponseEntity<Void> setVariables(@Param("id") String id,
                                       SetProcessVariablesPayload setProcessVariablesPayload);

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessVariablesRuntimeBundleSteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/ProcessVariablesRuntimeBundleSteps.java
@@ -49,9 +49,9 @@ public class ProcessVariablesRuntimeBundleSteps {
     }
 
     @Step
-    public ResponseEntity<Void> setVariables(String id,
+    public ResponseEntity<Void> updateVariables(String id,
                                       SetProcessVariablesPayload setProcessVariablesPayload) {
-        return processVariablesRuntimeService.setVariables(id, setProcessVariablesPayload);
+        return processVariablesRuntimeService.updateVariables(id, setProcessVariablesPayload);
     }
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceVariableController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceVariableController.java
@@ -17,9 +17,9 @@ package org.activiti.cloud.services.rest.api;
 
 import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,8 +33,8 @@ public interface ProcessInstanceVariableController {
     @RequestMapping(method = RequestMethod.GET)
     CollectionModel<EntityModel<CloudVariableInstance>> getVariables(@PathVariable String processInstanceId);
 
-    @RequestMapping(method = RequestMethod.POST)
-    ResponseEntity<Void> setVariables(@PathVariable String processInstanceId,
+    @RequestMapping(method = RequestMethod.PUT)
+    ResponseEntity<Void> updateVariables(@PathVariable String processInstanceId,
                                       @RequestBody SetProcessVariablesPayload setProcessVariablesPayload);
 
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImpl.java
@@ -35,11 +35,11 @@ import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
 import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.services.rest.api.ProcessInstanceVariableController;
-import org.activiti.cloud.services.rest.assemblers.ProcessInstanceVariableRepresentationModelAssembler;
 import org.activiti.cloud.services.rest.assemblers.CollectionModelAssembler;
+import org.activiti.cloud.services.rest.assemblers.ProcessInstanceVariableRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,7 +71,7 @@ public class ProcessInstanceVariableControllerImpl implements ProcessInstanceVar
     }
 
     @Override
-    public ResponseEntity<Void> setVariables(@PathVariable String processInstanceId,
+    public ResponseEntity<Void> updateVariables(@PathVariable String processInstanceId,
                                              @RequestBody SetProcessVariablesPayload setProcessVariablesPayload) {
 
         if (setProcessVariablesPayload != null) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -15,7 +15,19 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
@@ -48,19 +60,6 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProcessInstanceVariableControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -158,7 +157,7 @@ public class ProcessInstanceVariableControllerImplIT {
         given(processRuntime.processInstance(any()))
         .willReturn(processInstance);
 
-        this.mockMvc.perform(post("/v1/process-instances/{processInstanceId}/variables",
+        this.mockMvc.perform(put("/v1/process-instances/{processInstanceId}/variables",
                                   1).contentType(MediaType.APPLICATION_JSON).content(
                 mapper.writeValueAsString(ProcessPayloadBuilder.setVariables().withProcessInstanceId("1").withVariables(variables).build())))
                 .andExpect(status().isOk());

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -320,7 +320,7 @@ public class ProcessInstanceRestTemplate {
                 setProcessVariablesPayload,
                 null);
         ResponseEntity<Void> responseEntity = testRestTemplate.exchange(PROCESS_INSTANCES_RELATIVE_URL + processInstanceId + "/variables/",
-                                                                        HttpMethod.POST,
+                                                                        HttpMethod.PUT,
                                                                         requestEntity,
                                                                         new ParameterizedTypeReference<Void>() {
                                                                         });


### PR DESCRIPTION
This PR closes Activiti/Activiti#4205 changing `POST: /v1/process-instances/{processInstanceId}/variables` to `PUT: /v1/process-instances/{processInstanceId}/variables`.

The name of the controller method has also been aligned with the one in `ProcessInstanceVariableAdminController`.