### PR TITLE
Upgrade spring-web to version 5.3.25

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -38,6 +38,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${spring-web.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
     <project.year>2020</project.year>
 
     <spring-boot.version>2.7.7</spring-boot.version>
+    <spring-web.version>5.3.25</spring-web.version>
 
     <!-- configuration properties for tests-->
     <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>


### PR DESCRIPTION
This PR closes Activiti/Activiti#4211.
It forces the upgrade of `spring-web` to version 5.3.25, which will be included in `SpringBoot` version 2.7.8.
