### PR TITLE
Include detailed message for error cause when throwing CloudBpmnError

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
@@ -39,6 +39,15 @@ public class CloudBpmnError extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+
+    public CloudBpmnError(String errorCode, String message, Throwable cause) {
+        super(message, cause);
+
+        requireValidErrorCode(errorCode);
+
+        this.errorCode = errorCode;
+    }
+
     public String getErrorCode() {
         return this.errorCode;
     }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/CloudBpmnError.java
@@ -39,10 +39,8 @@ public class CloudBpmnError extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-
     public CloudBpmnError(String errorCode, String message, Throwable cause) {
         super(message, cause);
-
         requireValidErrorCode(errorCode);
 
         this.errorCode = errorCode;


### PR DESCRIPTION
This PR adds `CloudBpmnError` constructor with `errorCode`, `message`, `cause` attributes to be able to include detailed message for error cause when throwing `CloudBpmnError`

https://alfresco.atlassian.net/browse/AAE-13311