### PR TITLE
fix: search users filtering by groups

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
@@ -16,7 +16,6 @@
 package org.activiti.cloud.services.identity.keycloak;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -90,13 +89,11 @@ public class KeycloakManagementService implements IdentityManagementService {
             ? StringUtils.contains(user.getUsername(), searchKey) || StringUtils.contains(user.getEmail(), searchKey)
             : true;
         try {
-            return groups.stream()
-                .map(this::findUsersByGroupName)
-                .flatMap(Collection::stream)
-                .distinct()
-                .filter(maybeMatchSearchKey)
-                .collect(Collectors.toList());
-
+            List<User> users = new ArrayList<>();
+            String firstGroup = groups.iterator().next();
+            users.addAll(findUsersByGroupName((firstGroup)));
+            groups.forEach(group -> users.retainAll(findUsersByGroupName(group)));
+            return users.stream().filter(maybeMatchSearchKey).collect(Collectors.toList());
         } catch (IdentityInvalidGroupException exception) {
             return Collections.emptyList();
         }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
@@ -195,6 +195,18 @@ class KeycloakManagementServiceTest {
         defineSearchUsersByGroupsFromKeycloak();
 
         UserSearchParams userSearchParams = new UserSearchParams();
+        userSearchParams.setGroups(Set.of("groupOne", "groupTwo"));
+        List<User> users = keycloakManagementService.findUsers(userSearchParams);
+        assertThat(users.size()).isEqualTo(1);
+        assertThat(users).containsExactly(userTwo);
+    }
+
+    @Test
+    void shouldReturnGroupsWhenSearchingUsingMultipleGroups() {
+        defineSearchUsersFromKeycloak();
+        defineSearchUsersByGroupsFromKeycloak();
+
+        UserSearchParams userSearchParams = new UserSearchParams();
         userSearchParams.setSearch("userTwo");
         userSearchParams.setGroups(Set.of("groupOne", "groupTwo"));
         List<User> users = keycloakManagementService.findUsers(userSearchParams);

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
@@ -115,8 +115,11 @@ class KeycloakManagementServiceTest {
         groupOne.setId("one");
         groupOne.setName("groupOne");
         groupTwo.setId("two");
+        groupTwo.setName("groupTwo");
         groupThree.setId("three");
+        groupThree.setName("groupThree");
         groupFour.setId("four");
+        groupFour.setName("groupFour");
 
         clientOne.setId("one");
         clientOne.setClientId("client-one");
@@ -133,7 +136,9 @@ class KeycloakManagementServiceTest {
         kGroupTwo.setId("two");
         kGroupTwo.setName("groupTwo");
         kGroupThree.setId("three");
+        kGroupThree.setName("groupThree");
         kGroupFour.setId("four");
+        kGroupFour.setName("groupFour");
     }
 
     @Test
@@ -185,14 +190,12 @@ class KeycloakManagementServiceTest {
     }
 
     @Test
-    void shouldReturnUsersWhenSearchingUsingMultipleGroups() {
+    void shouldReturnOnlyUsersMembersOfAllTheGroupsWhenSearchingUsingMultipleGroups() {
         defineSearchUsersFromKeycloak();
         defineSearchUsersByGroupsFromKeycloak();
-        when(keycloakClient.getUserGroups(userOne.getId())).thenReturn(List.of(kGroupOne));
-        when(keycloakClient.getUserGroups(userTwo.getId())).thenReturn(List.of(kGroupOne, kGroupTwo));
 
         UserSearchParams userSearchParams = new UserSearchParams();
-        userSearchParams.setSearch("o");
+        userSearchParams.setSearch("userTwo");
         userSearchParams.setGroups(Set.of("groupOne", "groupTwo"));
         List<User> users = keycloakManagementService.findUsers(userSearchParams);
         assertThat(users.size()).isEqualTo(1);
@@ -260,8 +263,6 @@ class KeycloakManagementServiceTest {
         defineSearchUsersFromKeycloak();
         setUpUsersApplicationRoles();
         defineSearchUsersByGroupsFromKeycloak();
-        when(keycloakClient.getUserGroups(userOne.getId())).thenReturn(List.of(kGroupOne));
-        when(keycloakClient.getUserGroups(userTwo.getId())).thenReturn(List.of(kGroupTwo));
 
         UserSearchParams userSearchParams = new UserSearchParams();
         userSearchParams.setSearch("userOne");
@@ -696,8 +697,8 @@ class KeycloakManagementServiceTest {
         when(keycloakClient.searchGroups(eq(groupOne.getName()), eq(0), eq(50))).thenReturn(List.of(kGroupOne));
         when(keycloakClient.getUsersByGroupId(kGroupOne.getId())).thenReturn(List.of(kUserOne, kUserTwo));
 
-        when(keycloakClient.searchGroups(eq(kGroupTwo.getName()), eq(0), eq(50))).thenReturn(List.of(kGroupTwo));
-        when(keycloakClient.getUsersByGroupId(kGroupTwo.getId())).thenReturn(List.of(kUserThree));
+        when(keycloakClient.searchGroups(eq(groupTwo.getName()), eq(0), eq(50))).thenReturn(List.of(kGroupTwo));
+        when(keycloakClient.getUsersByGroupId(kGroupTwo.getId())).thenReturn(List.of(kUserTwo, kUserThree));
     }
 
     private void setUpUsersApplicationRoles() {


### PR DESCRIPTION
User search filtered by a list of group is not working as expected. Current implementation returns all the user that are member of at least one of the groups passed as search parameter. The expected behaviour is to return only users that are member of  all the group passed in the search parameter.
ref. https://github.com/Activiti/Activiti/issues/4212