### PR TITLE
AAE-14299 extend keycloak client api for pagination

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
@@ -15,9 +15,9 @@
  */
 package org.activiti.cloud.services.identity.keycloak.client;
 
-import java.util.List;
 import feign.Headers;
 import feign.Response;
+import java.util.List;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakClientRepresentation;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakGroup;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakMappingsRepresentation;
@@ -140,11 +140,8 @@ public interface KeycloakClient {
         @RequestBody List<KeycloakRoleMapping> roles
     );
 
-    default List<KeycloakUser> getUsersClientRoleMapping(
-            String id,
-            String roleName
-    ) {
-        return getUsersClientRoleMapping(id, roleName, 0 ,100);
+    default List<KeycloakUser> getUsersClientRoleMapping(String id, String roleName) {
+        return getUsersClientRoleMapping(id, roleName, 0, 100);
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles/{role-name}/users")
@@ -188,9 +185,9 @@ public interface KeycloakClient {
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{groupId}/members")
     @Headers("Content-Type: application/json")
     List<KeycloakUser> getUsersByGroupId(
-            @PathVariable("groupId") String groupId,
-            @RequestParam(value = "first") Integer first,
-            @RequestParam(value = "max") Integer max
+        @PathVariable("groupId") String groupId,
+        @RequestParam(value = "first") Integer first,
+        @RequestParam(value = "max") Integer max
     );
 
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{id}")

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/client/KeycloakClient.java
@@ -15,9 +15,9 @@
  */
 package org.activiti.cloud.services.identity.keycloak.client;
 
+import java.util.List;
 import feign.Headers;
 import feign.Response;
-import java.util.List;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakClientRepresentation;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakGroup;
 import org.activiti.cloud.services.identity.keycloak.model.KeycloakMappingsRepresentation;
@@ -140,11 +140,20 @@ public interface KeycloakClient {
         @RequestBody List<KeycloakRoleMapping> roles
     );
 
+    default List<KeycloakUser> getUsersClientRoleMapping(
+            String id,
+            String roleName
+    ) {
+        return getUsersClientRoleMapping(id, roleName, 0 ,100);
+    }
+
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/roles/{role-name}/users")
     @Headers("Content-Type: application/json")
     List<KeycloakUser> getUsersClientRoleMapping(
         @PathVariable("id") String id,
-        @PathVariable("role-name") String roleName
+        @PathVariable("role-name") String roleName,
+        @RequestParam(value = "first") Integer first,
+        @RequestParam(value = "max") Integer max
     );
 
     @RequestMapping(method = RequestMethod.GET, value = "clients/{id}/service-account-user")
@@ -172,9 +181,17 @@ public interface KeycloakClient {
         @RequestBody KeycloakRoleMapping keycloakRoleMapping
     );
 
+    default List<KeycloakUser> getUsersByGroupId(String groupId) {
+        return getUsersByGroupId(groupId, 0, 100);
+    }
+
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{groupId}/members")
     @Headers("Content-Type: application/json")
-    List<KeycloakUser> getUsersByGroupId(@PathVariable("groupId") String groupId);
+    List<KeycloakUser> getUsersByGroupId(
+            @PathVariable("groupId") String groupId,
+            @RequestParam(value = "first") Integer first,
+            @RequestParam(value = "max") Integer max
+    );
 
     @RequestMapping(method = RequestMethod.GET, value = "/groups/{id}")
     @Headers("Content-Type: application/json")

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
@@ -15,8 +15,8 @@
  */
 package org.activiti.cloud.services.identity.keycloak;
 
-import java.util.Optional;
 import feign.Feign;
+import java.util.Optional;
 import org.activiti.api.runtime.shared.security.SecurityContextTokenProvider;
 import org.activiti.cloud.identity.config.IdentitySearchCacheConfiguration;
 import org.activiti.cloud.security.feign.AuthTokenRequestInterceptor;
@@ -66,29 +66,31 @@ public class KeycloakClientApplication {
 
     @Bean
     public TestKeycloakClient testKeycloakClient(
-            @Value("${keycloak.auth-server-url}/admin/realms/${keycloak.realm}/") String url,
-            ObjectFactory<HttpMessageConverters> messageConverters,
-            ObjectProvider<HttpMessageConverterCustomizer> customizers,
-            OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
-            ClientRegistrationRepository clientRegistrationRepository
+        @Value("${keycloak.auth-server-url}/admin/realms/${keycloak.realm}/") String url,
+        ObjectFactory<HttpMessageConverters> messageConverters,
+        ObjectProvider<HttpMessageConverterCustomizer> customizers,
+        OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
+        ClientRegistrationRepository clientRegistrationRepository
     ) {
-        ClientCredentialsAuthConfiguration clientCredentialsAuthConfiguration = new ClientCredentialsAuthConfiguration();
+        ClientCredentialsAuthConfiguration clientCredentialsAuthConfiguration =
+            new ClientCredentialsAuthConfiguration();
         ClientRegistration clientRegistration = clientCredentialsAuthConfiguration.clientRegistration(
-                clientRegistrationRepository,
-                "keycloak"
+            clientRegistrationRepository,
+            "keycloak"
         );
-        AuthTokenRequestInterceptor clientCredentialsAuthRequestInterceptor = clientCredentialsAuthConfiguration.clientCredentialsAuthRequestInterceptor(
+        AuthTokenRequestInterceptor clientCredentialsAuthRequestInterceptor =
+            clientCredentialsAuthConfiguration.clientCredentialsAuthRequestInterceptor(
                 oAuth2AuthorizedClientService,
                 clientRegistrationRepository,
                 clientRegistration
-        );
+            );
         TestKeycloakClient testKeycloakClient = Feign
-                .builder()
-                .contract(new SpringMvcContract())
-                .encoder(new SpringEncoder(messageConverters))
-                .decoder(new SpringDecoder(messageConverters, customizers))
-                .requestInterceptor(clientCredentialsAuthRequestInterceptor)
-                .target(TestKeycloakClient.class, url);
+            .builder()
+            .contract(new SpringMvcContract())
+            .encoder(new SpringEncoder(messageConverters))
+            .decoder(new SpringDecoder(messageConverters, customizers))
+            .requestInterceptor(clientCredentialsAuthRequestInterceptor)
+            .target(TestKeycloakClient.class, url);
         return testKeycloakClient;
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
@@ -72,18 +72,16 @@ public class KeycloakClientApplication {
         OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
         ClientRegistrationRepository clientRegistrationRepository
     ) {
-        ClientCredentialsAuthConfiguration clientCredentialsAuthConfiguration =
-            new ClientCredentialsAuthConfiguration();
+        ClientCredentialsAuthConfiguration clientCredentialsAuthConfiguration = new ClientCredentialsAuthConfiguration();
         ClientRegistration clientRegistration = clientCredentialsAuthConfiguration.clientRegistration(
             clientRegistrationRepository,
             "keycloak"
         );
-        AuthTokenRequestInterceptor clientCredentialsAuthRequestInterceptor =
-            clientCredentialsAuthConfiguration.clientCredentialsAuthRequestInterceptor(
-                oAuth2AuthorizedClientService,
-                clientRegistrationRepository,
-                clientRegistration
-            );
+        AuthTokenRequestInterceptor clientCredentialsAuthRequestInterceptor = clientCredentialsAuthConfiguration.clientCredentialsAuthRequestInterceptor(
+            oAuth2AuthorizedClientService,
+            clientRegistrationRepository,
+            clientRegistration
+        );
         TestKeycloakClient testKeycloakClient = Feign
             .builder()
             .contract(new SpringMvcContract())

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientApplication.java
@@ -16,17 +16,30 @@
 package org.activiti.cloud.services.identity.keycloak;
 
 import java.util.Optional;
+import feign.Feign;
 import org.activiti.api.runtime.shared.security.SecurityContextTokenProvider;
 import org.activiti.cloud.identity.config.IdentitySearchCacheConfiguration;
+import org.activiti.cloud.security.feign.AuthTokenRequestInterceptor;
+import org.activiti.cloud.security.feign.configuration.ClientCredentialsAuthConfiguration;
 import org.activiti.cloud.services.identity.keycloak.config.ActivitiKeycloakAutoConfiguration;
 import org.activiti.cloud.services.test.identity.keycloak.KeycloakTokenProducer;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.openfeign.support.HttpMessageConverterCustomizer;
+import org.springframework.cloud.openfeign.support.SpringDecoder;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.cloud.openfeign.support.SpringMvcContract;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 @SpringBootApplication
 @Import({ IdentitySearchCacheConfiguration.class, ActivitiKeycloakAutoConfiguration.class })
@@ -49,6 +62,34 @@ public class KeycloakClientApplication {
                     .withResource("activiti")
                     .getAccessTokenString()
             );
+    }
+
+    @Bean
+    public TestKeycloakClient testKeycloakClient(
+            @Value("${keycloak.auth-server-url}/admin/realms/${keycloak.realm}/") String url,
+            ObjectFactory<HttpMessageConverters> messageConverters,
+            ObjectProvider<HttpMessageConverterCustomizer> customizers,
+            OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
+            ClientRegistrationRepository clientRegistrationRepository
+    ) {
+        ClientCredentialsAuthConfiguration clientCredentialsAuthConfiguration = new ClientCredentialsAuthConfiguration();
+        ClientRegistration clientRegistration = clientCredentialsAuthConfiguration.clientRegistration(
+                clientRegistrationRepository,
+                "keycloak"
+        );
+        AuthTokenRequestInterceptor clientCredentialsAuthRequestInterceptor = clientCredentialsAuthConfiguration.clientCredentialsAuthRequestInterceptor(
+                oAuth2AuthorizedClientService,
+                clientRegistrationRepository,
+                clientRegistration
+        );
+        TestKeycloakClient testKeycloakClient = Feign
+                .builder()
+                .contract(new SpringMvcContract())
+                .encoder(new SpringEncoder(messageConverters))
+                .decoder(new SpringDecoder(messageConverters, customizers))
+                .requestInterceptor(clientCredentialsAuthRequestInterceptor)
+                .target(TestKeycloakClient.class, url);
+        return testKeycloakClient;
     }
 
     public static void main(String[] args) {

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
@@ -370,7 +370,12 @@ public class KeycloakClientIT {
         String clientId = testKeycloakClient.searchClients(ACTIVITI_CLIENT_ID, 0, 1).get(0).getId();
         KeycloakRoleMapping kRoleToAdd = assignRole(clientId);
 
-        List<KeycloakUser> users = keycloakClient.getUsersClientRoleMapping(clientId, kRoleToAdd.getName(), 0, Integer.MAX_VALUE);
+        List<KeycloakUser> users = keycloakClient.getUsersClientRoleMapping(
+            clientId,
+            kRoleToAdd.getName(),
+            0,
+            Integer.MAX_VALUE
+        );
 
         assertThat(users).hasSize(101);
 
@@ -378,13 +383,15 @@ public class KeycloakClientIT {
     }
 
     private KeycloakRoleMapping assignRole(String clientId) {
-        KeycloakRoleMapping kRoleToAdd = testKeycloakClient.getClientRoles(clientId)
-                .stream()
-                .filter(kRole -> kRole.getName().equals(DYNAMIC_ROLE_NAME))
-                .findFirst()
-                .get();
-        keycloakClient.searchUsers(TEST_USER_PREFIX, 0, Integer.MAX_VALUE).forEach(user ->
-                testKeycloakClient.addUserClientRoleMapping(user.getId(), clientId, List.of(kRoleToAdd)));
+        KeycloakRoleMapping kRoleToAdd = testKeycloakClient
+            .getClientRoles(clientId)
+            .stream()
+            .filter(kRole -> kRole.getName().equals(DYNAMIC_ROLE_NAME))
+            .findFirst()
+            .get();
+        keycloakClient
+            .searchUsers(TEST_USER_PREFIX, 0, Integer.MAX_VALUE)
+            .forEach(user -> testKeycloakClient.addUserClientRoleMapping(user.getId(), clientId, List.of(kRoleToAdd)));
         return kRoleToAdd;
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakClientIT.java
@@ -51,9 +51,16 @@ public class KeycloakClientIT {
     public static final String ACTIVITI_MODELER = "ACTIVITI_MODELER";
     public static final String ACTIVITI_CLIENT_ID = "activiti";
     public static final String ACTIVITI_ADMIN = "ACTIVITI_ADMIN";
+    public static final String DYNAMIC_GROUP_ID = "51331bf0-00e4-4eff-ad88-bad9511ac919";
+    public static final String DYNAMIC_GROUP_NAME = "dynamic";
+    public static final String DYNAMIC_ROLE_NAME = "DYNAMIC_ROLE";
+    public static final String TEST_USER_PREFIX = "testKeycloakUser";
 
     @Autowired
     private KeycloakClient keycloakClient;
+
+    @Autowired
+    private TestKeycloakClient testKeycloakClient;
 
     @Autowired
     private CacheManager cacheManager;
@@ -344,6 +351,50 @@ public class KeycloakClientIT {
         List<KeycloakUser> users = keycloakClient.getUsersByGroupId(HR_GROUP_ID);
 
         assertThat(users).hasSizeGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    public void should_get101Users_by_groupId() {
+        addUsers(101);
+
+        List<KeycloakUser> users = keycloakClient.getUsersByGroupId(DYNAMIC_GROUP_ID, 0, Integer.MAX_VALUE);
+
+        assertThat(users).hasSize(101);
+
+        users.forEach(user -> testKeycloakClient.deleteUser(user.getId()));
+    }
+
+    @Test
+    public void should_get101Users_by_Role() {
+        addUsers(101);
+        String clientId = testKeycloakClient.searchClients(ACTIVITI_CLIENT_ID, 0, 1).get(0).getId();
+        KeycloakRoleMapping kRoleToAdd = assignRole(clientId);
+
+        List<KeycloakUser> users = keycloakClient.getUsersClientRoleMapping(clientId, kRoleToAdd.getName(), 0, Integer.MAX_VALUE);
+
+        assertThat(users).hasSize(101);
+
+        users.forEach(user -> testKeycloakClient.deleteUser(user.getId()));
+    }
+
+    private KeycloakRoleMapping assignRole(String clientId) {
+        KeycloakRoleMapping kRoleToAdd = testKeycloakClient.getClientRoles(clientId)
+                .stream()
+                .filter(kRole -> kRole.getName().equals(DYNAMIC_ROLE_NAME))
+                .findFirst()
+                .get();
+        keycloakClient.searchUsers(TEST_USER_PREFIX, 0, Integer.MAX_VALUE).forEach(user ->
+                testKeycloakClient.addUserClientRoleMapping(user.getId(), clientId, List.of(kRoleToAdd)));
+        return kRoleToAdd;
+    }
+
+    private void addUsers(int userCount) {
+        for (int i = 0; i < userCount; i++) {
+            TestKeycloakUser user = new TestKeycloakUser();
+            user.setUsername(TEST_USER_PREFIX + i);
+            user.setGroups(List.of(DYNAMIC_GROUP_NAME));
+            testKeycloakClient.addUser(user);
+        }
     }
 
     @Test

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.identity.keycloak;
+
+import feign.Headers;
+import org.activiti.cloud.services.identity.keycloak.client.KeycloakClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+public interface TestKeycloakClient extends KeycloakClient {
+
+    @RequestMapping(method = RequestMethod.POST, value = "/users")
+    @Headers("Content-Type: application/json")
+    void addUser(TestKeycloakUser user);
+
+    @RequestMapping(method = RequestMethod.DELETE, value = "/users/{id}")
+    @Headers("Content-Type: application/json")
+    void deleteUser(@PathVariable("id") String id);
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakClient.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakClient.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 public interface TestKeycloakClient extends KeycloakClient {
-
     @RequestMapping(method = RequestMethod.POST, value = "/users")
     @Headers("Content-Type: application/json")
     void addUser(TestKeycloakUser user);
@@ -31,5 +30,4 @@ public interface TestKeycloakClient extends KeycloakClient {
     @RequestMapping(method = RequestMethod.DELETE, value = "/users/{id}")
     @Headers("Content-Type: application/json")
     void deleteUser(@PathVariable("id") String id);
-
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakUser.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakUser.java
@@ -30,5 +30,4 @@ public class TestKeycloakUser extends KeycloakUser {
     public void setGroups(List<String> groups) {
         this.groups = groups;
     }
-
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakUser.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/TestKeycloakUser.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.identity.keycloak;
+
+import java.util.List;
+import org.activiti.cloud.services.identity.keycloak.model.KeycloakUser;
+
+public class TestKeycloakUser extends KeycloakUser {
+
+    private List<String> groups;
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
+    }
+
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
@@ -81,7 +81,12 @@
     },
     {
       "id": "51331bf0-00e4-4eff-ad88-bad9511ac919",
-      "name": "dynamic"
+      "name": "dynamic",
+      "clientRoles": {
+        "activiti": [
+          "DYNAMIC_ROLE"
+        ]
+      }
     },
     {
       "name": "salesgroup",

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/resources/activiti-realm.json
@@ -59,6 +59,12 @@
           "name": "ACTIVITI_ADMIN",
           "clientRole": true
         }
+      ],
+      "activiti": [
+        {
+          "name": "DYNAMIC_ROLE",
+          "clientRole": true
+        }
       ]
     }
   },
@@ -72,6 +78,10 @@
     },
     {
       "name": "testgroup"
+    },
+    {
+      "id": "51331bf0-00e4-4eff-ad88-bad9511ac919",
+      "name": "dynamic"
     },
     {
       "name": "salesgroup",

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
@@ -220,8 +220,8 @@ public abstract class AbstractIdentityManagementControllerIT {
         mockMvc
             .perform(get("/v1/groups?application=activiti"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", hasSize(1)))
-            .andExpect(jsonPath("$[0].name", is("salesgroup")));
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[?(@.name)].name", containsInAnyOrder("salesgroup", "dynamic")));
     }
 
     @Test

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
@@ -377,7 +377,7 @@ public abstract class AbstractIdentityManagementControllerIT {
     public void should_returnApplicationPermissions() throws Exception {
         this.mockMvc.perform(get("/v1/permissions/{application}", "activiti"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$", hasSize(5)))
+            .andExpect(jsonPath("$", hasSize(6)))
             .andExpect(
                 jsonPath(
                     "$[?(@.role)].role",
@@ -386,7 +386,8 @@ public abstract class AbstractIdentityManagementControllerIT {
                         "ACTIVITI_ADMIN",
                         "APPLICATION_MANAGER",
                         "uma_authorization",
-                        "offline_access"
+                        "offline_access",
+                        "DYNAMIC_ROLE"
                     )
                 )
             );


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4327
The keycloak API endpoints `clients/{id}/roles/{role-name}/users` and `/groups/{groupId}/members` handle pagination and it should be reflected in KeycloakClient. It enables projects based on activiti-cloud to handle pagination.