### PR TITLE
AAE-12448 convert svg to png for model extensions

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/pom.xml
@@ -43,6 +43,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-common-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/main/java/org/activiti/cloud/modeling/converter/JsonConverter.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/main/java/org/activiti/cloud/modeling/converter/JsonConverter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.modeling.core.error.ModelingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -102,7 +103,7 @@ public class JsonConverter<T> {
 
     public T convertToEntity(byte[] json,
                              Class<?> view) {
-        if (StringUtils.isEmpty(json)) {
+        if (ObjectUtils.isEmpty(json)) {
             return null;
         }
         return convertToEntity(new String(json,
@@ -118,7 +119,7 @@ public class JsonConverter<T> {
     public T convertToEntity(String json,
                              Class<?> view) {
         try {
-            if (StringUtils.isEmpty(json)) {
+            if (!StringUtils.hasLength(json)) {
                 return null;
             }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/main/java/org/activiti/cloud/modeling/converter/StringSanitizingDeserializer.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/main/java/org/activiti/cloud/modeling/converter/StringSanitizingDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.modeling.converter;
+
+import java.io.IOException;
+import java.util.Base64;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
+import org.activiti.cloud.services.common.util.ImageProcessingException;
+import org.activiti.cloud.services.common.util.ImageUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringSanitizingDeserializer extends StringDeserializer {
+
+    private static final long serialVersionUID = -5484119319853721838L;
+
+    private static final Logger logger = LoggerFactory.getLogger(StringSanitizingDeserializer.class);
+
+    private static final String SVG_IMAGE_PREFIX = "data:image/svg+xml;base64,";
+
+    private static final String SVG_IMAGE_PREFIX_REGEX = "^data:image/svg\\+xml;base64,";
+
+    private static final String PNG_IMAGE_PREFIX = "data:image/png;base64,";
+
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.hasToken(JsonToken.VALUE_STRING) &&
+                p.getText().trim().toLowerCase().startsWith(SVG_IMAGE_PREFIX)) {
+            final String deserializedString = convertSvgToPng(p.getText());
+            if (deserializedString != null) {
+                return deserializedString;
+            }
+        }
+        return super.deserialize(p, ctxt);
+    }
+
+    private String convertSvgToPng(final String svgImageText) throws IOException {
+        try {
+            final String base64Svg = svgImageText.replaceFirst(SVG_IMAGE_PREFIX_REGEX, "");
+            final byte[] decodedSvgBytes = Base64.getDecoder().decode(base64Svg);
+            final byte[] pngBytes = ImageUtils.svgToPng(decodedSvgBytes);
+            final String base64Png = Base64.getEncoder().encodeToString(pngBytes);
+            return PNG_IMAGE_PREFIX + base64Png;
+        } catch (ImageProcessingException e) {
+            logger.warn("Image processing error", e);
+        }
+        return null;
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/test/java/org/activiti/cloud/modeling/converter/StringSanitizingDeserializerTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-core/src/test/java/org/activiti/cloud/modeling/converter/StringSanitizingDeserializerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.modeling.converter;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StringSanitizingDeserializerTest {
+
+    private final static String SVG = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmci" +
+            "IHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48ZyBpZD0ic2F2ZS0yNHB4XzFfIiBkYXRhLW5hbWU9InNh" +
+            "dmUtMjRweCAoMSkiIG9wYWNpdHk9IjEiPjxwYXRoIGlkPSJQYXRoXzE3OTY1IiBkYXRhLW5hbWU9IlBhdGggMTc5NjUiIGQ9Ik0wLDBI" +
+            "MjRWMjRIMFoiIGZpbGw9Im5vbmUiLz48cGF0aCBpZD0iUGF0aF8xNzk2NiIgZGF0YS1uYW1lPSJQYXRoIDE3OTY2IiBkPSJNMTcsM0g1" +
+            "QTIsMiwwLDAsMCwzLDVWMTlhMiwyLDAsMCwwLDIsMkgxOWEyLjAwNiwyLjAwNiwwLDAsMCwyLTJWN1ptMiwxNkg1VjVIMTYuMTdMMTks" +
+            "Ny44M1ptLTctN2EzLDMsMCwxLDAsMywzQTMsMywwLDAsMCwxMiwxMlpNNiw2aDl2NEg2WiIvPjwvZz48L3N2Zz4K";
+
+    private static final String PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAIGNIUk0A" +
+            "AHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAEZ0FNQQAAsY58+1GTAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/" +
+            "oL2nkwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAMVJREFUeNpjYBgFBAAjGt8TiGcBsQyJ5jQAcSM2CWY0/j4gliXDoQ5Q+iC6BAsaXxaH" +
+            "z/CBcCBeAvUFA7pPWPBo/E9kEK+EsrFawkSluARZEoMUHwzUtoAByScMtLIAK2AhIQmTBQbUB8iADZoy4qH8hUBcD8S/qGVBExCXI/Er" +
+            "oEFYQa0giiVSjP5xQKwFi4kUIzsO6qBFB3okU80CUGqphGKKkuljaIn6n4Jgf4yvPrgBxPZAzEem4U+AOA2I74zW5UQDACHHHaj63Wy2" +
+            "AAAAAElFTkSuQmCC";
+
+    private static final String SIMPLE_TEXT = "simple text";
+
+    private static final String WRONG_SVG = "data:image/svg+xml;base64,SGVsbG8gdGhlcmUK";
+
+    private StringSanitizingDeserializer stringSanitizingDeserializer = new StringSanitizingDeserializer();
+
+    @Test
+    public void should_sanitizeConvertSvgStringToPng() throws Exception {
+        JsonParser jsonParser = mock(JsonParser.class);
+        when(jsonParser.hasToken(eq(JsonToken.VALUE_STRING))).thenReturn(true);
+        when(jsonParser.getText()).thenReturn(SVG);
+        String result = stringSanitizingDeserializer.deserialize(jsonParser, mock(DeserializationContext.class));
+        Assertions.assertThat(result).isEqualTo(PNG);
+    }
+
+    @Test
+    public void should_omitSanitization_when_stringIsNotSvg() throws Exception {
+        JsonParser jsonParser = mock(JsonParser.class);
+        when(jsonParser.hasToken(eq(JsonToken.VALUE_STRING))).thenReturn(true);
+        when(jsonParser.getText()).thenReturn(SIMPLE_TEXT);
+        String result = stringSanitizingDeserializer.deserialize(jsonParser, mock(DeserializationContext.class));
+        Assertions.assertThat(result).isEqualTo(SIMPLE_TEXT);
+    }
+
+    @Test
+    public void should_omitSanitization_when_exceptionIsThrown() throws Exception {
+        JsonParser jsonParser = mock(JsonParser.class);
+        when(jsonParser.hasToken(eq(JsonToken.VALUE_STRING))).thenReturn(true);
+        when(jsonParser.getText()).thenReturn(WRONG_SVG);
+        String result = stringSanitizingDeserializer.deserialize(jsonParser, mock(DeserializationContext.class));
+        Assertions.assertThat(result).isEqualTo(WRONG_SVG);
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ObjectMapperJpaConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ObjectMapperJpaConfiguration.java
@@ -24,6 +24,7 @@ import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.modeling.api.process.Extensions;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.converter.JsonConverter;
+import org.activiti.cloud.modeling.converter.StringSanitizingDeserializer;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -45,6 +46,14 @@ public class ObjectMapperJpaConfiguration {
                             ModelEntity.class);
 
         module.setAbstractTypes(resolver);
+        return module;
+    }
+
+    @Bean
+    public Module jsonStringSanitizingModelingModule() {
+        SimpleModule module = new SimpleModule("jsonStringSanitizingModelingModule",
+                Version.unknownVersion());
+        module.addDeserializer(String.class, new StringSanitizingDeserializer());
         return module;
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ImageProcessingException.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ImageProcessingException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.common.util;
+
+public class ImageProcessingException extends Exception {
+    public ImageProcessingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ImageUtils.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/util/ImageUtils.java
@@ -28,13 +28,15 @@ public class ImageUtils {
     private ImageUtils() {
     }
 
-    public static byte[] svgToPng(byte[] streamBytes) throws TranscoderException, IOException {
+    public static byte[] svgToPng(byte[] streamBytes) throws IOException, ImageProcessingException {
         try (ByteArrayInputStream input = new ByteArrayInputStream(streamBytes);
              ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             new PNGTranscoder().transcode(new TranscoderInput(input),
                     new TranscoderOutput(output));
             output.flush();
             return output.toByteArray();
+        } catch (TranscoderException e) {
+            throw new ImageProcessingException(e);
         }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/util/ImageUtilsTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/util/ImageUtilsTest.java
@@ -16,7 +16,10 @@
 
 package org.activiti.cloud.services.common.util;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class ImageUtilsTest {
@@ -26,6 +29,12 @@ class ImageUtilsTest {
         byte[] svg = this.getClass().getClassLoader().getResourceAsStream("images/save.svg").readAllBytes();
         byte[] png = ImageUtils.svgToPng(svg);
         byte[] expectedPng = this.getClass().getClassLoader().getResourceAsStream("images/save.png").readAllBytes();
-        Assertions.assertThat(png).isEqualTo(expectedPng);
+        assertThat(png).isEqualTo(expectedPng);
+    }
+
+    @Test
+    void should_throwImageProcessingException_when_TranscoderExceptionThrown() {
+        byte[] svg = "wrong svg".getBytes(StandardCharsets.UTF_8);
+        assertThatExceptionOfType(ImageProcessingException.class).isThrownBy(() -> ImageUtils.svgToPng(svg));
     }
 }


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4241
In order to mitigate the XSS in SVG uploaded file we can convert it to PNG. It applies to all extensions nodes.