### PR TITLE
Reuse contexts in integration tests

### DIFF
--- a/activiti-cloud-messages-service/integration-tests/pom.xml
+++ b/activiti-cloud-messages-service/integration-tests/pom.xml
@@ -18,10 +18,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-stream</artifactId>
-      <type>test-jar</type>
+      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
-      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-messages-service/integration-tests/pom.xml
+++ b/activiti-cloud-messages-service/integration-tests/pom.xml
@@ -18,8 +18,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
+      <classifier>test-binder</classifier>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -66,13 +66,15 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {
-                "spring.datasource.platform=postgresql",
-                "activiti.cloud.application.name=messages-app",
-                "spring.application.name=rb",
-                "spring.jmx.enabled=false",
-        })
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.datasource.platform=postgresql",
+        "activiti.cloud.application.name=messages-app",
+        "spring.application.name=rb",
+        "spring.jmx.enabled=false",
+    }
+)
 @DirtiesContext
 @Testcontainers
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -45,6 +45,7 @@ import org.activiti.cloud.services.messages.events.producer.BpmnMessageWaitingEv
 import org.activiti.cloud.services.messages.events.producer.MessageSubscriptionCancelledEventMessageProducer;
 import org.activiti.cloud.services.messages.events.producer.StartMessageDeployedEventMessageProducer;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundle;
 import org.activiti.engine.RuntimeService;
 import org.awaitility.Durations;
@@ -57,8 +58,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -77,8 +76,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 )
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
+                                      KeycloakContainerApplicationInitializer.class})
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -76,8 +76,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 )
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
-                                      KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/events/MessageEventsIT.java
@@ -45,7 +45,6 @@ import org.activiti.cloud.services.messages.events.producer.BpmnMessageWaitingEv
 import org.activiti.cloud.services.messages.events.producer.MessageSubscriptionCancelledEventMessageProducer;
 import org.activiti.cloud.services.messages.events.producer.StartMessageDeployedEventMessageProducer;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundle;
 import org.activiti.engine.RuntimeService;
 import org.awaitility.Durations;
