### PR TITLE
AAE-13346 remove fix spring web version

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -38,11 +38,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${spring-web.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,6 @@
     <project.year>2020</project.year>
 
     <spring-boot.version>2.7.10</spring-boot.version>
-    <spring-web.version>5.3.25</spring-web.version>
 
     <!-- configuration properties for tests-->
     <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>


### PR DESCRIPTION
With the migration to spring-boot 2.7.10 we can remove the fix version of spring-web as a higher version is already included.