### PR TITLE
Update commons-fileupload from 1.4 to 1.5

### DIFF
--- a/activiti-cloud-acceptance-scenarios/identity-adapter-acceptance-tests/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/identity-adapter-acceptance-tests/pom.xml
@@ -46,5 +46,10 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-slf4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -26,6 +26,7 @@
     <maven.compiler.release>${java.release}</maven.compiler.release>
     <activiti-cloud.version>${project.version}</activiti-cloud.version>
     <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
+    <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-shared/pom.xml
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-shared/pom.xml
@@ -54,5 +54,10 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-openfeign-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-acceptance-tests/pom.xml
+++ b/activiti-cloud-acceptance-tests/pom.xml
@@ -21,6 +21,7 @@
     <serenity-jbehave.version>1.46.0</serenity-jbehave.version>
     <feign-form.version>3.8.0</feign-form.version>
     <batik.version>1.16</batik.version>
+    <commons-fileupload.version>1.5</commons-fileupload.version>
     <enforcer.skip>true</enforcer.skip>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/pom.xml
@@ -88,5 +88,11 @@
       <artifactId>feign-core</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -19,6 +19,7 @@
   </modules>
   <properties>
     <activiti.version>7.10.0-alpha.5</activiti.version>
+    <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>spring-cloud-starter-openfeign</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>${commons-fileupload.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -49,6 +49,7 @@
     <!-- override resteasy vulnerable 0.8.3 version of org.apache.james dependencies -->
     <james.apache-mime4j.version>0.8.9</james.apache-mime4j.version>
     <batik.version>1.16</batik.version>
+    <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR fixes Activiti/Activiti#4299 updating `commons-fileupload` to version 1.5.