@@ -58,6 +57,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -65,20 +66,17 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "spring.datasource.platform=postgresql",
-        "activiti.cloud.application.name=messages-app",
-        "spring.application.name=rb",
-        "spring.jmx.enabled=false",
-    }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "spring.datasource.platform=postgresql",
+                "activiti.cloud.application.name=messages-app",
+                "spring.application.name=rb",
+                "spring.jmx.enabled=false",
+        })
 @DirtiesContext
 @Testcontainers
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(TestChannelBinderConfiguration.class)
 class MessageEventsIT {
 
     @Container

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/audit/AuditorAwareIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/audit/AuditorAwareIT.java
@@ -26,10 +26,8 @@ import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest(classes = ModelingJpaApplication.class)
-@DirtiesContext
 public class AuditorAwareIT {
 
     @Autowired

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorModelControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorModelControllerIT.java
@@ -19,7 +19,6 @@ import static org.activiti.cloud.services.modeling.asserts.AssertResponse.assert
 import static org.activiti.cloud.services.modeling.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.modeling.mock.MockFactory.project;
 import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,17 +31,18 @@ import org.activiti.cloud.modeling.repository.ModelRepository;
 import org.activiti.cloud.modeling.repository.ProjectRepository;
 import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -50,8 +50,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles("test")
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @WithMockModelerUser
 public class ConnectorModelControllerIT {
 
@@ -72,14 +72,30 @@ public class ConnectorModelControllerIT {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
+    private Project project;
+    private Model connectorModel;
+
     @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        project = null;
+        connectorModel = null;
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        if (connectorModel != null) {
+            modelRepository.deleteModel(connectorModel);
+        }
+
+        if (project != null) {
+            projectRepository.deleteProject(project);
+        }
     }
 
     @Test
     public void should_returnStatusCreatedAndConnectorName_when_creatingConnectorModel() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         mockMvc
             .perform(
@@ -93,7 +109,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_throwRequiredFieldException_when_creatingConnectorWithNameNull() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         ResultActions resultActions = mockMvc.perform(
             post("/v1/projects/{projectId}/models", project.getId())
@@ -110,7 +126,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_throwEmptyFieldException_when_creatingConnectorModelWithNameEmpty() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         ResultActions resultActions = mockMvc.perform(
             post("/v1/projects/{projectId}/models", project.getId())
@@ -127,7 +143,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_throwTooLongNameException_when_createConnectorModelWithNameTooLong() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         ResultActions resultActions = mockMvc.perform(
             post("/v1/projects/{projectId}/models", project.getId())
@@ -146,7 +162,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_create_when_creatingConnectorModelWithNameWithUnderscore() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         ResultActions resultActions = mockMvc.perform(
             post("/v1/projects/{projectId}/models", project.getId())
@@ -159,7 +175,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_create_when_creatingConnectorModelWithNameWithUppercase() throws Exception {
-        Project project = projectRepository.createProject(project("project-with-connectors"));
+        project = projectRepository.createProject(project("project-with-connectors"));
 
         ResultActions resultActions = mockMvc.perform(
             post("/v1/projects/{projectId}/models", project.getId())
@@ -172,7 +188,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_returnStatusOKAndConnectorName_when_updatingConnectorModel() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         mockMvc
             .perform(
@@ -186,7 +202,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_returnStatusOKAndConnectorName_when_updatingConnectorModelWithNameNull() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         mockMvc
             .perform(
@@ -200,7 +216,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_throwEmptyNameException_when_updatingConnectorModelWithNameEmpty() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         ResultActions resultActions = mockMvc.perform(
             put("/v1/models/{modelId}", connectorModel.getId())
@@ -217,7 +233,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_throwBadNameException_when_updatingConnectorModelWithNameTooLong() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         ResultActions resultActions = mockMvc.perform(
             put("/v1/models/{modelId}", connectorModel.getId())
@@ -236,7 +252,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_update_when_updatingConnectorModelWithNameWithUnderscore() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         ResultActions resultActions = mockMvc.perform(
             put("/v1/models/{modelId}", connectorModel.getId())
@@ -249,7 +265,7 @@ public class ConnectorModelControllerIT {
 
     @Test
     public void should_update_when_updatingConnectorModelWithNameWithUppercase() throws Exception {
-        Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
 
         ResultActions resultActions = mockMvc.perform(
             put("/v1/models/{modelId}", connectorModel.getId())

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ConnectorValidationControllerIT.java
@@ -23,7 +23,6 @@ import static org.activiti.cloud.services.modeling.asserts.AssertResponse.assert
 import static org.activiti.cloud.services.modeling.mock.MockFactory.connectorModel;
 import static org.activiti.cloud.services.modeling.validation.DNSNameValidator.DNS_LABEL_REGEX;
 import static org.hamcrest.Matchers.isEmptyString;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
@@ -31,13 +30,14 @@ import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.repository.ModelRepository;
 import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -45,8 +45,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles("test")
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @WithMockModelerUser
 public class ConnectorValidationControllerIT {
 
@@ -56,15 +56,21 @@ public class ConnectorValidationControllerIT {
     @Autowired
     private ModelRepository modelRepository;
 
+    private Model connectorModel;
+
     @BeforeEach
     public void setUp() {
         webAppContextSetup(context);
+        connectorModel = modelRepository.createModel(connectorModel("connector-name"));
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        modelRepository.deleteModel(connectorModel);
     }
 
     @Test
     public void should_returnStatusNoContent_when_validatingSimpleConnector() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",
@@ -80,8 +86,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_returnStatusNoContent_when_validatingConnectorTextContentType() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",
@@ -97,8 +101,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_returnStatusNoContent_when_validatingConnectorWithEvents() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",
@@ -114,8 +116,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidSimpleConnector() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -140,8 +140,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_throwSyntacticValidationException_when_validatingJsonInvalidConnector() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -163,8 +161,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_throwSyntacticValidationException_when_validatingInvalidConnectorTextContentType()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -186,8 +182,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidConnectorNameTooLong()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -209,8 +203,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidConnectorNameEmpty() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -233,8 +225,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidConnectorNameWithUnderscore()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -254,8 +244,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidConnectorNameWithUppercase()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -275,8 +263,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_returnStatusNoContent_when_validatingConnectorWithCustomTypesInEventsAndActions()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",
@@ -292,8 +278,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_returnStatusNoContent_when_validatingConnectorWithErrors() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",
@@ -310,8 +294,6 @@ public class ConnectorValidationControllerIT {
     @Test
     public void should_throwSemanticValidationException_when_validatingInvalidConnectorErrorInvalidProperty()
         throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         assertThatResponse(
             given()
                 .multiPart(
@@ -330,8 +312,6 @@ public class ConnectorValidationControllerIT {
 
     @Test
     public void should_returnStatusNoContent_when_validatingConnectorEventWithModel() throws IOException {
-        final Model connectorModel = modelRepository.createModel(connectorModel("connector-name"));
-
         given()
             .multiPart(
                 "file",

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeContentUpdateListenerControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeContentUpdateListenerControllerIT.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
@@ -34,15 +33,16 @@ import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.entity.ModelEntity;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
 import org.activiti.cloud.services.modeling.service.utils.ModelExtensionsPrettyPrinter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -50,8 +50,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles(profiles = { "test", "generic" })
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @WithMockModelerUser
 public class GenericJsonModelTypeContentUpdateListenerControllerIT {
 
@@ -79,16 +79,24 @@ public class GenericJsonModelTypeContentUpdateListenerControllerIT {
 
     private static final String GENERIC_MODEL_NAME = "simple-model";
 
+    private Model genericJsonModel;
+
     @BeforeEach
     public void setUp() {
         this.mockMvc = webAppContextSetup(context).build();
+        genericJsonModel =
+            modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName()));
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        modelRepository.deleteModel(genericJsonModel);
     }
 
     @Test
     public void should_callJsonContentUpdateListener_when_updatingModelContent() throws Exception {
-        Model genericJsonModel = modelRepository.createModel(
-            new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName())
-        );
+        genericJsonModel =
+            modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName()));
 
         String stringModel = objectMapper.writer(jsonPrettyPrinter).writeValueAsString(genericJsonModel);
 
@@ -108,10 +116,6 @@ public class GenericJsonModelTypeContentUpdateListenerControllerIT {
 
     @Test
     public void should_notCallNonJsonContentUpdateListener_when_updatingModelContent() throws Exception {
-        Model genericJsonModel = modelRepository.createModel(
-            new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName())
-        );
-
         String stringModel = objectMapper.writer(jsonPrettyPrinter).writeValueAsString(genericJsonModel);
 
         mockMvc

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericJsonModelTypeValidationControllerIT.java
@@ -27,7 +27,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
@@ -43,14 +42,15 @@ import org.activiti.cloud.modeling.repository.ModelRepository;
 import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.entity.ModelEntity;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -58,8 +58,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles(profiles = { "test", "generic" })
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @WithMockModelerUser
 public class GenericJsonModelTypeValidationControllerIT {
 
@@ -87,6 +87,11 @@ public class GenericJsonModelTypeValidationControllerIT {
         webAppContextSetup(context);
         genericJsonModel =
             modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName()));
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        modelRepository.deleteModel(genericJsonModel);
     }
 
     private void validateInvalidContent() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/GenericNonJsonModelTypeValidationControllerIT.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
@@ -49,9 +48,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -59,8 +58,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles(profiles = { "test", "generic" })
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
-@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
 @WithMockModelerUser
 public class GenericNonJsonModelTypeValidationControllerIT {
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
@@ -78,6 +78,7 @@ import org.activiti.cloud.services.modeling.jpa.ModelJpaRepository;
 import org.activiti.cloud.services.modeling.jpa.ProjectJpaRepository;
 import org.activiti.cloud.services.modeling.mock.MockFactory;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -87,7 +88,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -97,7 +97,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = ModelingRestApplication.class)
 @WebAppConfiguration
-@DirtiesContext
 @WithMockModelerUser
 @Transactional
 public class ModelControllerIT {
@@ -125,6 +124,10 @@ public class ModelControllerIT {
     @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @AfterEach
+    public void cleanUp() {
         modelJpaRepository.deleteAll();
         projectJpaRepository.deleteAll();
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelUpdateListenerControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelUpdateListenerControllerIT.java
@@ -32,6 +32,7 @@ import org.activiti.cloud.modeling.repository.ModelRepository;
 import org.activiti.cloud.services.modeling.config.ModelingRestApplication;
 import org.activiti.cloud.services.modeling.entity.ModelEntity;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -48,6 +50,7 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @ActiveProfiles(profiles = { "test", "generic" })
 @SpringBootTest(classes = ModelingRestApplication.class)
+@Transactional
 @WebAppConfiguration
 @WithMockModelerUser
 public class ModelUpdateListenerControllerIT {
@@ -72,20 +75,25 @@ public class ModelUpdateListenerControllerIT {
 
     private MockMvc mockMvc;
 
+    private Model genericJsonModel;
+
     private static final String GENERIC_MODEL_NAME = "simple-model";
 
     @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(context).build();
+        genericJsonModel =
+            modelRepository.createModel(new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName()));
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        modelRepository.deleteModel(genericJsonModel);
     }
 
     @Test
     public void should_callUpdateListenerMatchingWithModelType_when_updatingModelContent() throws Exception {
         String name = "updated-model-name";
-        Model genericJsonModel = modelRepository.createModel(
-            new ModelEntity(GENERIC_MODEL_NAME, genericJsonModelType.getName())
-        );
-
         Model updatedModel = new ModelEntity(name, genericJsonModelType.getName());
 
         mockMvc

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
@@ -48,15 +48,16 @@ import org.activiti.cloud.services.modeling.jpa.ModelJpaRepository;
 import org.activiti.cloud.services.modeling.jpa.ProjectJpaRepository;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
 import org.activiti.cloud.services.modeling.service.api.ModelService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -64,8 +65,8 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @SpringBootTest(classes = ModelingRestApplication.class)
 @WebAppConfiguration
-@DirtiesContext
 @WithMockModelerUser
+@Transactional
 public class ModelValidationControllerIT {
 
     @Autowired
@@ -97,6 +98,10 @@ public class ModelValidationControllerIT {
     @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @AfterEach
+    public void cleanUp() {
         modelJpaRepository.deleteAll();
         projectJpaRepository.deleteAll();
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerExistingNameIT.java
@@ -45,6 +45,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Propagation;
@@ -53,7 +54,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = ModelingRestApplication.class)
 @WebAppConfiguration
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @Transactional
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ProjectControllerExistingNameIT {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ProjectControllerIT.java
@@ -68,6 +68,7 @@ import org.activiti.cloud.services.modeling.entity.ProjectEntity;
 import org.activiti.cloud.services.modeling.jpa.ModelJpaRepository;
 import org.activiti.cloud.services.modeling.security.WithMockModelerUser;
 import org.activiti.cloud.services.modeling.service.api.ModelService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +76,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -85,7 +85,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = ModelingRestApplication.class)
 @WebAppConfiguration
-@DirtiesContext
 @WithMockModelerUser
 @Transactional
 public class ProjectControllerIT {
@@ -116,6 +115,10 @@ public class ProjectControllerIT {
     @BeforeEach
     public void setUp() {
         mockMvc = webAppContextSetup(webApplicationContext).build();
+    }
+
+    @AfterEach
+    public void cleanUp() {
         modelJpaRepository.deleteAll();
         ((JpaRepository) projectRepository).deleteAll();
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/ApplicationTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/ApplicationTest.java
@@ -17,10 +17,8 @@ package org.activiti.cloud.starter.modeling;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest(classes = Application.class)
-@DirtiesContext
 public class ApplicationTest {
 
     @Test

--- a/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-starter-modeling/src/test/java/org/activiti/cloud/starter/modeling/swagger/ModelingSwaggerIT.java
@@ -16,10 +16,16 @@
 package org.activiti.cloud.starter.modeling.swagger;
 
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.StringRegularExpression.matchesRegex;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
@@ -27,13 +33,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class ModelingSwaggerIT {
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDefinitionIT.java
@@ -40,14 +40,12 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StreamUtils;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @Import({ ProcessDefinitionAdminRestTemplate.class, TestChannelBinderConfiguration.class })
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryAdminProcessDefinitionIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessDiagramIT.java
@@ -56,13 +56,11 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessDiagramIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -74,13 +74,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminProcessServiceTasksIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminVariablesIT.java
@@ -47,13 +47,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test-admin.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryAdminVariablesIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryApplicationEntityIT.java
@@ -42,13 +42,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryApplicationEntityIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -65,14 +65,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @EnableAutoConfiguration(exclude = { WebMvcAutoConfiguration.class })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryBPMNActivityIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionCandidateStartersIT.java
@@ -41,13 +41,11 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @Import({ ProcessDefinitionRestTemplate.class, TestChannelBinderConfiguration.class })
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryProcessDefinitionCandidateStartersIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDefinitionIT.java
@@ -42,14 +42,12 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StreamUtils;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @Import({ ProcessDefinitionRestTemplate.class, TestChannelBinderConfiguration.class })
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryProcessDefinitionIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessDiagramIT.java
@@ -58,13 +58,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessDiagramIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstanceEntityVariablesIT.java
@@ -42,13 +42,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstanceEntityVariablesIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -65,13 +65,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryProcessInstancesEntityIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTaskEntityVariablesIT.java
@@ -55,13 +55,11 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryTaskEntityVariablesIT {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryTasksIT.java
@@ -75,14 +75,12 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.CollectionUtils;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class QueryTasksIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -61,7 +61,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -69,17 +68,12 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@Import(
-    {
-        CommandEndPointITStreamHandler.class,
-        ProcessInstanceRestTemplate.class,
-        TaskRestTemplate.class,
-        MessageClientStreamConfiguration.class,
-        TestChannelBinderConfiguration.class,
-    }
-)
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import({CommandEndPointITStreamHandler.class,
+    ProcessInstanceRestTemplate.class,
+    TaskRestTemplate.class,
+    MessageClientStreamConfiguration.class,
+    TestChannelBinderConfiguration.class})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 public class CommandEndpointIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -68,12 +68,16 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@Import({CommandEndPointITStreamHandler.class,
-    ProcessInstanceRestTemplate.class,
-    TaskRestTemplate.class,
-    MessageClientStreamConfiguration.class,
-    TestChannelBinderConfiguration.class})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(
+    {
+        CommandEndPointITStreamHandler.class,
+        ProcessInstanceRestTemplate.class,
+        TaskRestTemplate.class,
+        MessageClientStreamConfiguration.class,
+        TestChannelBinderConfiguration.class,
+    }
+)
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class CommandEndpointIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:engine.properties")
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class EngineConfigurationIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -34,18 +34,22 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-                properties = {"ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
-                              "ACT_MESSAGING_DEST_SEPARATOR=.",
-                              "ACT_MESSAGING_DEST_PREFIX=namespace",
-                              "ACT_RB_ENG_EVT_DEST=engine-events",
-                              "ACT_RB_SIG_EVT_DEST=signal-event",
-                              "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
-                              "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
-                              "ACT_RB_MSG_EVT_DEST=message-events",
-                              "ACT_RB_CMD_RES_DEST=command-results",
-                              "ACT_INT_RES_CONSUMER=integration-result",
-                              "ACT_INT_ERR_CONSUMER:integration-error"})
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
+        "ACT_MESSAGING_DEST_SEPARATOR=.",
+        "ACT_MESSAGING_DEST_PREFIX=namespace",
+        "ACT_RB_ENG_EVT_DEST=engine-events",
+        "ACT_RB_SIG_EVT_DEST=signal-event",
+        "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
+        "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
+        "ACT_RB_MSG_EVT_DEST=message-events",
+        "ACT_RB_CMD_RES_DEST=command-results",
+        "ACT_INT_RES_CONSUMER=integration-result",
+        "ACT_INT_ERR_CONSUMER:integration-error",
+    }
+)
 @DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -31,27 +31,12 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
-        "ACT_MESSAGING_DEST_SEPARATOR=.",
-        "ACT_MESSAGING_DEST_PREFIX=namespace",
-        "ACT_RB_ENG_EVT_DEST=engine-events",
-        "ACT_RB_SIG_EVT_DEST=signal-event",
-        "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
-        "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
-        "ACT_RB_MSG_EVT_DEST=message-events",
-        "ACT_RB_CMD_RES_DEST=command-results",
-        "ACT_INT_RES_CONSUMER=integration-result",
-        "ACT_INT_ERR_CONSUMER:integration-error",
-    }
-)
-@DirtiesContext
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource("classpath:engine.properties")
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class EngineConfigurationIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -34,22 +34,18 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
-        "ACT_MESSAGING_DEST_SEPARATOR=.",
-        "ACT_MESSAGING_DEST_PREFIX=namespace",
-        "ACT_RB_ENG_EVT_DEST=engine-events",
-        "ACT_RB_SIG_EVT_DEST=signal-event",
-        "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
-        "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
-        "ACT_RB_MSG_EVT_DEST=message-events",
-        "ACT_RB_CMD_RES_DEST=command-results",
-        "ACT_INT_RES_CONSUMER=integration-result",
-        "ACT_INT_ERR_CONSUMER:integration-error",
-    }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+                properties = {"ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true",
+                              "ACT_MESSAGING_DEST_SEPARATOR=.",
+                              "ACT_MESSAGING_DEST_PREFIX=namespace",
+                              "ACT_RB_ENG_EVT_DEST=engine-events",
+                              "ACT_RB_SIG_EVT_DEST=signal-event",
+                              "ACT_RB_CMD_CONSUMER_DEST=command-consumer",
+                              "ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs",
+                              "ACT_RB_MSG_EVT_DEST=message-events",
+                              "ACT_RB_CMD_RES_DEST=command-results",
+                              "ACT_INT_RES_CONSUMER=integration-result",
+                              "ACT_INT_ERR_CONSUMER:integration-error"})
 @DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
@@ -29,25 +29,27 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest(
-    properties = { "spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/" },
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource({"classpath:application-test.properties",
+    "classpath:access-control.properties"})
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
-@DirtiesContext
 public class NeverFailDeploymentStrategyIT {
 
     @Autowired
     private ProcessDefinitionRestTemplate processDefinitionRestTemplate;
+
+    @DynamicPropertySource
+    public static void signalProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.activiti.process-definition-location-prefix", () -> "classpath*:/invalid-processes/");
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:test-never-fail");
+    }
 
     @Test
     public void rb_should_startEven_when_itFailsToParseSomeProcessDefinition() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/NeverFailDeploymentStrategyIT.java
@@ -35,10 +35,11 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties",
-    "classpath:access-control.properties"})
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class NeverFailDeploymentStrategyIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -46,14 +46,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@DirtiesContext
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@TestPropertySource({"classpath:application-test.properties",
+    "classpath:access-control.properties"})
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -50,9 +50,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties",
-    "classpath:access-control.properties"})
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -21,12 +21,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,8 +35,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
+    KeycloakContainerApplicationInitializer.class})
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -33,8 +33,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
-    KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -21,11 +21,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.activiti.cloud.services.common.security.test.support.WithActivitiMockUser;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,9 +36,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -34,10 +33,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
-@ContextConfiguration(
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
+    KeycloakContainerApplicationInitializer.class})
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class ActuatorHealthIndicatorsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/monitoring/ActuatorHealthIndicatorsIT.java
@@ -35,8 +35,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext
-@ContextConfiguration(initializers = {RabbitMQContainerApplicationInitializer.class,
-    KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 public class ActuatorHealthIndicatorsIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -33,7 +33,6 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -46,7 +45,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -56,10 +57,9 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
+@Import(TestChannelBinderConfiguration.class)
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -57,8 +57,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public abstract class AbstractMQServiceTaskIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -56,9 +56,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(classes = RuntimeITConfiguration.class,
-    initializers = {RabbitMQContainerApplicationInitializer.class,
-        KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = RuntimeITConfiguration.class,
+    initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
+)
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -33,6 +33,7 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.containers.RabbitMQContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
@@ -45,9 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -57,11 +56,9 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext
-@ContextConfiguration(
-    classes = RuntimeITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
-@Import(TestChannelBinderConfiguration.class)
+@ContextConfiguration(classes = RuntimeITConfiguration.class,
+    initializers = {RabbitMQContainerApplicationInitializer.class,
+        KeycloakContainerApplicationInitializer.class})
 public abstract class AbstractMQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -98,11 +98,10 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(value = { "classpath:application-test.properties", "classpath:async-executor.properties" })
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@TestPropertySource("classpath:application-test.properties")
+@ContextConfiguration(classes = {RuntimeITConfiguration.class,
+    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class JobExecutorIT {
@@ -181,8 +180,8 @@ public class JobExecutorIT {
 
     @DynamicPropertySource
     public static void signalProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.activiti.process-definition-location-prefix", () -> "classpath*:/invalid-processes/");
-        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:test-never-fail");
+        registry.add("spring.activiti.asyncExecutorActivate", () -> true);
+        registry.add("spring.cloud.stream.bindings.asyncExecutorJobsInput.consumer.max-attempts", () -> 4);
     }
 
     @BeforeEach

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -98,10 +98,11 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(value = {"classpath:application-test.properties", "classpath:async-executor.properties"})
-@ContextConfiguration(classes = {RuntimeITConfiguration.class,
-    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource(value = { "classpath:application-test.properties", "classpath:async-executor.properties" })
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class JobExecutorIT {
@@ -134,7 +135,7 @@ public class JobExecutorIT {
     @Autowired
     private RuntimeBundleProperties runtimeBundleProperties;
 
-    @SpyBean()
+    @SpyBean
     private JobMessageProducer jobMessageProducer;
 
     private ProcessEngineConfiguration processEngineConfiguration;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -85,8 +85,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -94,20 +97,13 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
-@TestPropertySource("classpath:application-test.properties")
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-        "spring.activiti.asyncExecutorActivate=true",
-        "spring.cloud.stream.bindings.asyncExecutorJobsInput.consumer.max-attempts=4", // customized
-    }
-)
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(value = {"classpath:application-test.properties", "classpath:async-executor.properties"})
+@ContextConfiguration(classes = {RuntimeITConfiguration.class,
+    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class JobExecutorIT {
 
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);
@@ -138,7 +134,7 @@ public class JobExecutorIT {
     @Autowired
     private RuntimeBundleProperties runtimeBundleProperties;
 
-    @SpyBean
+    @SpyBean()
     private JobMessageProducer jobMessageProducer;
 
     private ProcessEngineConfiguration processEngineConfiguration;
@@ -180,6 +176,12 @@ public class JobExecutorIT {
                 }
             };
         }
+    }
+
+    @DynamicPropertySource
+    public static void signalProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.activiti.process-definition-location-prefix", () -> "classpath*:/invalid-processes/");
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:test-never-fail");
     }
 
     @BeforeEach

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -99,9 +99,10 @@ import org.springframework.transaction.support.TransactionTemplate;
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {RuntimeITConfiguration.class,
-    JobExecutorIT.JobExecutorITProcessEngineConfigurer.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, JobExecutorIT.JobExecutorITProcessEngineConfigurer.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class JobExecutorIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -76,8 +76,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageEventsIT.java
@@ -71,17 +71,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, MessageEventsIT.TestConfigurationContext.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class MessageEventsIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -37,8 +37,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -32,17 +32,13 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class MessageIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -33,17 +33,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessDefinitionIT.java
@@ -37,9 +37,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessDefinitionIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -57,9 +57,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessInstanceIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -53,17 +53,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessInstanceIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -65,17 +65,13 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -69,9 +69,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ProcessVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -52,8 +52,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class SignalIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -47,17 +47,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class SignalIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -49,8 +49,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariableMappingIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -44,17 +44,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariableMappingIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -52,8 +52,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -47,17 +47,13 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class TaskVariablesIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -57,17 +57,13 @@ import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
-@DirtiesContext
-@ContextConfiguration(
-    classes = { RuntimeITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
+@ContextConfiguration(classes = {RuntimeITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class TasksIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -61,9 +61,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
-@ContextConfiguration(classes = {RuntimeITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@TestPropertySource({ "classpath:application-test.properties", "classpath:access-control.properties" })
+@ContextConfiguration(
+    classes = { RuntimeITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class TasksIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -117,6 +117,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -124,11 +125,9 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class AuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -126,8 +126,10 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class AuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -64,7 +64,6 @@ import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -72,11 +71,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(ConnectorAuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ConnectorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ConnectorAuditProducerIT.java
@@ -71,8 +71,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(ConnectorAuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ConnectorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -73,7 +73,6 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -81,11 +80,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -80,8 +80,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -48,8 +48,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ErrorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -41,7 +41,6 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -49,11 +48,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ErrorAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -73,8 +73,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -66,7 +66,6 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -74,11 +73,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -65,8 +65,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -58,7 +58,6 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -66,11 +65,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -48,7 +48,6 @@ import org.springframework.cloud.stream.binder.test.TestChannelBinderConfigurati
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -56,11 +55,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class MessageAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -55,8 +55,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class })
+@ContextConfiguration(
+    classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class MessageAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -130,10 +130,7 @@ public class MessageProducerCommandContextCloseListenerIT {
 
         // when
         Throwable thrown = catchThrowable(() -> {
-            ProcessInstance processInstance = runtimeService
-                .createProcessInstanceBuilder()
-                .processDefinitionKey(processDefinitionKey)
-                .start();
+            runtimeService.createProcessInstanceBuilder().processDefinitionKey(processDefinitionKey).start();
         });
 
         // then

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -47,7 +47,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles({AuditProducerIT.AUDIT_PRODUCER_IT})
+@ActiveProfiles({ AuditProducerIT.AUDIT_PRODUCER_IT })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @ContextConfiguration(
@@ -70,7 +70,6 @@ public class MessageProducerCommandContextCloseListenerIT {
     public static void asyncProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.activiti.asyncExecutorActivate", () -> true);
         registry.add("spring.datasource.url", () -> "jdbc:h2:mem:msg-producer-test");
-
     }
 
     @BeforeEach
@@ -129,12 +128,12 @@ public class MessageProducerCommandContextCloseListenerIT {
             .when(subject)
             .closed(any(CommandContext.class));
 
-
         // when
         Throwable thrown = catchThrowable(() -> {
-            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
-                          .processDefinitionKey(processDefinitionKey)
-                          .start();
+            ProcessInstance processInstance = runtimeService
+                .createProcessInstanceBuilder()
+                .processDefinitionKey(processDefinitionKey)
+                .start();
         });
 
         // then

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -38,6 +38,8 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -54,6 +56,7 @@ import org.springframework.test.context.TestPropertySource;
     classes = { ServicesAuditITConfiguration.class },
     initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
 )
+@Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -38,8 +38,6 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -56,7 +54,6 @@ import org.springframework.test.context.TestPropertySource;
     classes = { ServicesAuditITConfiguration.class },
     initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
 )
-@Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class MessageProducerCommandContextCloseListenerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerIT.java
@@ -40,21 +40,21 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = { "spring.activiti.asyncExecutorActivate=true" }
-)
+@ActiveProfiles({AuditProducerIT.AUDIT_PRODUCER_IT})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class },
+    classes = ServicesAuditITConfiguration.class,
     initializers = { RabbitMQContainerApplicationInitializer.class, KeycloakContainerApplicationInitializer.class }
 )
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class MessageProducerCommandContextCloseListenerIT {
 
     @Autowired
@@ -65,6 +65,13 @@ public class MessageProducerCommandContextCloseListenerIT {
 
     @Autowired
     private AuditConsumerStreamHandler streamHandler;
+
+    @DynamicPropertySource
+    public static void asyncProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.activiti.asyncExecutorActivate", () -> true);
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:msg-producer-test");
+
+    }
 
     @BeforeEach
     public void setUp() {
@@ -122,9 +129,12 @@ public class MessageProducerCommandContextCloseListenerIT {
             .when(subject)
             .closed(any(CommandContext.class));
 
+
         // when
         Throwable thrown = catchThrowable(() -> {
-            runtimeService.createProcessInstanceBuilder().processDefinitionKey(processDefinitionKey).start();
+            ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder()
+                          .processDefinitionKey(processDefinitionKey)
+                          .start();
         });
 
         // then

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -39,7 +39,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -47,11 +46,8 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = ServicesAuditITConfiguration.class,
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -46,8 +46,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = ServicesAuditITConfiguration.class,
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = ServicesAuditITConfiguration.class,
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -29,9 +29,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -47,7 +45,6 @@ import org.activiti.cloud.starter.tests.helper.ProcessDefinitionRestTemplate;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.SignalRestTemplate;
 import org.activiti.engine.RuntimeService;
-import org.activiti.engine.runtime.ProcessInstance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,8 +85,6 @@ public class SignalAuditProducerIT {
 
     @Autowired
     private ProcessDefinitionRestTemplate processDefinitionRestTemplate;
-
-    private Map<String, String> processDefinitionIds = new HashMap<>();
 
     @DynamicPropertySource
     public static void signalProperties(DynamicPropertyRegistry registry) {
@@ -154,71 +149,15 @@ public class SignalAuditProducerIT {
                 assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
                 List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getLatestReceivedEvents();
 
-            List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
-                .processDefinitionKey("processWithSignalStart1")
-                .list();
-
-            String startedBySignalProcessInstanceId = Optional
-                .ofNullable(runtimeService.createProcessInstanceQuery()
-                    .processDefinitionKey("processWithSignalStart1")
-                    .singleResult()
-                    .getId())
-                .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1"));
-
-            List<CloudBPMNSignalReceivedEvent> signalReceivedEvents = receivedEvents
-                .stream()
-                .filter(CloudBPMNSignalReceivedEvent.class::isInstance)
-                .map(CloudBPMNSignalReceivedEvent.class::cast)
-                .collect(Collectors.toList());
-
-            assertThat(signalReceivedEvents)
-                .filteredOn(event -> SIGNAL_RECEIVED.name().equals(event.getEventType().name()))
-                .extracting(CloudRuntimeEvent::getEventType,
-                    CloudRuntimeEvent::getProcessDefinitionId,
-                    CloudRuntimeEvent::getProcessInstanceId,
-                    CloudRuntimeEvent::getProcessDefinitionKey,
-                    CloudRuntimeEvent::getProcessDefinitionVersion,
-                    event -> event.getEntity().getProcessDefinitionId(),
-                    event -> event.getEntity().getProcessInstanceId(),
-                    event -> event.getEntity().getElementId(),
-                    event -> event.getEntity().getSignalPayload().getName(),
-                    event -> event.getEntity().getSignalPayload().getVariables()
-                )
-                .contains(
-                    tuple(SIGNAL_RECEIVED,
-                        processWithSignalStart.getId(),
-                        startedBySignalProcessInstanceId,
-                        processWithSignalStart.getKey(),
-                        processWithSignalStart.getVersion(),
-                        processWithSignalStart.getId(),
-                        startedBySignalProcessInstanceId,
-                        "theStart",
-                        "Test",
-                        Collections.singletonMap("signalVar", "timeToGo")
-                    ),
-                    tuple(SIGNAL_RECEIVED,
-                        startProcessEntity1.getBody().getProcessDefinitionId(),
-                        startProcessEntity1.getBody().getId(),
-                        startProcessEntity1.getBody().getProcessDefinitionKey(),
-                        1, // version
-                        startProcessEntity1.getBody().getProcessDefinitionId(),
-                        startProcessEntity1.getBody().getId(),
-                        "signalintermediatecatchevent1",
-                        "Test",
-                        Collections.singletonMap("signalVar", "timeToGo")
-                    ),
-                    tuple(SIGNAL_RECEIVED,
-                        startProcessEntity2.getBody().getProcessDefinitionId(),
-                        startProcessEntity2.getBody().getId(),
-                        startProcessEntity2.getBody().getProcessDefinitionKey(),
-                        1, // version
-                        startProcessEntity2.getBody().getProcessDefinitionId(),
-                        startProcessEntity2.getBody().getId(),
-                        "signalintermediatecatchevent1",
-                        "Test",
-                        Collections.singletonMap("signalVar", "timeToGo")
+                String startedBySignalProcessInstanceId = Optional
+                    .ofNullable(
+                        runtimeService
+                            .createProcessInstanceQuery()
+                            .processDefinitionKey("processWithSignalStart1")
+                            .singleResult()
+                            .getId()
                     )
-                    .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1")));
+                    .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1"));
 
                 List<CloudBPMNSignalReceivedEvent> signalReceivedEvents = receivedEvents
                     .stream()

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -60,11 +60,13 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
-@ActiveProfiles({AuditProducerIT.AUDIT_PRODUCER_IT})
+@ActiveProfiles({ AuditProducerIT.AUDIT_PRODUCER_IT })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @DirtiesContext
 @Import(TestChannelBinderConfiguration.class)
 public class SignalAuditProducerIT {
@@ -285,5 +287,4 @@ public class SignalAuditProducerIT {
                     );
             });
     }
-
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -218,7 +218,7 @@ public class SignalAuditProducerIT {
                         "Test",
                         Collections.singletonMap("signalVar", "timeToGo")
                     )
-                    .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1"));
+                    .orElseThrow(() -> new NoSuchElementException("processWithSignalStart1")));
 
                 List<CloudBPMNSignalReceivedEvent> signalReceivedEvents = receivedEvents
                     .stream()

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TestGatewayConcurrencyIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TestGatewayConcurrencyIT.java
@@ -59,13 +59,15 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
 @Import({ TestChannelBinderConfiguration.class })
+@DirtiesContext
 @ContextConfiguration(
     classes = ServicesAuditITConfiguration.class,
     initializers = { KeycloakContainerApplicationInitializer.class }
@@ -99,6 +101,11 @@ public class TestGatewayConcurrencyIT {
 
     private ExecutorService executorService;
 
+    @DynamicPropertySource
+    public static void concurrencyProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:concurrency-test");
+    }
+
     @BeforeEach
     public void setUp() {
         identityTokenProducer.withTestUser("testuser");
@@ -109,6 +116,7 @@ public class TestGatewayConcurrencyIT {
     @AfterEach
     public void cleanUp() {
         executorService.shutdown();
+        streamHandler.clear();
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -65,9 +65,10 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles({ AuditProducerIT.AUDIT_PRODUCER_IT, TimerAuditProducerIT.TIMER_AUDIT_PRODUCER_IT })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
-    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class},
-    initializers = {KeycloakContainerApplicationInitializer.class})
+@ContextConfiguration(
+    classes = { ServicesAuditITConfiguration.class, TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class },
+    initializers = { KeycloakContainerApplicationInitializer.class }
+)
 @Import(TestChannelBinderConfiguration.class)
 @DirtiesContext
 public class TimerAuditProducerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -65,12 +65,11 @@ import org.springframework.test.context.TestPropertySource;
 @ActiveProfiles({ AuditProducerIT.AUDIT_PRODUCER_IT, TimerAuditProducerIT.TIMER_AUDIT_PRODUCER_IT })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
-@DirtiesContext
-@ContextConfiguration(
-    classes = { ServicesAuditITConfiguration.class, TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class },
-    initializers = { KeycloakContainerApplicationInitializer.class }
-)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class,
+    TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class},
+    initializers = {KeycloakContainerApplicationInitializer.class})
 @Import(TestChannelBinderConfiguration.class)
+@DirtiesContext
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -58,6 +58,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -70,7 +71,7 @@ import org.springframework.test.context.TestPropertySource;
     initializers = { KeycloakContainerApplicationInitializer.class }
 )
 @Import(TestChannelBinderConfiguration.class)
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";
@@ -106,6 +107,7 @@ public class TimerAuditProducerIT {
 
     @BeforeEach
     public void setUp() {
+        asyncExecutor.start();
         streamHandler.clear();
         processEngineConfiguration.getClock().reset();
     }
@@ -113,6 +115,7 @@ public class TimerAuditProducerIT {
     @AfterEach
     public void tearDown() {
         processEngineConfiguration.getClock().reset();
+        asyncExecutor.shutdown();
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/swagger/RuntimeBundleSwaggerIT.java
@@ -36,13 +36,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(TestChannelBinderConfiguration.class)
 public class RuntimeBundleSwaggerIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/async-executor.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/async-executor.properties
@@ -1,0 +1,2 @@
+spring.activiti.asyncExecutorActivate=true
+spring.cloud.stream.bindings.asyncExecutorJobsInput.consumer.max-attempts=4

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/async-executor.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/async-executor.properties
@@ -1,2 +1,0 @@
-spring.activiti.asyncExecutorActivate=true
-spring.cloud.stream.bindings.asyncExecutorJobsInput.consumer.max-attempts=4

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/engine.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/engine.properties
@@ -1,0 +1,11 @@
+ACT_MESSAGING_DEST_TRANSFORMERS_ENABLED=true
+ACT_MESSAGING_DEST_SEPARATOR=.
+ACT_MESSAGING_DEST_PREFIX=namespace
+ACT_RB_ENG_EVT_DEST=engine-events
+ACT_RB_SIG_EVT_DEST=signal-event
+ACT_RB_CMD_CONSUMER_DEST=command-consumer
+ACT_RB_ASYNC_JOB_EXEC_DEST=async-executor-jobs
+ACT_RB_MSG_EVT_DEST=message-events
+ACT_RB_CMD_RES_DEST=command-results
+ACT_INT_RES_CONSUMER=integration-result
+ACT_INT_ERR_CONSUMER=integration-error

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/invalid-process.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/invalid-process.properties
@@ -1,0 +1,3 @@
+"spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/"
+
+spring.datasource.url=jdbc:h2:mem:test-invalid

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/invalid-process.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/invalid-process.properties
@@ -1,3 +1,0 @@
-"spring.activiti.process-definition-location-prefix=classpath*:/invalid-processes/"
-
-spring.datasource.url=jdbc:h2:mem:test-invalid


### PR DESCRIPTION
This PR includes the changes from Activiti/activiti-cloud#1044 and closes Activiti/Activiti#4280.

Many integration tests use the annotation `@DirtiesContext` to recreate the context used by other integration tests.
In some cases it is necessary, but in many others it wastes time slowing down `mvn verify`.

This PR tries to reduce the usage of `@DirtiesContext` unless it is strictly required by test case.