### PR TITLE
Replace 'RabbitMQContainerApplicationInitializer' with 'TestChannelBinderConfiguration'

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
@@ -141,8 +141,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
+      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/APIEventToEntityConvertersIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/APIEventToEntityConvertersIT.java
@@ -72,20 +72,18 @@ import org.activiti.cloud.services.audit.jpa.converters.VariableCreatedEventConv
 import org.activiti.cloud.services.audit.jpa.converters.VariableDeletedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.VariableUpdatedEventConverter;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext
 @TestPropertySource("classpath:application.properties")
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 public class APIEventToEntityConvertersIT {
 
     @Autowired

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -102,7 +102,7 @@ import org.activiti.cloud.api.task.model.impl.events.CloudTaskUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.starters.test.MyProducer;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -133,8 +133,8 @@ public class AuditServiceIT {
     @Autowired
     private MyProducer producer;
 
-    @BeforeEach
-    public void setUp() {
+    @AfterEach
+    public void cleanUp() {
         repository.deleteAll();
     }
 

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -101,12 +101,12 @@ import org.activiti.cloud.api.task.model.impl.events.CloudTaskCreatedEventImpl;
 import org.activiti.cloud.api.task.model.impl.events.CloudTaskUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -117,10 +117,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @TestPropertySource("classpath:application.properties")
-@Import(EventsRestTemplate.class)
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@Import({EventsRestTemplate.class, TestChannelBinderConfiguration.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class AuditServiceIT {
 
     private static final String ERROR_MESSAGE =

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -117,7 +117,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 @TestPropertySource("classpath:application.properties")
-@Import({EventsRestTemplate.class, TestChannelBinderConfiguration.class})
+@Import({ EventsRestTemplate.class, TestChannelBinderConfiguration.class })
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class AuditServiceIT {
 

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
@@ -56,11 +56,6 @@ class AuditVariableEventsIT {
     @Autowired
     private MyProducer producer;
 
-    //    @BeforeEach
-    //    public void setUp() {
-    //        repository.deleteAll();
-    //    }
-
     @AfterEach
     public void cleanUp() {
         repository.deleteAll();

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
@@ -31,24 +31,20 @@ import org.activiti.cloud.api.model.shared.impl.events.CloudVariableDeletedEvent
 import org.activiti.cloud.api.model.shared.impl.events.CloudVariableUpdatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starters.test.MyProducer;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(EventsRestTemplate.class)
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
-@DirtiesContext
+@Import({ EventsRestTemplate.class, TestChannelBinderConfiguration.class })
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 class AuditVariableEventsIT {
 
     @Autowired
@@ -60,8 +56,13 @@ class AuditVariableEventsIT {
     @Autowired
     private MyProducer producer;
 
-    @BeforeEach
-    public void setUp() {
+//    @BeforeEach
+//    public void setUp() {
+//        repository.deleteAll();
+//    }
+
+    @AfterEach
+    public void cleanUp() {
         repository.deleteAll();
     }
 

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditVariableEventsIT.java
@@ -56,10 +56,10 @@ class AuditVariableEventsIT {
     @Autowired
     private MyProducer producer;
 
-//    @BeforeEach
-//    public void setUp() {
-//        repository.deleteAll();
-//    }
+    //    @BeforeEach
+    //    public void setUp() {
+    //        repository.deleteAll();
+    //    }
 
     @AfterEach
     public void cleanUp() {

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerIT.java
@@ -27,22 +27,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 public class AuditSwaggerIT {
 
     @Autowired

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/swagger/AuditSwaggerITSupport.java
@@ -23,22 +23,20 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.File;
 import java.nio.file.Files;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
-@DirtiesContext
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 public class AuditSwaggerITSupport {
 
     @Autowired

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/src/test/java/org/activiti/cloud/connectors/starter/test/it/ActivitiCloudConnectorServiceIT.java
@@ -27,23 +27,21 @@ import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.connectors.starter.ActivitiCloudConnectorApp;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ActivitiCloudConnectorApp.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 @ActiveProfiles(ConnectorsITStreamHandlers.CONNECTOR_IT)
-@ContextConfiguration(initializers = RabbitMQContainerApplicationInitializer.class)
+@Import(TestChannelBinderConfiguration.class)
 public class ActivitiCloudConnectorServiceIT {
 
     private static final String INTEGRATION_CONTEXT_ID = "integrationContextId";

--- a/activiti-cloud-examples/activiti-cloud-identity-adapter/src/test/java/org/activiti/cloud/identity/adapter/IdentityAdapterApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-identity-adapter/src/test/java/org/activiti/cloud/identity/adapter/IdentityAdapterApplicationIT.java
@@ -17,20 +17,17 @@ package org.activiti.cloud.identity.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.identity.adapter.IdentityAdapterApplication;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Test for modeling rest services
  */
 @SpringBootTest(classes = { IdentityAdapterApplication.class })
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class IdentityAdapterApplicationIT {
 

--- a/activiti-cloud-examples/activiti-cloud-identity-adapter/src/test/java/org/activiti/cloud/identity/adapter/KeycloakManagementControllerIT.java
+++ b/activiti-cloud-examples/activiti-cloud-identity-adapter/src/test/java/org/activiti/cloud/identity/adapter/KeycloakManagementControllerIT.java
@@ -15,13 +15,10 @@
  */
 package org.activiti.cloud.identity.adapter;
 
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
-
 import org.activiti.cloud.identity.web.controller.AbstractIdentityManagementControllerIT;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -29,7 +26,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ActiveProfiles("test")
 @SpringBootTest(classes = { IdentityAdapterApplication.class, IdentityAdapterAuthenticationTestConfiguration.class })
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @WithMockUser
 class KeycloakManagementControllerIT extends AbstractIdentityManagementControllerIT {}

--- a/activiti-cloud-examples/activiti-cloud-modeling/src/test/java/org/activiti/cloud/modeling/ModelingApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-modeling/src/test/java/org/activiti/cloud/modeling/ModelingApplicationIT.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -34,7 +33,6 @@ import org.springframework.web.context.WebApplicationContext;
  * Test for modeling rest services
  */
 @SpringBootTest(classes = ModelingApplication.class)
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class ModelingApplicationIT {
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -22,11 +22,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest(classes = RuntimeBundleApplication.class)
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class RuntimeBundleApplicationIT {
 

--- a/activiti-cloud-messages-service/integration-tests/pom.xml
+++ b/activiti-cloud-messages-service/integration-tests/pom.xml
@@ -18,10 +18,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-stream</artifactId>
-      <type>test-jar</type>
+      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
-      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-messages-service/integration-tests/pom.xml
+++ b/activiti-cloud-messages-service/integration-tests/pom.xml
@@ -18,8 +18,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
+      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -18,7 +18,10 @@ package org.activiti.cloud.messages.integration.tests.events;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,9 +39,12 @@ import org.activiti.api.process.model.results.ProcessInstanceResult;
 import org.activiti.cloud.services.core.commands.CommandEndpoint;
 import org.activiti.cloud.services.core.commands.ReceiveMessageCmdExecutor;
 import org.activiti.cloud.services.core.commands.StartMessageCmdExecutor;
-import org.activiti.cloud.services.messages.events.producer.*;
+import org.activiti.cloud.services.messages.events.producer.BpmnMessageReceivedEventMessageProducer;
+import org.activiti.cloud.services.messages.events.producer.BpmnMessageSentEventMessageProducer;
+import org.activiti.cloud.services.messages.events.producer.BpmnMessageWaitingEventMessageProducer;
+import org.activiti.cloud.services.messages.events.producer.MessageSubscriptionCancelledEventMessageProducer;
+import org.activiti.cloud.services.messages.events.producer.StartMessageDeployedEventMessageProducer;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundle;
 import org.activiti.engine.RuntimeService;
 import org.awaitility.Durations;
@@ -51,6 +57,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -58,20 +66,17 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "spring.datasource.platform=postgresql",
-        "activiti.cloud.application.name=messages-app",
-        "spring.application.name=rb",
-        "spring.jmx.enabled=false",
-    }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.datasource.platform=postgresql",
+                "activiti.cloud.application.name=messages-app",
+                "spring.application.name=rb",
+                "spring.jmx.enabled=false",
+        })
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -66,13 +66,15 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {
-                "spring.datasource.platform=postgresql",
-                "activiti.cloud.application.name=messages-app",
-                "spring.application.name=rb",
-                "spring.jmx.enabled=false",
-        })
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.datasource.platform=postgresql",
+        "activiti.cloud.application.name=messages-app",
+        "spring.application.name=rb",
+        "spring.jmx.enabled=false",
+    }
+)
 @DirtiesContext
 @Testcontainers
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -45,6 +45,7 @@ import org.activiti.cloud.services.messages.events.producer.BpmnMessageWaitingEv
 import org.activiti.cloud.services.messages.events.producer.MessageSubscriptionCancelledEventMessageProducer;
 import org.activiti.cloud.services.messages.events.producer.StartMessageDeployedEventMessageProducer;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundle;
 import org.activiti.engine.RuntimeService;
 import org.awaitility.Durations;
@@ -57,8 +58,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -77,8 +76,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 )
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
+                                      KeycloakContainerApplicationInitializer.class})
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -76,8 +76,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 )
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
-                                      KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
@@ -90,9 +90,11 @@ import reactor.netty.http.client.WebsocketClientSpec;
 import reactor.netty.http.websocket.WebsocketOutbound;
 import reactor.test.StepVerifier;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = {GrapqhQLApplication.class})
-@ContextConfiguration(classes = EngineEventsConfiguration.class,
-        initializers = { KeycloakContainerApplicationInitializer.class})
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { GrapqhQLApplication.class })
+@ContextConfiguration(
+    classes = EngineEventsConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ActivitiGraphQLStarterIT {
 

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
@@ -63,7 +63,6 @@ import org.activiti.cloud.services.notifications.graphql.ws.api.GraphQLMessage;
 import org.activiti.cloud.services.notifications.graphql.ws.api.GraphQLMessageType;
 import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.apache.groovy.util.Maps;
 import org.assertj.core.util.Arrays;
@@ -74,6 +73,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -89,11 +90,10 @@ import reactor.netty.http.client.WebsocketClientSpec;
 import reactor.netty.http.websocket.WebsocketOutbound;
 import reactor.test.StepVerifier;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = { GrapqhQLApplication.class })
-@ContextConfiguration(
-    classes = EngineEventsConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = {GrapqhQLApplication.class})
+@ContextConfiguration(classes = EngineEventsConfiguration.class,
+        initializers = { KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ActivitiGraphQLStarterIT {
 
     private static final String WS_GRAPHQL_URI = "/ws/graphql";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/pom.xml
@@ -92,8 +92,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
+      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
@@ -29,7 +29,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessDefinitionReposit
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.test.ProcessDefinitionAdminRestTemplate;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -48,10 +48,11 @@ import org.springframework.util.StreamUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({ ProcessDefinitionAdminRestTemplate.class })
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@Import({
+    ProcessDefinitionAdminRestTemplate.class,
+    TestChannelBinderConfiguration.class
+})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class QueryAdminProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
@@ -48,11 +48,8 @@ import org.springframework.util.StreamUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({
-    ProcessDefinitionAdminRestTemplate.class,
-    TestChannelBinderConfiguration.class
-})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import({ ProcessDefinitionAdminRestTemplate.class, TestChannelBinderConfiguration.class })
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryAdminProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
@@ -63,7 +63,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessDiagramIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
@@ -40,7 +40,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessDefinitionReposit
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -51,6 +50,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -62,9 +63,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessDiagramIT {
 
     private static final String PROC_URL = "/admin/v1/process-instances";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -57,7 +57,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepositor
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.model.StringUtils;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -68,6 +67,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -80,9 +81,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessServiceTasksIT {
 
     private static final String ERROR_MESSAGE =

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -81,7 +81,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessServiceTasksIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
@@ -54,7 +54,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminVariablesIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
@@ -28,7 +28,6 @@ import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.query.model.TaskVariableEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -41,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -53,9 +54,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryAdminVariablesIT {
 
     private static final String ADMIN_PROCESS_VARIABLES_URL =

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
@@ -28,7 +28,6 @@ import org.activiti.cloud.api.process.model.impl.events.CloudApplicationDeployed
 import org.activiti.cloud.services.query.app.repository.ApplicationRepository;
 import org.activiti.cloud.services.query.model.ApplicationEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +35,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -48,9 +49,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryApplicationEntityIT {
 
     private static final String APPS_URL = "/v1/applications";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
@@ -49,7 +49,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryApplicationEntityIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -73,7 +73,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryBPMNActivityIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -51,7 +51,6 @@ import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ServiceTaskEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -63,6 +62,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -72,9 +73,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryBPMNActivityIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
@@ -30,7 +30,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessDefinitionReposit
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.test.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.junit.jupiter.api.AfterEach;
@@ -38,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -48,10 +48,11 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({ ProcessDefinitionRestTemplate.class })
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@Import({
+    ProcessDefinitionRestTemplate.class,
+    TestChannelBinderConfiguration.class
+})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class QueryProcessDefinitionCandidateStartersIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
@@ -48,11 +48,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({
-    ProcessDefinitionRestTemplate.class,
-    TestChannelBinderConfiguration.class
-})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import({ ProcessDefinitionRestTemplate.class, TestChannelBinderConfiguration.class })
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryProcessDefinitionCandidateStartersIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
@@ -50,11 +50,8 @@ import org.springframework.util.StreamUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({
-    ProcessDefinitionRestTemplate.class,
-    TestChannelBinderConfiguration.class
-})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import({ ProcessDefinitionRestTemplate.class, TestChannelBinderConfiguration.class })
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryProcessDefinitionIT {
 
     public static final String TEST_CATEGORY = "Test category";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
@@ -31,7 +31,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessDefinitionReposit
 import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.test.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -50,10 +50,11 @@ import org.springframework.util.StreamUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({ ProcessDefinitionRestTemplate.class })
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@Import({
+    ProcessDefinitionRestTemplate.class,
+    TestChannelBinderConfiguration.class
+})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class QueryProcessDefinitionIT {
 
     public static final String TEST_CATEGORY = "Test category";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
@@ -43,7 +43,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessModelRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -54,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,9 +65,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryProcessDiagramIT {
 
     private static final String PROC_URL = "/v1/process-instances";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
@@ -65,7 +65,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessDiagramIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
@@ -24,7 +24,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepositor
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -36,6 +35,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -48,9 +49,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstanceEntityVariablesIT {
 
     private static final String VARIABLES_URL = "/v1/process-instances/{processInstanceId}/variables";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
@@ -49,7 +49,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstanceEntityVariablesIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -43,7 +43,6 @@ import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepositor
 import org.activiti.cloud.services.query.model.AbstractVariableEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -59,6 +58,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -71,9 +72,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstancesEntityIT {
 
     private static final String PROC_URL = "/v1/process-instances";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -72,7 +72,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstancesEntityIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
@@ -62,7 +62,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryTaskEntityVariablesIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
@@ -36,7 +36,6 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.model.TaskVariableEntity;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -49,6 +48,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -61,9 +62,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryTaskEntityVariablesIT {
 
     private static final String VARIABLES_URL = "/v1/tasks/{taskId}/variables";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -56,7 +56,6 @@ import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starters.test.EventsAggregator;
 import org.activiti.cloud.starters.test.MyProducer;
@@ -69,6 +68,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -82,9 +83,8 @@ import org.springframework.util.CollectionUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QueryTasksIT {
 
     private static final String TASKS_URL = "/v1/tasks";

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -83,7 +83,7 @@ import org.springframework.util.CollectionUtils;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryTasksIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -46,7 +46,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QuerySwaggerIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerIT.java
@@ -31,11 +31,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -45,9 +46,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QuerySwaggerIT {
 
     @Autowired

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
@@ -37,7 +37,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @DirtiesContext
 @AutoConfigureMockMvc
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QuerySwaggerITSupport {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/swagger/QuerySwaggerITSupport.java
@@ -23,11 +23,12 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.File;
 import java.nio.file.Files;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,9 +37,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @DirtiesContext
 @AutoConfigureMockMvc
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class QuerySwaggerITSupport {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -44,7 +44,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -53,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
@@ -70,17 +70,12 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import(
-    {
-        CommandEndPointITStreamHandler.class,
-        ProcessInstanceRestTemplate.class,
-        TaskRestTemplate.class,
-        MessageClientStreamConfiguration.class,
-    }
-)
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@Import({CommandEndPointITStreamHandler.class,
+    ProcessInstanceRestTemplate.class,
+    TaskRestTemplate.class,
+    MessageClientStreamConfiguration.class,
+    TestChannelBinderConfiguration.class})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class CommandEndpointIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -70,12 +70,16 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@Import({CommandEndPointITStreamHandler.class,
-    ProcessInstanceRestTemplate.class,
-    TaskRestTemplate.class,
-    MessageClientStreamConfiguration.class,
-    TestChannelBinderConfiguration.class})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(
+    {
+        CommandEndPointITStreamHandler.class,
+        ProcessInstanceRestTemplate.class,
+        TaskRestTemplate.class,
+        MessageClientStreamConfiguration.class,
+        TestChannelBinderConfiguration.class,
+    }
+)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class CommandEndpointIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -34,20 +34,24 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-                properties = {"ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
-                              "ACT_MESSAGING_DEST_SEPARATOR=.",
-                              "ACT_MESSAGING_DEST_PREFIX=namespace",
-                              "ACT_RB_ENG_EVT_DEST=engine-events",
-                              "ACT_RB_SIG_EVT_DEST=signal-event",
-                              "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
-                              "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
-                              "ACT_RB_MSG_EVT_DEST=message-events",
-                              "ACT_RB_CMD_RES_DEST=command-results",
-                              "ACT_INT_RES_CONSUMER=integration-result",
-                              "ACT_INT_ERR_CONSUMER:integration-error"})
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
+        "ACT_MESSAGING_DEST_SEPARATOR=.",
+        "ACT_MESSAGING_DEST_PREFIX=namespace",
+        "ACT_RB_ENG_EVT_DEST=engine-events",
+        "ACT_RB_SIG_EVT_DEST=signal-event",
+        "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
+        "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
+        "ACT_RB_MSG_EVT_DEST=message-events",
+        "ACT_RB_CMD_RES_DEST=command-results",
+        "ACT_INT_RES_CONSUMER=integration-result",
+        "ACT_INT_ERR_CONSUMER:integration-error",
+    }
+)
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class EngineConfigurationIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -15,43 +15,40 @@
  */
 package org.activiti.cloud.starter.tests.conf;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.AbstractMap;
 import java.util.Map;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
 import org.activiti.runtime.api.impl.MappingAwareActivityBehaviorFactory;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
-        "ACT_MESSAGING_DEST_SEPARATOR=.",
-        "ACT_MESSAGING_DEST_PREFIX=namespace",
-        "ACT_RB_ENG_EVT_DEST=engine-events",
-        "ACT_RB_SIG_EVT_DEST=signal-event",
-        "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
-        "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
-        "ACT_RB_MSG_EVT_DEST=message-events",
-        "ACT_RB_CMD_RES_DEST=command-results",
-        "ACT_INT_RES_CONSUMER=integration-result",
-        "ACT_INT_ERR_CONSUMER:integration-error",
-    }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+                properties = {"ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
+                              "ACT_MESSAGING_DEST_SEPARATOR=.",
+                              "ACT_MESSAGING_DEST_PREFIX=namespace",
+                              "ACT_RB_ENG_EVT_DEST=engine-events",
+                              "ACT_RB_SIG_EVT_DEST=signal-event",
+                              "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
+                              "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
+                              "ACT_RB_MSG_EVT_DEST=message-events",
+                              "ACT_RB_CMD_RES_DEST=command-results",
+                              "ACT_INT_RES_CONSUMER=integration-result",
+                              "ACT_INT_ERR_CONSUMER:integration-error"})
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class EngineConfigurationIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
@@ -34,11 +34,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(
-    properties = {"spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/"},
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+    properties = { "spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/" },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class NeverFailDeploymentStrategyIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
@@ -20,12 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.runtime.RuntimeITConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -33,14 +34,12 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(
-    properties = { "spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/" },
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+    properties = {"spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/"},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class NeverFailDeploymentStrategyIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -28,7 +28,6 @@ import org.activiti.bpmn.model.FlowElement;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.services.api.model.ProcessDefinitionMeta;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.util.TestResourceUtil;
 import org.activiti.editor.language.json.converter.BpmnJsonConverter;
@@ -38,6 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpEntity;
@@ -52,9 +53,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -21,12 +21,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,8 +35,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
+    KeycloakContainerApplicationInitializer.class})
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -21,11 +21,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,9 +36,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class ActuatorHealthIndicatorsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -35,8 +35,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
-    KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -33,7 +33,6 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -46,7 +45,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -56,10 +57,9 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -57,8 +57,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public abstract class AbstractMQServiceTaskIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -56,9 +56,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {RabbitMQContainerApplicationInitializer.class,
-        KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -33,6 +33,7 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -45,9 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -57,11 +56,9 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {RabbitMQContainerApplicationInitializer.class,
+        KeycloakContainerApplicationInitializer.class})
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -102,10 +102,14 @@ import org.springframework.transaction.support.TransactionTemplate;
     }
 )
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class,
-    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class,
-    TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = {
+        RuntimeITConfiguration.class,
+        JobExecutorIT.JobExecutorITProcessEngineConfigurer.class,
+        TestChannelBinderConfiguration.class,
+    },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class JobExecutorIT {
 
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -79,6 +79,7 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
@@ -102,14 +103,10 @@ import org.springframework.transaction.support.TransactionTemplate;
     }
 )
 @DirtiesContext
-@ContextConfiguration(
-    classes = {
-        RuntimeITConfiguration.class,
-        JobExecutorIT.JobExecutorITProcessEngineConfigurer.class,
-        TestChannelBinderConfiguration.class,
-    },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class,
+    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class JobExecutorIT {
 
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -103,9 +103,10 @@ import org.springframework.transaction.support.TransactionTemplate;
     }
 )
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class,
-    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class JobExecutorIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -43,7 +43,6 @@ import org.activiti.cloud.services.job.executor.JobMessageProducer;
 import org.activiti.cloud.services.job.executor.JobMessageSentEvent;
 import org.activiti.cloud.services.job.executor.MessageBasedJobManager;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.ProcessEngineConfiguration;
@@ -73,6 +72,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationEvent;
@@ -102,10 +102,10 @@ import org.springframework.transaction.support.TransactionTemplate;
     }
 )
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class,
+    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class,
+    TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class JobExecutorIT {
 
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -51,7 +51,6 @@ import org.activiti.cloud.services.messages.events.producer.BpmnMessageWaitingEv
 import org.activiti.cloud.services.messages.events.producer.MessageSubscriptionCancelledEventMessageProducer;
 import org.activiti.cloud.services.messages.events.producer.StartMessageDeployedEventMessageProducer;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.engine.RuntimeService;
 import org.awaitility.Durations;
@@ -79,10 +78,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class },
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class,
+    TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -78,14 +78,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = {
-        RuntimeITConfiguration.class,
-        MessageEventsIT.TestConfigurationContext.class,
-        TestChannelBinderConfiguration.class,
-    },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -78,8 +78,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -78,9 +78,14 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class,
-    TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = {
+        RuntimeITConfiguration.class,
+        MessageEventsIT.TestConfigurationContext.class,
+        TestChannelBinderConfiguration.class,
+    },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -38,10 +39,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class MessageIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -39,8 +39,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -22,13 +22,13 @@ import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.MessageRestTemplate;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -38,10 +38,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class MessageIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -38,8 +38,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class MessageIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,10 +40,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -40,8 +40,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -22,13 +22,13 @@ import java.util.Map;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,10 +39,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -39,8 +39,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ProcessDefinitionIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -49,6 +49,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,10 +60,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ProcessInstanceIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -59,8 +59,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ProcessInstanceIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -60,8 +60,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessInstanceIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -37,7 +37,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,10 +59,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ProcessInstanceIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
@@ -71,10 +72,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ProcessVariablesIT {
 
     private static final String LONG = "long";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -72,8 +72,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -49,7 +49,6 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.api.model.ProcessVariableValue;
 import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.MessageRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
@@ -60,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
@@ -71,10 +71,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ProcessVariablesIT {
 
     private static final String LONG = "long";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -71,8 +71,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ProcessVariablesIT {
 
     private static final String LONG = "long";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -33,7 +33,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.SignalRestTemplate;
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -53,10 +53,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class SignalIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -54,8 +54,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class SignalIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -53,8 +53,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class SignalIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -53,10 +54,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class SignalIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -50,10 +51,9 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class TaskVariableMappingIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -51,8 +51,10 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariableMappingIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -30,7 +30,6 @@ import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -40,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -50,10 +50,8 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class TaskVariableMappingIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -50,8 +50,10 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class TaskVariableMappingIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -29,7 +29,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.definition.ProcessDefinitionIT;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
@@ -40,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
@@ -53,10 +53,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class TaskVariablesIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
@@ -53,10 +54,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class TaskVariablesIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -53,8 +53,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class TaskVariablesIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -54,8 +54,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
@@ -63,10 +64,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class TasksIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -41,7 +41,6 @@ import org.activiti.cloud.api.process.model.impl.CandidateGroup;
 import org.activiti.cloud.api.process.model.impl.CandidateUser;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
@@ -51,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
@@ -63,10 +63,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class TasksIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -64,8 +64,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TasksIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -63,8 +63,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
 @DirtiesContext
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class TasksIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -125,8 +125,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class AuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -124,8 +124,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class AuditProducerIT {
 
     private static final int VERSION_1 = 1;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -97,7 +97,6 @@ import org.activiti.cloud.api.task.model.events.CloudTaskCancelledEvent;
 import org.activiti.cloud.api.task.model.events.CloudTaskCandidateUserRemovedEvent;
 import org.activiti.cloud.api.task.model.events.CloudTaskCreatedEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
 import org.activiti.engine.RepositoryService;
@@ -108,6 +107,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -124,10 +124,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class AuditProducerIT {
 
     private static final int VERSION_1 = 1;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -108,6 +108,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
@@ -124,10 +125,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class AuditProducerIT {
 
     private static final int VERSION_1 = 1;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -73,8 +73,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ConnectorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -72,8 +72,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ConnectorAuditProducerIT {
 
     private static final String ROUTING_KEY_HEADER = "routingKey";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -52,7 +52,6 @@ import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +59,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.support.MessageBuilder;
@@ -72,10 +72,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ConnectorAuditProducerIT {
 
     private static final String ROUTING_KEY_HEADER = "routingKey";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -61,6 +61,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
@@ -72,10 +73,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ConnectorAuditProducerIT {
 
     private static final String ROUTING_KEY_HEADER = "routingKey";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -67,6 +67,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -81,10 +82,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -82,8 +82,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -81,8 +81,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class EmbeddedSubProcessAuditIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -56,7 +56,6 @@ import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.api.task.model.events.CloudTaskAssignedEvent;
 import org.activiti.cloud.api.task.model.events.CloudTaskCreatedEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.SignalRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -67,6 +66,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -81,10 +81,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class EmbeddedSubProcessAuditIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -49,10 +50,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ErrorAuditProducerIT {
 
     private static final String ERROR_START_EVENT_SUBPROCESS = "errorStartEventSubProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -49,8 +49,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ErrorAuditProducerIT {
 
     private static final String ERROR_START_EVENT_SUBPROCESS = "errorStartEventSubProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -32,12 +32,12 @@ import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.events.CloudBPMNErrorReceivedEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -49,10 +49,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ErrorAuditProducerIT {
 
     private static final String ERROR_START_EVENT_SUBPROCESS = "errorStartEventSubProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -50,8 +50,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ErrorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -75,8 +75,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -60,6 +60,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -74,10 +75,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 
     private static final String EXCLUSIVE_GATEWAY_PROCESS = "basicExclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -19,16 +19,26 @@ import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.V
 import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_UPDATED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
-import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.*;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_CREATED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_UPDATED;
 import static org.activiti.api.process.model.events.SequenceFlowEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN;
 import static org.activiti.api.task.model.events.TaskCandidateUserEvent.TaskCandidateUserEvents.TASK_CANDIDATE_USER_ADDED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.*;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_COMPLETED;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_CREATED;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_UPDATED;
 import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.ALL_REQUIRED_HEADERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
@@ -41,7 +51,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -50,6 +59,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -64,10 +74,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class ExclusiveGatewayAuditProducerIT {
 
     private static final String EXCLUSIVE_GATEWAY_PROCESS = "basicExclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -74,8 +74,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class ExclusiveGatewayAuditProducerIT {
 
     private static final String EXCLUSIVE_GATEWAY_PROCESS = "basicExclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -52,6 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -66,10 +67,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 
     private static final String INCLUSIVE_GATEWAY_PROCESS = "basicInclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -67,8 +67,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -66,8 +66,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class InclusiveGatewayAuditProducerIT {
 
     private static final String INCLUSIVE_GATEWAY_PROCESS = "basicInclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -43,7 +43,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -52,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
@@ -66,10 +66,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class InclusiveGatewayAuditProducerIT {
 
     private static final String INCLUSIVE_GATEWAY_PROCESS = "basicInclusiveGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -37,7 +37,6 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.events.CloudBPMNMessageEvent;
 import org.activiti.cloud.api.process.model.events.CloudMessageSubscriptionCancelledEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.MessageRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.apache.groovy.util.Maps;
@@ -45,6 +44,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -56,10 +57,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 public class MessageAuditProducerIT {
 
     private static final String CATCH_MESSAGE = "catchMessage";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -57,8 +57,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class })
+@ContextConfiguration(
+    classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -50,10 +51,10 @@ import org.springframework.test.context.TestPropertySource;
     properties = { "spring.activiti.asyncExecutorActivate=true" }
 )
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+                      initializers = {KeycloakContainerApplicationInitializer.class}
 )
+@Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verify;
 
 import org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -38,6 +37,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -50,9 +50,8 @@ import org.springframework.test.context.TestPropertySource;
     properties = { "spring.activiti.asyncExecutorActivate=true" }
 )
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+                      initializers = {KeycloakContainerApplicationInitializer.class}
 )
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -51,8 +51,9 @@ import org.springframework.test.context.TestPropertySource;
     properties = { "spring.activiti.asyncExecutorActivate=true" }
 )
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-                      initializers = {KeycloakContainerApplicationInitializer.class}
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
 )
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -50,8 +50,9 @@ import org.springframework.test.context.TestPropertySource;
     properties = { "spring.activiti.asyncExecutorActivate=true" }
 )
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-                      initializers = {KeycloakContainerApplicationInitializer.class}
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
 )
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -50,9 +50,9 @@ import org.springframework.test.context.TestPropertySource;
     properties = { "spring.activiti.asyncExecutorActivate=true" }
 )
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-                      initializers = {RabbitMQContainerApplicationInitializer.class,
-                          KeycloakContainerApplicationInitializer.class}
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
 )
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -32,11 +32,12 @@ import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -47,10 +48,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 
     private static final String PARALLEL_GATEWAY_PROCESS = "basicParallelGateway";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -48,8 +48,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -41,7 +41,6 @@ import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.events.CloudBPMNSignalReceivedEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.SignalRestTemplate;
@@ -50,6 +49,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -60,10 +60,8 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class SignalAuditProducerIT {
 
     private static final String SIGNAL_PROCESS = "broadcastSignalCatchEventProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -61,8 +61,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class SignalAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -60,8 +60,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class SignalAuditProducerIT {
 
     private static final String SIGNAL_PROCESS = "broadcastSignalCatchEventProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -60,10 +61,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TestChannelBinderConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class SignalAuditProducerIT {
 
     private static final String SIGNAL_PROCESS = "broadcastSignalCatchEventProcess";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -54,6 +54,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -65,14 +66,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = {
-        ServicesAuditITConfiguration.class,
-        TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class,
-        TestChannelBinderConfiguration.class,
-    },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
+    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -66,9 +66,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
-    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TimerAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -37,7 +37,6 @@ import org.activiti.cloud.api.process.model.events.CloudBPMNTimerExecutedEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNTimerFiredEvent;
 import org.activiti.cloud.api.process.model.events.CloudBPMNTimerScheduledEvent;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ProcessEngineConfiguration;
@@ -54,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -65,10 +65,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class },
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
+    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class,
+    TestChannelBinderConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -65,10 +65,14 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
-    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class,
-    TestChannelBinderConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = {
+        ServicesAuditITConfiguration.class,
+        TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class,
+        TestChannelBinderConfiguration.class,
+    },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class RuntimeBundleSwaggerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -27,13 +27,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.spring.ProcessDeployedEventProducer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -42,9 +43,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class RuntimeBundleSwaggerIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
@@ -37,7 +37,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 class RuntimeBundleSwaggerITSupport {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerITSupport.java
@@ -23,22 +23,22 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.File;
 import java.nio.file.Files;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.spring.ProcessDeployedEventProducer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 class RuntimeBundleSwaggerITSupport {
 
     @Autowired


### PR DESCRIPTION
This PR closes Activiti/Activiti#4279 replacing `RabbitMQContainerApplicationInitializer` with `TestChannelBinderConfiguration` when possible.
Since reuse of test containers is not allowed without manual control of the container lifecycle, this PR is going to reduce the execution time of the tests that depend from a `spring-cloud` binder.