### PR TITLE
AAE-12742 update batik from 1.14 to 1.16

### DIFF
--- a/activiti-cloud-acceptance-tests/pom.xml
+++ b/activiti-cloud-acceptance-tests/pom.xml
@@ -20,7 +20,7 @@
     <serenity.version>2.3.31</serenity.version>
     <serenity-jbehave.version>1.46.0</serenity-jbehave.version>
     <feign-form.version>3.8.0</feign-form.version>
-    <batik.version>1.14</batik.version>
+    <batik.version>1.16</batik.version>
     <enforcer.skip>true</enforcer.skip>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -48,7 +48,7 @@
     <jsonwebtoken.version>0.9.1</jsonwebtoken.version>
     <!-- override resteasy vulnerable 0.8.3 version of org.apache.james dependencies -->
     <james.apache-mime4j.version>0.8.9</james.apache-mime4j.version>
-    <batik.version>1.14</batik.version>
+    <batik.version>1.16</batik.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4253

We should update batik to 1.16 in order to fix known vulnerabilities: CVE-2022-41704, CVE-2022-40146, CVE-2022-38648, CVE-2022-38398.