### PR TITLE
Add PrettyPrinter for preserving json format

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeContentUpdateListenerControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeContentUpdateListenerControllerIT.java
@@ -24,6 +24,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.modeling.api.ContentUpdateListener;
 import org.activiti.cloud.modeling.api.JsonModelType;
@@ -32,6 +33,7 @@ import org.activiti.cloud.modeling.repository.ModelRepository;
 import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.entity.ModelEntity;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.activiti.cloud.services.modeling.service.utils.ModelExtensionsPrettyPrinter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +61,8 @@ public class GenericJsonModelTypeContentUpdateListenerControllerIT {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private final PrettyPrinter jsonPrettyPrinter = new ModelExtensionsPrettyPrinter().withEmptyObjectSeparator(false);
+
     @Autowired
     private ModelRepository modelRepository;
 
@@ -85,7 +89,7 @@ public class GenericJsonModelTypeContentUpdateListenerControllerIT {
         Model genericJsonModel = modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME,
                                                                              genericJsonModelType.getName()));
 
-        String stringModel = objectMapper.writeValueAsString(genericJsonModel);
+        String stringModel = objectMapper.writer(jsonPrettyPrinter).writeValueAsString(genericJsonModel);
 
         mockMvc.perform(putMultipart("/v1/models/{modelId}/content",
                                      genericJsonModel.getId()).file("file",
@@ -105,7 +109,7 @@ public class GenericJsonModelTypeContentUpdateListenerControllerIT {
         Model genericJsonModel = modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME,
                                                                              genericJsonModelType.getName()));
 
-        String stringModel = objectMapper.writeValueAsString(genericJsonModel);
+        String stringModel = objectMapper.writer(jsonPrettyPrinter).writeValueAsString(genericJsonModel);
 
         mockMvc.perform(putMultipart("/v1/models/{modelId}/content",
                                      genericJsonModel.getId()).file("file",

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizer.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizer.java
@@ -16,10 +16,12 @@
 
 package org.activiti.cloud.services.modeling.service.utils;
 
-import java.util.Map;
+import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.Map;
 import org.activiti.cloud.modeling.converter.StringSanitizingDeserializer;
 import org.activiti.cloud.services.common.file.FileContent;
 import org.activiti.cloud.services.common.util.ContentTypeUtils;
@@ -34,8 +36,14 @@ public class FileContentSanitizer {
 
     private final ObjectMapper objectMapper;
 
+    private final PrettyPrinter prettyPrinter;
+
     public FileContentSanitizer() {
         this.objectMapper = new ObjectMapper();
+        this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        this.prettyPrinter = new ModelExtensionsPrettyPrinter().withEmptyObjectSeparator('\0');
+
         SimpleModule module = new SimpleModule("jsonStringSanitizingModelingModule", Version.unknownVersion());
         module.addDeserializer(String.class, new StringSanitizingDeserializer());
         this.objectMapper.registerModule(module);
@@ -53,7 +61,7 @@ public class FileContentSanitizer {
             } else if (ContentTypeUtils.isJsonContentType(fileContent.getContentType())) {
                 // ObjectMapper sanitizes String values
                 Map deserializedMap = objectMapper.readValue(fileContent.getFileContent(), Map.class);
-                updatedFileContent = objectMapper.writer().writeValueAsBytes(deserializedMap);
+                updatedFileContent = objectMapper.writer(prettyPrinter).writeValueAsBytes(deserializedMap);
             }
             return new FileContent(updatedFileName, updatedContentType, updatedFileContent);
         } catch (Exception e) {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizer.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizer.java
@@ -42,10 +42,11 @@ public class FileContentSanitizer {
         this.objectMapper = new ObjectMapper();
         this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
 
-        this.prettyPrinter = new ModelExtensionsPrettyPrinter().withEmptyObjectSeparator('\0');
+        this.prettyPrinter = new ModelExtensionsPrettyPrinter().withEmptyObjectSeparator(false);
 
         SimpleModule module = new SimpleModule("jsonStringSanitizingModelingModule", Version.unknownVersion());
         module.addDeserializer(String.class, new StringSanitizingDeserializer());
+
         this.objectMapper.registerModule(module);
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/ModelExtensionsPrettyPrinter.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/ModelExtensionsPrettyPrinter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import java.io.IOException;
+
+public class ModelExtensionsPrettyPrinter extends DefaultPrettyPrinter {
+
+    private char emptyObjectSeparator = ' ';
+
+    public ModelExtensionsPrettyPrinter withEmptyObjectSeparator(char separator) {
+        this.emptyObjectSeparator = separator;
+        return this;
+    }
+
+    @Override
+    public void writeEndObject(JsonGenerator g, int nrOfEntries) throws IOException
+    {
+        if (!_objectIndenter.isInline()) {
+            --_nesting;
+        }
+        if (nrOfEntries > 0) {
+            _objectIndenter.writeIndentation(g, _nesting);
+        } else {
+            g.writeRaw(emptyObjectSeparator);
+        }
+        g.writeRaw('}');
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/ModelExtensionsPrettyPrinter.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/utils/ModelExtensionsPrettyPrinter.java
@@ -18,14 +18,28 @@ package org.activiti.cloud.services.modeling.service.utils;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.Separators;
 import java.io.IOException;
 
 public class ModelExtensionsPrettyPrinter extends DefaultPrettyPrinter {
 
-    private char emptyObjectSeparator = ' ';
+    private boolean useEmptyObjectSeparator = true;
 
-    public ModelExtensionsPrettyPrinter withEmptyObjectSeparator(char separator) {
-        this.emptyObjectSeparator = separator;
+    @Override
+    public ModelExtensionsPrettyPrinter createInstance() {
+        return new ModelExtensionsPrettyPrinter()
+            .withEmptyObjectSeparator(useEmptyObjectSeparator);
+    }
+
+    public ModelExtensionsPrettyPrinter withEmptyObjectSeparator(boolean useEmptyObjectSeparator) {
+        this.useEmptyObjectSeparator = useEmptyObjectSeparator;
+        return this;
+    }
+
+    @Override
+    public DefaultPrettyPrinter withSeparators(Separators separators) {
+        _separators = separators;
+        _objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSeparator() + " ";
         return this;
     }
 
@@ -38,7 +52,9 @@ public class ModelExtensionsPrettyPrinter extends DefaultPrettyPrinter {
         if (nrOfEntries > 0) {
             _objectIndenter.writeIndentation(g, _nesting);
         } else {
-            g.writeRaw(emptyObjectSeparator);
+            if(useEmptyObjectSeparator) {
+                g.writeRaw(' ');
+            }
         }
         g.writeRaw('}');
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizerTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizerTest.java
@@ -60,7 +60,7 @@ class FileContentSanitizerTest {
 
         Assertions.assertThat(sanitizedContent.getFilename()).isEqualTo("img.json");
         Assertions.assertThat(sanitizedContent.getContentType()).isEqualTo(ContentTypeUtils.CONTENT_TYPE_JSON);
-        Assertions.assertThat(sanitizedContent.toString()).contains("{\"image\":\"data:image/png;base64,");
+        Assertions.assertThat(sanitizedContent.toString()).contains("\"image\": \"data:image/png;base64,");
     }
 
     @Test
@@ -74,6 +74,6 @@ class FileContentSanitizerTest {
 
         Assertions.assertThat(sanitizedContent.getFilename()).isEqualTo("basic-process.json");
         Assertions.assertThat(sanitizedContent.getContentType()).isEqualTo(ContentTypeUtils.CONTENT_TYPE_JSON);
-        Assertions.assertThat(sanitizedContent.toString()).isEqualTo(new String(json, StandardCharsets.UTF_8));
+        Assertions.assertThat(sanitizedContent.toString().trim()).isEqualTo(new String(json, StandardCharsets.UTF_8).trim());
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizerTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/utils/FileContentSanitizerTest.java
@@ -31,6 +31,8 @@ class FileContentSanitizerTest {
 
     private static final String SVG_IMAGE_PREFIX = "data:image/svg+xml;base64,";
 
+    private static final String JSON_FILE_LOCATION = "extensions/basic-process.json";
+
     private final FileContentSanitizer fileContentSanitizer = new FileContentSanitizer();
 
     @Test
@@ -59,5 +61,19 @@ class FileContentSanitizerTest {
         Assertions.assertThat(sanitizedContent.getFilename()).isEqualTo("img.json");
         Assertions.assertThat(sanitizedContent.getContentType()).isEqualTo(ContentTypeUtils.CONTENT_TYPE_JSON);
         Assertions.assertThat(sanitizedContent.toString()).contains("{\"image\":\"data:image/png;base64,");
+    }
+
+    @Test
+    void should_deserializeJsonWithoutChangingFormat() throws IOException {
+        byte[] json = FileUtils.resourceAsStream(JSON_FILE_LOCATION)
+            .orElseThrow(() -> new IllegalArgumentException(SVG_FILE_LOCATION + " file not found"))
+            .readAllBytes();
+
+        FileContent sanitizedContent = fileContentSanitizer.sanitizeContent(new FileContent("basic-process.json",
+            ContentTypeUtils.CONTENT_TYPE_JSON, json));
+
+        Assertions.assertThat(sanitizedContent.getFilename()).isEqualTo("basic-process.json");
+        Assertions.assertThat(sanitizedContent.getContentType()).isEqualTo(ContentTypeUtils.CONTENT_TYPE_JSON);
+        Assertions.assertThat(sanitizedContent.toString()).isEqualTo(new String(json, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
This PR solves Activiti/Activiti#4247 introducing a custom `PrettyPrinter` for formatting the content of json files after sanitization.