### PR TITLE
Revert removal of create and start created process instance endpoints

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -15,8 +15,7 @@
  */
 package org.activiti.cloud.services.rest.api;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
+import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
@@ -36,6 +35,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 public interface ProcessInstanceController {
 
     @GetMapping("/v1/process-instances")
@@ -44,6 +45,13 @@ public interface ProcessInstanceController {
 
     @PostMapping(path = "/v1/process-instances", consumes = APPLICATION_JSON_VALUE)
     EntityModel<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload cmd);
+
+    @PostMapping(value = "/v1/process-instances/{processInstanceId}/start", consumes = APPLICATION_JSON_VALUE)
+    EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable(value = "processInstanceId") String processInstanceId,
+        @RequestBody(required = false) StartProcessPayload payload);
+
+    @PostMapping(value = "/v1/process-instances/create", consumes = APPLICATION_JSON_VALUE)
+    EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload cmd);
 
     @GetMapping(value = "/v1/process-instances/{processInstanceId}")
     EntityModel<CloudProcessInstance> getProcessInstanceById(@PathVariable(value = "processInstanceId") String processInstanceId);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -15,6 +15,8 @@
  */
 package org.activiti.cloud.services.rest.api;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
@@ -35,8 +37,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 public interface ProcessInstanceController {
 
     @GetMapping("/v1/process-instances")
@@ -46,10 +46,12 @@ public interface ProcessInstanceController {
     @PostMapping(path = "/v1/process-instances", consumes = APPLICATION_JSON_VALUE)
     EntityModel<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload cmd);
 
+    @Deprecated
     @PostMapping(value = "/v1/process-instances/{processInstanceId}/start", consumes = APPLICATION_JSON_VALUE)
     EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable(value = "processInstanceId") String processInstanceId,
         @RequestBody(required = false) StartProcessPayload payload);
 
+    @Deprecated
     @PostMapping(value = "/v1/process-instances/create", consumes = APPLICATION_JSON_VALUE)
     EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload cmd);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -30,6 +30,10 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
