### PR TITLE
Add ConsumerConnector functional interface

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConsumerConnector.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConsumerConnector.java
@@ -1,0 +1,12 @@
+package org.activiti.cloud.common.messaging.functional;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ConsumerConnector<T> extends Connector<T, Void>, Consumer<T> {
+
+    default Void apply(T t) {
+        this.accept(t);
+        return null;
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConsumerConnector.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConsumerConnector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.common.messaging.functional;
 
 import java.util.function.Consumer;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -15,12 +15,18 @@
  */
 package org.activiti.cloud.common.messaging.config.test;
 
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_RESULTS;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,11 +49,6 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_RESULTS;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 @SpringBootTest(properties = {
     "activiti.cloud.application.name=foo",
@@ -116,19 +117,17 @@ public class ConnectorConfigurationIT {
 
         @Bean(FUNCTION_NAME_A)
         @ConnectorBinding(input = AUDIT_CONSUMER, condition = "headers['type']=='TestAuditConsumerA'")
-        public Connector<?, Void> auditConsumerHandlerA() {
+        public ConsumerConnector<?> auditConsumerHandlerA() {
             return payload -> {
                 assertThat(payload).isNotNull().isEqualTo("TestA");
-                return null;
             };
         }
 
         @Bean(FUNCTION_NAME_B)
         @ConnectorBinding(input = AUDIT_CONSUMER, condition = "headers['type']=='TestAuditConsumerB'")
-        public Connector<?, Void> auditConsumerHandlerB() {
+        public ConsumerConnector<?> auditConsumerHandlerB() {
             return payload -> {
                 assertThat(payload).isNotNull().isEqualTo("TestB");
-                return null;
             };
         }
 


### PR DESCRIPTION
This PR closes Activiti/Activiti#4234 introducing a new functional interface for connectors that do not produce any response.