### PR TITLE
Fix execute command PropagateCloudBpmnErrorCmd

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -18,6 +18,7 @@ package org.activiti.services.connectors.channel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.IntegrationError;
@@ -117,6 +118,12 @@ public class ServiceTaskIntegrationErrorEventHandler {
                             return;
                         } catch (Throwable cause) {
                             LOGGER.error("Error propagating CloudBpmnError: {}", cause.getMessage());
+                            // cleaned the commands list from PropagateCloudBpmnErrorCmd and AggregateIntegrationErrorReceivedClosingEventCmd
+                            commands =
+                                commands
+                                    .stream()
+                                    .filter(command -> command.getClass().equals(DeleteIntegrationContextCmd.class))
+                                    .collect(Collectors.toList());
                         }
                     } else {
                         LOGGER.warn(

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -119,11 +119,7 @@ public class ServiceTaskIntegrationErrorEventHandler {
                         } catch (Throwable cause) {
                             LOGGER.error("Error propagating CloudBpmnError: {}", cause.getMessage());
                             // cleaned the commands list from PropagateCloudBpmnErrorCmd and AggregateIntegrationErrorReceivedClosingEventCmd
-                            commands =
-                                commands
-                                    .stream()
-                                    .filter(command -> command.getClass().equals(DeleteIntegrationContextCmd.class))
-                                    .collect(Collectors.toList());
+                            commands = restoreCommandList(commands);
                         }
                     } else {
                         LOGGER.warn(
@@ -156,5 +152,12 @@ public class ServiceTaskIntegrationErrorEventHandler {
 
             managementService.executeCommand(CompositeCommand.of(commands.toArray(Command[]::new)));
         }
+    }
+
+    private static List<Command<?>> restoreCommandList(List<Command<?>> commands) {
+        return commands
+            .stream()
+            .filter(command -> command.getClass().equals(DeleteIntegrationContextCmd.class))
+            .collect(Collectors.toList());
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandler.java
@@ -154,7 +154,7 @@ public class ServiceTaskIntegrationErrorEventHandler {
         }
     }
 
-    private static List<Command<?>> restoreCommandList(List<Command<?>> commands) {
+    private List<Command<?>> restoreCommandList(List<Command<?>> commands) {
         return commands
             .stream()
             .filter(command -> command.getClass().equals(DeleteIntegrationContextCmd.class))

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandlerTest.java
@@ -162,7 +162,7 @@ public class ServiceTaskIntegrationErrorEventHandlerTest {
             .thenAnswer(invocation -> {
                 CompositeCommand arg = invocation.getArgument(0);
                 if (arg.getCommands().stream().anyMatch(c -> c instanceof PropagateCloudBpmnErrorCmd)) {
-                    throw new RuntimeException("some exception");
+                    throw new Exception("some exception");
                 }
                 return arg;
             });

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationErrorEventHandlerTest.java
@@ -32,6 +32,7 @@ import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.RuntimeService;
+import org.activiti.engine.delegate.BpmnError;
 import org.activiti.engine.impl.cmd.integration.DeleteIntegrationContextCmd;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
@@ -162,7 +163,7 @@ public class ServiceTaskIntegrationErrorEventHandlerTest {
             .thenAnswer(invocation -> {
                 CompositeCommand arg = invocation.getArgument(0);
                 if (arg.getCommands().stream().anyMatch(c -> c instanceof PropagateCloudBpmnErrorCmd)) {
-                    throw new Exception("some exception");
+                    throw new BpmnError("some exception");
                 }
                 return arg;
             });


### PR DESCRIPTION
This PR fixes https://github.com/Activiti/Activiti/issues/4305.

When there is a `CloudBpmnError` the command `new PropagateCloudBpmnErrorCmd(integrationError, execution)` is added, which in this case throws an exception which is caught, then when we re-execute `managementService.executeCommand(CompositeCommand.of(commands.toArray(Command[]::new)));` at the end of the method we still have `PropagateCloudBpmnErrorCmd` in the command list, and then the exception is thrown again, which in this case is not caught, so the event to update the status of the service activity is not sent.

To solve this bug, the command list is cleaned in the catch 
Added unit test for this scenario