### PR TITLE
Fix concurrency exception in modeling service

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
@@ -69,6 +69,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-modeling-api-impl</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelingServiceAutoConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelingServiceAutoConfiguration.java
@@ -42,7 +42,7 @@ import org.activiti.cloud.services.modeling.service.utils.FileContentSanitizer;
 import org.activiti.cloud.services.modeling.validation.extensions.ExtensionsModelValidator;
 import org.activiti.cloud.services.modeling.validation.magicnumber.FileMagicNumberValidator;
 import org.activiti.cloud.services.modeling.validation.project.ProjectValidator;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -62,8 +62,8 @@ public class ModelingServiceAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ExtensionsModelValidator extensionsModelValidator(SchemaLoader modelExtensionsSchemaLoader) {
-        return new ExtensionsModelValidator(modelExtensionsSchemaLoader);
+    public ExtensionsModelValidator extensionsModelValidator(Schema modelExtensionsSchema) {
+        return new ExtensionsModelValidator(modelExtensionsSchema);
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ConnectorModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ConnectorModelValidator.java
@@ -21,19 +21,19 @@ import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.ModelContentValidator;
 import org.activiti.cloud.modeling.api.ModelType;
 import org.activiti.cloud.modeling.api.ModelValidator;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 
 /**
  * {@link ModelValidator} implementation of connector models
  */
 public class ConnectorModelValidator extends JsonSchemaModelValidator implements ModelContentValidator {
 
-    private final SchemaLoader connectorSchemaLoader;
+    private final Schema connectorSchema;
 
     private final ConnectorModelType connectorModelType;
 
-    public ConnectorModelValidator(SchemaLoader connectorSchemaLoader, ConnectorModelType connectorModelType) {
-        this.connectorSchemaLoader = connectorSchemaLoader;
+    public ConnectorModelValidator(Schema connectorSchema, ConnectorModelType connectorModelType) {
+        this.connectorSchema = connectorSchema;
         this.connectorModelType = connectorModelType;
     }
 
@@ -48,7 +48,7 @@ public class ConnectorModelValidator extends JsonSchemaModelValidator implements
     }
 
     @Override
-    public SchemaLoader schemaLoader() {
-        return connectorSchemaLoader;
+    public Schema schema() {
+        return connectorSchema;
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidator.java
@@ -30,7 +30,6 @@ import org.activiti.cloud.modeling.core.error.SyntacticModelValidationException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
-import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -44,7 +43,7 @@ public abstract class JsonSchemaModelValidator implements ModelValidator {
 
     private final Logger log = LoggerFactory.getLogger(JsonSchemaModelValidator.class);
 
-    protected abstract SchemaLoader schemaLoader();
+    protected abstract Schema schema();
 
     @Override
     public Collection<ModelValidationError> validate(byte[] bytes, ValidationContext validationContext) {
@@ -52,7 +51,7 @@ public abstract class JsonSchemaModelValidator implements ModelValidator {
         try {
             log.debug("Validating json model content: " + new String(bytes));
             processExtensionJson = new JSONObject(new JSONTokener(new String(bytes)));
-            schemaLoader().load().build().validate(processExtensionJson);
+            schema().validate(processExtensionJson);
         } catch (JSONException jsonException) {
             log.debug("Syntactic model JSON validation errors encountered", jsonException);
             throw new SyntacticModelValidationException(jsonException);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/JsonSchemaModelValidatorConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.modeling.validation;
 
 import java.io.IOException;
 import java.io.InputStream;
+import org.everit.json.schema.Schema;
 import org.everit.json.schema.loader.SchemaClient;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
@@ -38,22 +39,22 @@ public class JsonSchemaModelValidatorConfiguration {
     @Value("${activiti.validation.model-extensions-schema:schema/model-extensions-schema.json}")
     private String modelExtensionsSchema;
 
-    @Bean(name = "connectorSchemaLoader")
-    public SchemaLoader getConnectorSchemaLoader() throws IOException {
-        return buildSchemaLoaderFromClasspath(connectorSchema);
+    @Bean(name = "connectorSchema")
+    public Schema getConnectorSchemaLoader() throws IOException {
+        return buildSchemaFromClasspath(connectorSchema);
     }
 
-    @Bean(name = "processExtensionsSchemaLoader")
-    public SchemaLoader getProcessExtensionsSchemaLoader() throws IOException {
-        return buildSchemaLoaderFromClasspath(processExtensionsSchema);
+    @Bean(name = "processExtensionsSchema")
+    public Schema getProcessExtensionsSchemaLoader() throws IOException {
+        return buildSchemaFromClasspath(processExtensionsSchema);
     }
 
-    @Bean(name = "modelExtensionsSchemaLoader")
-    public SchemaLoader getModelExtensionsSchemaLoader() throws IOException {
-        return buildSchemaLoaderFromClasspath(modelExtensionsSchema);
+    @Bean(name = "modelExtensionsSchema")
+    public Schema getModelExtensionsSchemaLoader() throws IOException {
+        return buildSchemaFromClasspath(modelExtensionsSchema);
     }
 
-    private SchemaLoader buildSchemaLoaderFromClasspath(String schemaFileName) throws IOException {
+    private Schema buildSchemaFromClasspath(String schemaFileName) throws IOException {
         try (InputStream schemaInputStream = new ClassPathResource(schemaFileName).getInputStream()) {
             JSONObject jsonSchema = new JSONObject(new JSONTokener(schemaInputStream));
 
@@ -62,6 +63,8 @@ public class JsonSchemaModelValidatorConfiguration {
                 .schemaClient(SchemaClient.classPathAwareClient())
                 .schemaJson(new JsonSchemaFlattener().flatten(jsonSchema))
                 .draftV7Support()
+                .build()
+                .load()
                 .build();
         }
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/ProcessModelValidatorConfiguration.java
@@ -54,7 +54,7 @@ import org.activiti.cloud.services.modeling.validation.project.ProjectNameValida
 import org.activiti.validation.ProcessValidator;
 import org.activiti.validation.ProcessValidatorImpl;
 import org.activiti.validation.validator.ValidatorSetFactory;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -82,14 +82,14 @@ public class ProcessModelValidatorConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ProcessExtensionsModelValidator processExtensionsModelValidator(
-        SchemaLoader processExtensionsSchemaLoader,
+        Schema processExtensionsSchema,
         Set<ProcessExtensionsValidator> processExtensionsValidators,
         ProcessModelType processModelType,
         JsonConverter<Extensions> jsonExtensionsConverter,
         ProcessModelContentConverter processModelContentConverter
     ) {
         return new ProcessExtensionsModelValidator(
-            processExtensionsSchemaLoader,
+            processExtensionsSchema,
             processExtensionsValidators,
             processModelType,
             jsonExtensionsConverter,
@@ -141,10 +141,10 @@ public class ProcessModelValidatorConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ConnectorModelValidator connectorModelValidator(
-        SchemaLoader connectorSchemaLoader,
+        Schema connectorSchema,
         ConnectorModelType connectorModelType
     ) {
-        return new ConnectorModelValidator(connectorSchemaLoader, connectorModelType);
+        return new ConnectorModelValidator(connectorSchema, connectorModelType);
     }
 
     @Bean

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ExtensionsModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ExtensionsModelValidator.java
@@ -21,7 +21,7 @@ import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelType;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.ValidationContext;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -29,11 +29,11 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class ExtensionsModelValidator extends ExtensionsJsonSchemaValidator {
 
-    private final SchemaLoader modelExtensionsSchemaLoader;
+    private final Schema modelExtensionsSchema;
 
     @Autowired
-    public ExtensionsModelValidator(SchemaLoader modelExtensionsSchemaLoader) {
-        this.modelExtensionsSchemaLoader = modelExtensionsSchemaLoader;
+    public ExtensionsModelValidator(Schema modelExtensionsSchema) {
+        this.modelExtensionsSchema = modelExtensionsSchema;
     }
 
     @Override
@@ -42,8 +42,8 @@ public class ExtensionsModelValidator extends ExtensionsJsonSchemaValidator {
     }
 
     @Override
-    protected SchemaLoader schemaLoader() {
-        return modelExtensionsSchemaLoader;
+    protected Schema schema() {
+        return modelExtensionsSchema;
     }
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/extensions/ProcessExtensionsModelValidator.java
@@ -18,7 +18,11 @@ package org.activiti.cloud.services.modeling.validation.extensions;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.removeStart;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.activiti.cloud.modeling.api.Model;
@@ -32,7 +36,7 @@ import org.activiti.cloud.modeling.core.error.ModelingException;
 import org.activiti.cloud.modeling.core.error.SyntacticModelValidationException;
 import org.activiti.cloud.services.modeling.converter.BpmnProcessModelContent;
 import org.activiti.cloud.services.modeling.converter.ProcessModelContentConverter;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidator {
@@ -42,7 +46,7 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
     public static final String UNKNOWN_PROCESS_ID_VALIDATION_ERROR_DESCRIPTION =
         "The process extensions are bound to an unknown process id '%s'";
 
-    private final SchemaLoader processExtensionsSchemaLoader;
+    private final Schema processExtensionsSchema;
 
     private final Set<ProcessExtensionsValidator> processExtensionsValidators;
 
@@ -54,13 +58,13 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
 
     @Autowired
     public ProcessExtensionsModelValidator(
-        SchemaLoader processExtensionsSchemaLoader,
+        Schema processExtensionsSchema,
         Set<ProcessExtensionsValidator> processExtensionsValidators,
         ProcessModelType processModelType,
         JsonConverter<Extensions> jsonExtensionsConverter,
         ProcessModelContentConverter processModelContentConverter
     ) {
-        this.processExtensionsSchemaLoader = processExtensionsSchemaLoader;
+        this.processExtensionsSchema = processExtensionsSchema;
         this.processExtensionsValidators = processExtensionsValidators;
         this.processModelType = processModelType;
         this.jsonExtensionsConverter = jsonExtensionsConverter;
@@ -143,7 +147,7 @@ public class ProcessExtensionsModelValidator extends ExtensionsJsonSchemaValidat
     }
 
     @Override
-    public SchemaLoader schemaLoader() {
-        return processExtensionsSchemaLoader;
+    public Schema schema() {
+        return processExtensionsSchema;
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ConnectorModelValidatorIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ConnectorModelValidatorIT.java
@@ -21,7 +21,7 @@ import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteAr
 import java.io.IOException;
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.config.ModelingApiAutoConfiguration;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,8 +33,8 @@ import org.springframework.test.context.ContextConfiguration;
 public class ConnectorModelValidatorIT {
 
     @Autowired
-    @Qualifier("connectorSchemaLoader")
-    public SchemaLoader connectorSchemaLoader;
+    @Qualifier("connectorSchema")
+    public Schema connectorSchema;
 
     @Autowired
     public ConnectorModelType connectorModelType;
@@ -42,7 +42,7 @@ public class ConnectorModelValidatorIT {
     @Test
     public void should_notThrowException_when_validatingAValidConnectorWithExtendedProperties() throws IOException {
         ConnectorModelValidator connectorModelValidator = new ConnectorModelValidator(
-            connectorSchemaLoader,
+            connectorSchema,
             connectorModelType
         );
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.config.ModelingApiAutoConfiguration;
-import org.everit.json.schema.loader.SchemaLoader;
+import org.everit.json.schema.Schema;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -48,8 +48,8 @@ public class ValidatorConcurrencyIT {
     private static final int THREADS = 2;
 
     @Autowired
-    @Qualifier("connectorSchemaLoader")
-    public SchemaLoader connectorSchemaLoader;
+    @Qualifier("connectorSchema")
+    public Schema connectorSchema;
 
     @Autowired
     public ConnectorModelType connectorModelType;
@@ -70,7 +70,7 @@ public class ValidatorConcurrencyIT {
     public void should_notThrowException_when_validatingAValidConnectorConcurrently() throws InterruptedException {
         // given
         ConnectorModelValidator connectorModelValidator = new ConnectorModelValidator(
-            connectorSchemaLoader,
+            connectorSchema,
             connectorModelType
         );
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.modeling.validation;
+
+import static org.activiti.cloud.modeling.api.ValidationContext.EMPTY_CONTEXT;
+import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
+import static org.awaitility.Awaitility.await;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.activiti.cloud.modeling.api.ConnectorModelType;
+import org.activiti.cloud.modeling.api.ModelValidationError;
+import org.activiti.cloud.modeling.api.config.ModelingApiAutoConfiguration;
+import org.everit.json.schema.Schema;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = { JsonSchemaModelValidatorConfiguration.class, ModelingApiAutoConfiguration.class })
+public class ValidatorConcurrencyIT {
+
+    private static final int THREADS = 2;
+
+    @Autowired
+    @Qualifier("connectorSchema")
+    public Schema connectorSchema;
+
+    @Autowired
+    public ConnectorModelType connectorModelType;
+
+    private static ExecutorService executorService;
+
+    @BeforeAll
+    static void setUp() {
+        executorService = Executors.newFixedThreadPool(THREADS);
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void should_notThrowException_when_validatingAValidConnectorConcurrently() throws InterruptedException {
+        // given
+        ConnectorModelValidator connectorModelValidator = new ConnectorModelValidator(
+            connectorSchema,
+            connectorModelType
+        );
+
+        Set<Callable<Collection<ModelValidationError>>> tasks = createTasks(connectorModelValidator, THREADS);
+
+        // when
+        List<Future<Collection<ModelValidationError>>> futureList = executorService.invokeAll(tasks);
+
+        // then
+        await()
+            .untilAsserted(() -> {
+                if (futureList.stream().map(Future::isDone).count() == THREADS) {
+                    List<ModelValidationError> errors = futureList
+                        .stream()
+                        .map(f -> {
+                            try {
+                                return f.get();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
+
+                    assert (errors).isEmpty();
+                }
+            });
+    }
+
+    protected Set<Callable<Collection<ModelValidationError>>> createTasks(
+        ConnectorModelValidator connectorModelValidator,
+        int size
+    ) {
+        Set<Callable<Collection<ModelValidationError>>> tasks = new LinkedHashSet<>();
+
+        for (int i = 0; i < size; i++) {
+            tasks.add(() -> {
+                return connectorModelValidator.validateModelContent(
+                    resourceAsByteArray("connector/connector-with-model.json"),
+                    EMPTY_CONTEXT
+                );
+            });
+        }
+
+        return tasks;
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIT.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.config.ModelingApiAutoConfiguration;
-import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -48,8 +48,8 @@ public class ValidatorConcurrencyIT {
     private static final int THREADS = 2;
 
     @Autowired
-    @Qualifier("connectorSchema")
-    public Schema connectorSchema;
+    @Qualifier("connectorSchemaLoader")
+    public SchemaLoader connectorSchemaLoader;
 
     @Autowired
     public ConnectorModelType connectorModelType;
@@ -70,7 +70,7 @@ public class ValidatorConcurrencyIT {
     public void should_notThrowException_when_validatingAValidConnectorConcurrently() throws InterruptedException {
         // given
         ConnectorModelValidator connectorModelValidator = new ConnectorModelValidator(
-            connectorSchema,
+            connectorSchemaLoader,
             connectorModelType
         );
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIntegrationTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/validation/ValidatorConcurrencyIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.activiti.cloud.modeling.api.ValidationContext.EMPTY_CONTEXT;
 import static org.activiti.cloud.services.common.util.FileUtils.resourceAsByteArray;
 import static org.awaitility.Awaitility.await;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -43,7 +44,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ContextConfiguration(classes = { JsonSchemaModelValidatorConfiguration.class, ModelingApiAutoConfiguration.class })
-public class ValidatorConcurrencyIT {
+public class ValidatorConcurrencyIntegrationTest {
 
     private static final int THREADS = 2;
 
@@ -89,7 +90,7 @@ public class ValidatorConcurrencyIT {
                             try {
                                 return f.get();
                             } catch (Exception e) {
-                                throw new RuntimeException(e);
+                                throw new UndeclaredThrowableException(e);
                             }
                         })
                         .filter(Objects::nonNull)


### PR DESCRIPTION
This PR fixes Activiti/Activiti#4301.

`SchemaLoader` when used to load a `Schema` uses some static variables such `Map`. Using concurrently the same `SchemaLoader` actually causes:
1. inconsistencies due to properties being overridden by other threads;
2. `ConcurrentModificationException` when a `Map` is edited by multiple threads at the same time.

To solve the issue with the loader, this PR replaces the `SchemaLoader` with the `Schema`.