### PR TITLE
AAE-13446 fix audit integration events timestamps

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
@@ -22,8 +22,8 @@ import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
 
 public class CloudIntegrationErrorReceivedEventImpl
-        extends CloudIntegrationEventImpl
-        implements CloudIntegrationErrorReceivedEvent {
+    extends CloudIntegrationEventImpl
+    implements CloudIntegrationErrorReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
@@ -19,12 +19,9 @@ import java.util.List;
 import java.util.Objects;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
-import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
 
-public class CloudIntegrationErrorReceivedEventImpl
-    extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents>
-    implements CloudIntegrationErrorReceivedEvent {
+public class CloudIntegrationErrorReceivedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationErrorReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -43,16 +40,22 @@ public class CloudIntegrationErrorReceivedEventImpl
         List<StackTraceElement> stackTraceElements
     ) {
         super(integrationContext);
-        if (getEntity() != null) {
-            setEntityId(getEntity().getId());
-        }
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.errorClassName = errorClassName;
+        this.stackTraceElements = stackTraceElements;
+    }
 
-        setProcessInstanceId(integrationContext.getProcessInstanceId());
-        setProcessDefinitionId(integrationContext.getProcessDefinitionId());
-        setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
-        setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
-        setBusinessKey(integrationContext.getBusinessKey());
-
+    public CloudIntegrationErrorReceivedEventImpl(
+        String id,
+        Long timestamp,
+        IntegrationContext integrationContext,
+        String errorCode,
+        String errorMessage,
+        String errorClassName,
+        List<StackTraceElement> stackTraceElements
+    ) {
+        super(id, timestamp, integrationContext);
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.errorClassName = errorClassName;

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationErrorReceivedEventImpl.java
@@ -21,7 +21,9 @@ import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationErrorReceivedEvent;
 
-public class CloudIntegrationErrorReceivedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationErrorReceivedEvent {
+public class CloudIntegrationErrorReceivedEventImpl
+        extends CloudIntegrationEventImpl
+        implements CloudIntegrationErrorReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.api.process.model.impl.events;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.api.process.model.events.IntegrationEvent;
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+
+public abstract class CloudIntegrationEventImpl extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents> {
+
+    protected static final long serialVersionUID = 1L;
+
+    protected CloudIntegrationEventImpl() {
+    }
+
+    protected CloudIntegrationEventImpl(IntegrationContext integrationContext) {
+        super(integrationContext);
+        setFieldValues(integrationContext);
+    }
+
+    protected CloudIntegrationEventImpl(String id, Long timestamp, IntegrationContext integrationContext) {
+        super(id, timestamp, integrationContext);
+        setFieldValues(integrationContext);
+    }
+
+    protected void setFieldValues(IntegrationContext integrationContext) {
+        if (getEntity() != null) {
+            setEntityId(getEntity().getId());
+        }
+
+        setProcessInstanceId(integrationContext.getProcessInstanceId());
+        setProcessDefinitionId(integrationContext.getProcessDefinitionId());
+        setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
+        setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
+        setBusinessKey(integrationContext.getBusinessKey());
+    }
+}

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
@@ -20,7 +20,7 @@ import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 
 public abstract class CloudIntegrationEventImpl
-        extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents> {
+    extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents> {
 
     protected static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationEventImpl.java
@@ -19,12 +19,12 @@ import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 
-public abstract class CloudIntegrationEventImpl extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents> {
+public abstract class CloudIntegrationEventImpl
+        extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents> {
 
     protected static final long serialVersionUID = 1L;
 
-    protected CloudIntegrationEventImpl() {
-    }
+    protected CloudIntegrationEventImpl() {}
 
     protected CloudIntegrationEventImpl(IntegrationContext integrationContext) {
         super(integrationContext);

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
@@ -19,7 +19,9 @@ import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
 
-public class CloudIntegrationRequestedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationRequestedEvent {
+public class CloudIntegrationRequestedEventImpl
+        extends CloudIntegrationEventImpl
+        implements CloudIntegrationRequestedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
@@ -17,12 +17,9 @@ package org.activiti.cloud.api.process.model.impl.events;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
-import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
 
-public class CloudIntegrationRequestedEventImpl
-    extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents>
-    implements CloudIntegrationRequestedEvent {
+public class CloudIntegrationRequestedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationRequestedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -30,15 +27,10 @@ public class CloudIntegrationRequestedEventImpl
 
     public CloudIntegrationRequestedEventImpl(IntegrationContext integrationContext) {
         super(integrationContext);
-        if (getEntity() != null) {
-            setEntityId(getEntity().getId());
-        }
+    }
 
-        setProcessInstanceId(integrationContext.getProcessInstanceId());
-        setProcessDefinitionId(integrationContext.getProcessDefinitionId());
-        setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
-        setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
-        setBusinessKey(integrationContext.getBusinessKey());
+    public CloudIntegrationRequestedEventImpl(String id, Long timestamp, IntegrationContext integrationContext) {
+        super(id, timestamp, integrationContext);
     }
 
     @Override

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationRequestedEventImpl.java
@@ -20,8 +20,8 @@ import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationRequestedEvent;
 
 public class CloudIntegrationRequestedEventImpl
-        extends CloudIntegrationEventImpl
-        implements CloudIntegrationRequestedEvent {
+    extends CloudIntegrationEventImpl
+    implements CloudIntegrationRequestedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
@@ -19,7 +19,9 @@ import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
 
-public class CloudIntegrationResultReceivedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationResultReceivedEvent {
+public class CloudIntegrationResultReceivedEventImpl
+        extends CloudIntegrationEventImpl
+        implements CloudIntegrationResultReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
@@ -17,12 +17,9 @@ package org.activiti.cloud.api.process.model.impl.events;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.IntegrationEvent;
-import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
 
-public class CloudIntegrationResultReceivedEventImpl
-    extends CloudRuntimeEventImpl<IntegrationContext, IntegrationEvent.IntegrationEvents>
-    implements CloudIntegrationResultReceivedEvent {
+public class CloudIntegrationResultReceivedEventImpl extends CloudIntegrationEventImpl implements CloudIntegrationResultReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -30,19 +27,15 @@ public class CloudIntegrationResultReceivedEventImpl
 
     public CloudIntegrationResultReceivedEventImpl(IntegrationContext integrationContext) {
         super(integrationContext);
-        if (getEntity() != null) {
-            setEntityId(getEntity().getId());
-        }
+    }
 
-        setProcessInstanceId(integrationContext.getProcessInstanceId());
-        setProcessDefinitionId(integrationContext.getProcessDefinitionId());
-        setProcessDefinitionVersion(integrationContext.getProcessDefinitionVersion());
-        setProcessDefinitionKey(integrationContext.getProcessDefinitionKey());
-        setBusinessKey(integrationContext.getBusinessKey());
+    public CloudIntegrationResultReceivedEventImpl(String id, Long timestamp, IntegrationContext integrationContext) {
+        super(id, timestamp, integrationContext);
     }
 
     @Override
     public IntegrationEvent.IntegrationEvents getEventType() {
         return IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED;
     }
+
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIntegrationResultReceivedEventImpl.java
@@ -20,8 +20,8 @@ import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationResultReceivedEvent;
 
 public class CloudIntegrationResultReceivedEventImpl
-        extends CloudIntegrationEventImpl
-        implements CloudIntegrationResultReceivedEvent {
+    extends CloudIntegrationEventImpl
+    implements CloudIntegrationResultReceivedEvent {
 
     private static final long serialVersionUID = 1L;
 
@@ -39,5 +39,4 @@ public class CloudIntegrationResultReceivedEventImpl
     public IntegrationEvent.IntegrationEvents getEventType() {
         return IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED;
     }
-
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverter.java
@@ -46,6 +46,8 @@ public class IntegrationErrorReceivedEventConverter extends BaseEventToEntityCon
         IntegrationErrorReceivedEventEntity entity = IntegrationErrorReceivedEventEntity.class.cast(auditEventEntity);
 
         return new CloudIntegrationErrorReceivedEventImpl(
+            entity.getEventId(),
+            entity.getTimestamp(),
             entity.getIntegrationContext(),
             entity.getErrorCode(),
             entity.getErrorMessage(),

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
@@ -43,6 +43,6 @@ public class IntegrationRequestedEventConverter extends BaseEventToEntityConvert
     protected CloudRuntimeEventImpl<?, ?> createAPIEvent(AuditEventEntity auditEventEntity) {
         IntegrationRequestSentEventEntity entity = (IntegrationRequestSentEventEntity) auditEventEntity;
 
-        return new CloudIntegrationRequestedEventImpl(entity.getIntegrationContext());
+        return new CloudIntegrationRequestedEventImpl(entity.getEventId(), entity.getTimestamp(), entity.getIntegrationContext());
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
@@ -43,6 +43,10 @@ public class IntegrationRequestedEventConverter extends BaseEventToEntityConvert
     protected CloudRuntimeEventImpl<?, ?> createAPIEvent(AuditEventEntity auditEventEntity) {
         IntegrationRequestSentEventEntity entity = (IntegrationRequestSentEventEntity) auditEventEntity;
 
-        return new CloudIntegrationRequestedEventImpl(entity.getEventId(), entity.getTimestamp(), entity.getIntegrationContext());
+        return new CloudIntegrationRequestedEventImpl(
+                entity.getEventId(),
+                entity.getTimestamp(),
+                entity.getIntegrationContext()
+        );
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverter.java
@@ -44,9 +44,9 @@ public class IntegrationRequestedEventConverter extends BaseEventToEntityConvert
         IntegrationRequestSentEventEntity entity = (IntegrationRequestSentEventEntity) auditEventEntity;
 
         return new CloudIntegrationRequestedEventImpl(
-                entity.getEventId(),
-                entity.getTimestamp(),
-                entity.getIntegrationContext()
+            entity.getEventId(),
+            entity.getTimestamp(),
+            entity.getIntegrationContext()
         );
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
@@ -45,6 +45,10 @@ public class IntegrationResultReceivedEventConverter extends BaseEventToEntityCo
     protected CloudRuntimeEventImpl<?, ?> createAPIEvent(AuditEventEntity auditEventEntity) {
         IntegrationResultReceivedEventEntity entity = IntegrationResultReceivedEventEntity.class.cast(auditEventEntity);
 
-        return new CloudIntegrationResultReceivedEventImpl(entity.getEventId(), entity.getTimestamp(), entity.getIntegrationContext());
+        return new CloudIntegrationResultReceivedEventImpl(
+                entity.getEventId(),
+                entity.getTimestamp(),
+                entity.getIntegrationContext()
+        );
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
@@ -45,6 +45,6 @@ public class IntegrationResultReceivedEventConverter extends BaseEventToEntityCo
     protected CloudRuntimeEventImpl<?, ?> createAPIEvent(AuditEventEntity auditEventEntity) {
         IntegrationResultReceivedEventEntity entity = IntegrationResultReceivedEventEntity.class.cast(auditEventEntity);
 
-        return new CloudIntegrationResultReceivedEventImpl(entity.getIntegrationContext());
+        return new CloudIntegrationResultReceivedEventImpl(entity.getEventId(), entity.getTimestamp(), entity.getIntegrationContext());
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverter.java
@@ -46,9 +46,9 @@ public class IntegrationResultReceivedEventConverter extends BaseEventToEntityCo
         IntegrationResultReceivedEventEntity entity = IntegrationResultReceivedEventEntity.class.cast(auditEventEntity);
 
         return new CloudIntegrationResultReceivedEventImpl(
-                entity.getEventId(),
-                entity.getTimestamp(),
-                entity.getIntegrationContext()
+            entity.getEventId(),
+            entity.getTimestamp(),
+            entity.getIntegrationContext()
         );
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
@@ -28,18 +28,18 @@ import org.junit.jupiter.api.Test;
 public class IntegrationErrorReceivedEventConverterTest {
 
     private final IntegrationErrorReceivedEventConverter converter = new IntegrationErrorReceivedEventConverter(
-                    new EventContextInfoAppender()
-            );
+        new EventContextInfoAppender()
+    );
 
     @Test
     public void createEventEntity_should_setErrorRelatedProperties() {
         //given
         CloudIntegrationErrorReceivedEventImpl errorReceivedEvent = new CloudIntegrationErrorReceivedEventImpl(
-          new IntegrationContextImpl(),
-          "errorCode",
-          "Something went wrong",
-          RuntimeException.class.getName(),
-          Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
+            new IntegrationContextImpl(),
+            "errorCode",
+            "Something went wrong",
+            RuntimeException.class.getName(),
+            Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
         );
         errorReceivedEvent.setSequenceNumber(1);
 
@@ -59,11 +59,11 @@ public class IntegrationErrorReceivedEventConverterTest {
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {
         CloudIntegrationErrorReceivedEventImpl event = new CloudIntegrationErrorReceivedEventImpl(
-                new IntegrationContextImpl(),
-                "errorCode",
-                "Something went wrong",
-                RuntimeException.class.getName(),
-                Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
+            new IntegrationContextImpl(),
+            "errorCode",
+            "Something went wrong",
+            RuntimeException.class.getName(),
+            Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
         );
         event.setSequenceNumber(1);
         IntegrationErrorReceivedEventEntity eventEntity = new IntegrationErrorReceivedEventEntity(event);

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
@@ -67,7 +67,7 @@ public class IntegrationErrorReceivedEventConverterTest {
         );
         event.setSequenceNumber(1);
         IntegrationErrorReceivedEventEntity eventEntity = new IntegrationErrorReceivedEventEntity(event);
-        Thread.sleep(1);
+        Thread.sleep(1); // sleep to make sure the timestamp is retrieved from the db and is not current time
         CloudRuntimeEventImpl<?, ?> apiEvent = converter.createAPIEvent(eventEntity);
         assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
     }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationErrorReceivedEventConverterTest.java
@@ -27,18 +27,19 @@ import org.junit.jupiter.api.Test;
 
 public class IntegrationErrorReceivedEventConverterTest {
 
-    private final IntegrationErrorReceivedEventConverter converter =
-            new IntegrationErrorReceivedEventConverter(new EventContextInfoAppender());
+    private final IntegrationErrorReceivedEventConverter converter = new IntegrationErrorReceivedEventConverter(
+                    new EventContextInfoAppender()
+            );
 
     @Test
     public void createEventEntity_should_setErrorRelatedProperties() {
         //given
         CloudIntegrationErrorReceivedEventImpl errorReceivedEvent = new CloudIntegrationErrorReceivedEventImpl(
-            new IntegrationContextImpl(),
-            "errorCode",
-            "Something went wrong",
-            RuntimeException.class.getName(),
-            Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
+          new IntegrationContextImpl(),
+          "errorCode",
+          "Something went wrong",
+          RuntimeException.class.getName(),
+          Collections.singletonList(new StackTraceElement("any", "any", "any", 1))
         );
         errorReceivedEvent.setSequenceNumber(1);
 

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationRequestedEventConverterTest {
 
-    private final IntegrationRequestedEventConverter integrationRequestedEventConverter = new IntegrationRequestedEventConverter(
-            new EventContextInfoAppender()
-    );
+    private final IntegrationRequestedEventConverter integrationRequestedEventConverter =
+        new IntegrationRequestedEventConverter(new EventContextInfoAppender());
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -36,7 +36,7 @@ class IntegrationRequestedEventConverterTest {
         CloudIntegrationRequestedEventImpl event = new CloudIntegrationRequestedEventImpl(integrationContext);
         event.setSequenceNumber(1);
         IntegrationRequestSentEventEntity eventEntity = new IntegrationRequestSentEventEntity(event);
-        Thread.sleep(1);
+        Thread.sleep(1); // sleep to make sure the timestamp is retrieved from the db and is not current time
         CloudRuntimeEventImpl<?, ?> apiEvent = integrationRequestedEventConverter.createAPIEvent(eventEntity);
         assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
     }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class IntegrationRequestedEventConverterTest {
 
     private final IntegrationRequestedEventConverter integrationRequestedEventConverter = new IntegrationRequestedEventConverter(
-            new EventContextInfoAppender()
+        new EventContextInfoAppender()
     );
 
     @Test

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -26,8 +26,9 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationRequestedEventConverterTest {
 
-    private final IntegrationRequestedEventConverter integrationRequestedEventConverter =
-        new IntegrationRequestedEventConverter(new EventContextInfoAppender());
+    private final IntegrationRequestedEventConverter integrationRequestedEventConverter = new IntegrationRequestedEventConverter(
+            new EventContextInfoAppender()
+    );
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -26,8 +26,9 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationRequestedEventConverterTest {
 
-    private final IntegrationRequestedEventConverter integrationRequestedEventConverter =
-            new IntegrationRequestedEventConverter(new EventContextInfoAppender());
+    private final IntegrationRequestedEventConverter integrationRequestedEventConverter = new IntegrationRequestedEventConverter(
+            new EventContextInfoAppender()
+    );
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationRequestedEventConverterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.impl.CloudIntegrationContextImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationRequestedEventImpl;
+import org.activiti.cloud.services.audit.jpa.events.IntegrationRequestSentEventEntity;
+import org.junit.jupiter.api.Test;
+
+class IntegrationRequestedEventConverterTest {
+
+    private final IntegrationRequestedEventConverter integrationRequestedEventConverter =
+            new IntegrationRequestedEventConverter(new EventContextInfoAppender());
+
+    @Test
+    void shouldConvertToAPIEvent() throws InterruptedException {
+        CloudIntegrationContextImpl integrationContext = new CloudIntegrationContextImpl();
+        CloudIntegrationRequestedEventImpl event = new CloudIntegrationRequestedEventImpl(integrationContext);
+        event.setSequenceNumber(1);
+        IntegrationRequestSentEventEntity eventEntity = new IntegrationRequestSentEventEntity(event);
+        Thread.sleep(1);
+        CloudRuntimeEventImpl<?, ?> apiEvent = integrationRequestedEventConverter.createAPIEvent(eventEntity);
+        assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -26,8 +26,9 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationResultReceivedEventConverterTest {
 
-    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter =
-            new IntegrationResultReceivedEventConverter(new EventContextInfoAppender());
+    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter = new IntegrationResultReceivedEventConverter(
+            new EventContextInfoAppender()
+    );
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -26,8 +26,9 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationResultReceivedEventConverterTest {
 
-    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter =
-        new IntegrationResultReceivedEventConverter(new EventContextInfoAppender());
+    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter = new IntegrationResultReceivedEventConverter(
+            new EventContextInfoAppender()
+    );
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -26,9 +26,8 @@ import org.junit.jupiter.api.Test;
 
 class IntegrationResultReceivedEventConverterTest {
 
-    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter = new IntegrationResultReceivedEventConverter(
-            new EventContextInfoAppender()
-    );
+    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter =
+        new IntegrationResultReceivedEventConverter(new EventContextInfoAppender());
 
     @Test
     void shouldConvertToAPIEvent() throws InterruptedException {
@@ -41,5 +40,4 @@ class IntegrationResultReceivedEventConverterTest {
         CloudRuntimeEventImpl<?, ?> apiEvent = integrationResultReceivedEventConverter.createAPIEvent(eventEntity);
         assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
     }
-
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.impl.CloudIntegrationContextImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudIntegrationResultReceivedEventImpl;
+import org.activiti.cloud.services.audit.jpa.events.IntegrationResultReceivedEventEntity;
+import org.junit.jupiter.api.Test;
+
+class IntegrationResultReceivedEventConverterTest {
+
+    private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter =
+            new IntegrationResultReceivedEventConverter(new EventContextInfoAppender());
+
+    @Test
+    void shouldConvertToAPIEvent() throws InterruptedException {
+        CloudIntegrationContextImpl integrationContext = new CloudIntegrationContextImpl();
+        CloudIntegrationResultReceivedEventImpl event = new CloudIntegrationResultReceivedEventImpl(integrationContext);
+        event.setSequenceNumber(1);
+        IntegrationResultReceivedEventEntity eventEntity = new IntegrationResultReceivedEventEntity(event);
+        eventEntity.setEventId("eventId");
+        Thread.sleep(1);
+        CloudRuntimeEventImpl<?, ?> apiEvent = integrationResultReceivedEventConverter.createAPIEvent(eventEntity);
+        assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
+    }
+
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class IntegrationResultReceivedEventConverterTest {
 
     private final IntegrationResultReceivedEventConverter integrationResultReceivedEventConverter = new IntegrationResultReceivedEventConverter(
-            new EventContextInfoAppender()
+        new EventContextInfoAppender()
     );
 
     @Test

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IntegrationResultReceivedEventConverterTest.java
@@ -37,7 +37,7 @@ class IntegrationResultReceivedEventConverterTest {
         event.setSequenceNumber(1);
         IntegrationResultReceivedEventEntity eventEntity = new IntegrationResultReceivedEventEntity(event);
         eventEntity.setEventId("eventId");
-        Thread.sleep(1);
+        Thread.sleep(1); // sleep to make sure the timestamp is retrieved from the db and is not current time
         CloudRuntimeEventImpl<?, ?> apiEvent = integrationResultReceivedEventConverter.createAPIEvent(eventEntity);
         assertThat(apiEvent.getTimestamp()).isEqualTo(event.getTimestamp());
     }


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4314
Audit integration events are returned by the audit service with current timestamps instead of the real timestamps written in the databases. This fixes it by invoking the correct constructor.