### PR TITLE
Remove error sorting in AggregateErrorValidationStrategy

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/AggregateErrorValidationStrategy.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/AggregateErrorValidationStrategy.java
@@ -64,7 +64,6 @@ public class AggregateErrorValidationStrategy<V extends ModelValidator> implemen
             .filter(validationException -> validationException.getValidationErrors() != null)
             .flatMap(validationException -> validationException.getValidationErrors().stream())
             .distinct()
-            .sorted((a, b) -> a.isWarning() ? -1 : 1)
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This PR closes Activiti/Activiti#4228 removing validation error sorting which is causing intermittently failures in tests.