+import static java.util.Collections.emptyList;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
@@ -61,10 +65,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.nio.charset.StandardCharsets;
-
-import static java.util.Collections.emptyList;
 
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -119,10 +119,8 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
     @Override
     public EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable String processInstanceId,
                                                                  @RequestBody(required = false) StartProcessPayload startProcessPayload) {
-        if (startProcessPayload == null) {
-            startProcessPayload = ProcessPayloadBuilder.start().build();
-        }
-        startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+        StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(
+            Optional.ofNullable(startProcessPayload).orElse(ProcessPayloadBuilder.start().build()));
         return representationModelAssembler.toModel(processRuntime.startCreatedProcess(processInstanceId, startProcessPayload));
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -30,11 +30,9 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import static java.util.Collections.emptyList;
-
-import java.nio.charset.StandardCharsets;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
@@ -63,6 +61,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Collections.emptyList;
 
 @RestController
 @RequestMapping(produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -112,6 +114,21 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
         startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
 
         return representationModelAssembler.toModel(processRuntime.start(startProcessPayload));
+    }
+
+    @Override
+    public EntityModel<CloudProcessInstance> startCreatedProcess(@PathVariable String processInstanceId,
+                                                                 @RequestBody(required = false) StartProcessPayload startProcessPayload) {
+        if (startProcessPayload == null) {
+            startProcessPayload = ProcessPayloadBuilder.start().build();
+        }
+        startProcessPayload = variablesPayloadConverter.convert(startProcessPayload);
+        return representationModelAssembler.toModel(processRuntime.startCreatedProcess(processInstanceId, startProcessPayload));
+    }
+
+    @Override
+    public EntityModel<CloudProcessInstance> createProcessInstance(@RequestBody CreateProcessInstancePayload createProcessInstancePayload) {
+        return representationModelAssembler.toModel(processRuntime.create(createProcessInstancePayload));
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -121,7 +121,7 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
                                                                  @RequestBody(required = false) StartProcessPayload startProcessPayload) {
         StartProcessPayload convertedStartProcessPayload = variablesPayloadConverter.convert(
             Optional.ofNullable(startProcessPayload).orElse(ProcessPayloadBuilder.start().build()));
-        return representationModelAssembler.toModel(processRuntime.startCreatedProcess(processInstanceId, startProcessPayload));
+        return representationModelAssembler.toModel(processRuntime.startCreatedProcess(processInstanceId, convertedStartProcessPayload));
     }
 
     @Override

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -15,6 +15,11 @@
  */
 package org.activiti.cloud.starter.tests.helper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
@@ -41,12 +46,6 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @TestComponent
 public class ProcessInstanceRestTemplate {
@@ -81,7 +80,6 @@ public class ProcessInstanceRestTemplate {
 
     private ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionKey,
                                                               String processDefinitionId,
-                                                              Map<String, Object> variables,
                                                               String businessKey) {
 
         CreateProcessInstancePayload startProcess = ProcessPayloadBuilder.create()
@@ -119,12 +117,10 @@ public class ProcessInstanceRestTemplate {
     }
 
     public ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionId,
-                                                             Map<String, Object> variables,
                                                              String businessKey) {
 
         return createProcess(null,
             processDefinitionId,
-            variables,
             businessKey);
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -15,11 +15,6 @@
  */
 package org.activiti.cloud.starter.tests.helper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.CreateProcessInstancePayload;
@@ -46,6 +41,12 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @TestComponent
 public class ProcessInstanceRestTemplate {
@@ -78,6 +79,20 @@ public class ProcessInstanceRestTemplate {
         return startProcess(startProcess);
     }
 
+    private ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionKey,
+                                                              String processDefinitionId,
+                                                              Map<String, Object> variables,
+                                                              String businessKey) {
+
+        CreateProcessInstancePayload startProcess = ProcessPayloadBuilder.create()
+            .withProcessDefinitionId(processDefinitionId)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withBusinessKey(businessKey)
+            .build();
+
+        return createProcess(startProcess);
+    }
+
     public ResponseEntity<CloudProcessInstance> startProcess(String processDefinitionId) {
 
         return startProcess(processDefinitionId,
@@ -103,8 +118,22 @@ public class ProcessInstanceRestTemplate {
                             businessKey);
     }
 
+    public ResponseEntity<CloudProcessInstance> createProcess(String processDefinitionId,
+                                                             Map<String, Object> variables,
+                                                             String businessKey) {
+
+        return createProcess(null,
+            processDefinitionId,
+            variables,
+            businessKey);
+    }
+
     public ResponseEntity<CloudProcessInstance> startProcess(StartProcessPayload startProcess) {
         return startProcess(PROCESS_INSTANCES_RELATIVE_URL,startProcess);
+    }
+
+    public ResponseEntity<CloudProcessInstance> createProcess(CreateProcessInstancePayload startPayload) {
+        return createProcess(PROCESS_INSTANCES_RELATIVE_URL + "create", startPayload);
     }
 
     public ResponseEntity<CloudProcessInstance> adminStartProcess(StartProcessPayload startProcess) {
@@ -119,6 +148,22 @@ public class ProcessInstanceRestTemplate {
                                           });
     }
 
+    private ResponseEntity<CloudProcessInstance> startCreatedProcessCall(String baseURL) {
+        return testRestTemplate.exchange(baseURL,
+            HttpMethod.POST,
+            new HttpEntity<>(CONTENT_TYPE_HEADER),
+            new ParameterizedTypeReference<CloudProcessInstance>() {
+            });
+    }
+
+    private ResponseEntity<ActivitiErrorMessageImpl> startCreatedProcessCallFail(String baseURL) {
+        return testRestTemplate.exchange(baseURL,
+            HttpMethod.POST,
+            new HttpEntity<>(CONTENT_TYPE_HEADER),
+            new ParameterizedTypeReference<ActivitiErrorMessageImpl>() {
+            });
+    }
+
     private ResponseEntity<CloudProcessInstance> createProcessWithoutCheck(String baseURL, CreateProcessInstancePayload payload) {
         return  testRestTemplate.exchange(baseURL,
             HttpMethod.POST,
@@ -129,6 +174,31 @@ public class ProcessInstanceRestTemplate {
 
     private ResponseEntity<CloudProcessInstance> startProcess(String baseURL, StartProcessPayload startProcess) {
         ResponseEntity<CloudProcessInstance> responseEntity = startProcessWithoutCheck(baseURL, startProcess);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isNotNull();
+        assertThat(responseEntity.getBody().getId()).isNotNull();
+        return responseEntity;
+    }
+
+    public ResponseEntity<CloudProcessInstance> startCreatedProcess(String processInstanceId) {
+        String baseURL = PROCESS_INSTANCES_RELATIVE_URL.concat(processInstanceId).concat("/start");
+        ResponseEntity<CloudProcessInstance> responseEntity = startCreatedProcessCall(baseURL);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isNotNull();
+        assertThat(responseEntity.getBody().getId()).isNotNull();
+        return responseEntity;
+    }
+
+    public ResponseEntity<ActivitiErrorMessageImpl> startCreatedProcessFailing(String processInstanceId) {
+        String baseURL = PROCESS_INSTANCES_RELATIVE_URL.concat(processInstanceId).concat("/start");
+        ResponseEntity<ActivitiErrorMessageImpl> responseEntity = startCreatedProcessCallFail(baseURL);
+        return responseEntity;
+    }
+
+    private ResponseEntity<CloudProcessInstance> createProcess(String baseURL, CreateProcessInstancePayload startProcess) {
+        ResponseEntity<CloudProcessInstance> responseEntity = createProcessWithoutCheck(baseURL, startProcess);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(responseEntity.getBody()).isNotNull();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -15,6 +15,9 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -52,9 +55,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
@@ -128,7 +128,6 @@ public class ProcessInstanceIT {
     public void shouldCreateProcessInstanceWithoutStartingIt() {
         //when
         ResponseEntity<CloudProcessInstance> entity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
-            null,
             "business_key");
 
         //then
@@ -152,7 +151,6 @@ public class ProcessInstanceIT {
     public void shouldStartAnAlreadyCreatedProcess() {
         //when
         ResponseEntity<CloudProcessInstance> createdEntity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
-            null,
             "business_key");
         CloudProcessInstance createdProcInst = createdEntity.getBody();
         assertThat(createdProcInst).isNotNull();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -15,9 +15,6 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -29,6 +26,7 @@ import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
+import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.converter.util.InputStreamProvider;
 import org.activiti.bpmn.model.BpmnModel;
@@ -54,6 +52,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
@@ -121,6 +122,80 @@ public class ProcessInstanceIT {
         assertThat(returnedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
         assertThat(returnedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
         assertThat(returnedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
+    }
+
+    @Test
+    public void shouldCreateProcessInstanceWithoutStartingIt() {
+        //when
+        ResponseEntity<CloudProcessInstance> entity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
+            null,
+            "business_key");
+
+        //then
+        assertThat(entity).isNotNull();
+        CloudProcessInstance returnedProcInst = entity.getBody();
+        assertThat(returnedProcInst).isNotNull();
+        assertThat(returnedProcInst.getId()).isNotNull();
+        assertThat(returnedProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.CREATED);
+        assertThat(returnedProcInst.getProcessDefinitionId()).contains("SimpleProcess:");
+        assertThat(returnedProcInst.getInitiator()).isNotNull();
+        assertThat(returnedProcInst.getInitiator()).isEqualTo(keycloakTestUser);//will only match if using username not id
+        assertThat(returnedProcInst.getBusinessKey()).isEqualTo("business_key");
+        assertThat(returnedProcInst.getAppName()).isEqualTo(runtimeBundleProperties.getAppName());
+        assertThat(returnedProcInst.getServiceName()).isEqualTo(runtimeBundleProperties.getServiceName());
+        assertThat(returnedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
+        assertThat(returnedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
+        assertThat(returnedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
+    }
+
+    @Test
+    public void shouldStartAnAlreadyCreatedProcess() {
+        //when
+        ResponseEntity<CloudProcessInstance> createdEntity = processInstanceRestTemplate.createProcess(processDefinitionIds.get(SIMPLE_PROCESS),
+            null,
+            "business_key");
+        CloudProcessInstance createdProcInst = createdEntity.getBody();
+        assertThat(createdProcInst).isNotNull();
+        assertThat(createdProcInst.getId()).isNotNull();
+        assertThat(createdProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.CREATED);
+
+        ResponseEntity<CloudProcessInstance> startedEntity =
+            processInstanceRestTemplate.startCreatedProcess(createdEntity.getBody().getId());
+
+        //then
+        assertThat(startedEntity).isNotNull();
+        assertThat(startedEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        CloudProcessInstance startedProcInst = startedEntity.getBody();
+        assertThat(startedProcInst).isNotNull();
+        assertThat(startedProcInst.getId()).isNotNull();
+        assertThat(startedProcInst.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.RUNNING);
+        assertThat(startedProcInst.getProcessDefinitionId()).contains("SimpleProcess:");
+        assertThat(startedProcInst.getInitiator()).isNotNull();
+        assertThat(startedProcInst.getInitiator()).isEqualTo(keycloakTestUser);//will only match if using username not id
+        assertThat(startedProcInst.getBusinessKey()).isEqualTo("business_key");
+        assertThat(startedProcInst.getAppName()).isEqualTo(runtimeBundleProperties.getAppName());
+        assertThat(startedProcInst.getAppVersion()).isEqualTo("1");
+        assertThat(startedProcInst.getServiceName()).isEqualTo(runtimeBundleProperties.getServiceName());
+        assertThat(startedProcInst.getServiceFullName()).isEqualTo(runtimeBundleProperties.getServiceFullName());
+        assertThat(startedProcInst.getServiceType()).isEqualTo(runtimeBundleProperties.getServiceType());
+        assertThat(startedProcInst.getServiceVersion()).isEqualTo(runtimeBundleProperties.getServiceVersion());
+    }
+
+    @Test
+    public void shouldThrowAnError_when_StartingAnAlreadyStartedProcess() {
+        //when
+        ResponseEntity<CloudProcessInstance> entity = processInstanceRestTemplate.startProcess(processDefinitionIds.get(SIMPLE_PROCESS),
+            null,
+            "business_key");
+
+        //then
+        assertThat(entity).isNotNull();
+
+        CloudProcessInstance startedProcessInstance = entity.getBody();
+        ResponseEntity<ActivitiErrorMessageImpl> failEntity =
+            processInstanceRestTemplate.startCreatedProcessFailing(startedProcessInstance.getId());
+        assertThat(failEntity.getBody().getMessage()).isEqualTo("Process instance " + startedProcessInstance.getId() + " has already been started");
+        assertThat(failEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes Activiti/Activiti#4237 reintroducing the API for creating and starting a previously created Process Instance.
The APIs have been marked as `@Deprecated`.

This reverts commit 09a0dcbb2ec7d3569a6adfe1e00327abfb921164.