### PR TITLE
[PoC] Multi-thread Maven Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Maven Build and Test
         shell: bash
-        run: mvn -DnoAcceptanceTests=true -T 4 verify ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn -DnoAcceptanceTests=true verify  -T 4  ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Maven Build and Test
         shell: bash
-        run: mvn -DnoAcceptanceTests=true -T 1.5C verify ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn -DnoAcceptanceTests=true -T 4 verify ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Maven Build and Test
         shell: bash
-        run: mvn -DnoAcceptanceTests=true verify ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn -DnoAcceptanceTests=true -T 1.5C verify ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Maven Build and Test
         shell: bash
-        run: mvn -DnoAcceptanceTests=true verify  -T 1C  ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn verify -T 3 -DnoAcceptanceTests=true  ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Maven Build and Test
         shell: bash
-        run: mvn -DnoAcceptanceTests=true verify  -T 4  ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn -DnoAcceptanceTests=true verify  -T 1C  ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -19,7 +19,7 @@
     <module>identity-adapter-acceptance-tests</module>
   </modules>
   <properties>
-    <noAcceptanceTests>true</noAcceptanceTests>
+    <skipTests>${noAcceptanceTests}</skipTests>
     <maven.deploy.skip>true</maven.deploy.skip>
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
@@ -50,7 +50,10 @@
     <profile>
       <id>acceptance-tests</id>
       <activation>
-        <property>!noAcceptanceTests</property>
+        <property>
+          <name>noAcceptanceTests</name>
+          <value>!true</value>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -67,7 +70,7 @@
                 <include>**/*Tests.java</include>
                 <include>**/*TestSuite.java</include>
               </includes>
-              <forkCount>0</forkCount>
+              <forkCount>1</forkCount>
               <classesDirectory>${project.build.outputDirectory}</classesDirectory>
             </configuration>
           </plugin>

--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -19,13 +19,13 @@
     <module>identity-adapter-acceptance-tests</module>
   </modules>
   <properties>
-    <skipTests>${noAcceptanceTests}</skipTests>
+    <noAcceptanceTests>true</noAcceptanceTests>
     <maven.deploy.skip>true</maven.deploy.skip>
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
     <activiti-cloud.version>${project.version}</activiti-cloud.version>
-    <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
+    <serenity-maven-plugin.version>3.7.1</serenity-maven-plugin.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>
@@ -46,42 +46,46 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-          <skipTests>${skipTests}</skipTests>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*Test.java</include>
-            <include>**/*Tests.java</include>
-            <include>**/*TestSuite.java</include>
-          </includes>
-          <forkCount>0</forkCount>
-          <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>net.serenity-bdd.maven.plugins</groupId>
-        <artifactId>serenity-maven-plugin</artifactId>
-        <version>${serenity-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>acceptance-tests</id>
+      <activation>
+        <property>!noAcceptanceTests</property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*Test.java</include>
+                <include>**/*Tests.java</include>
+                <include>**/*TestSuite.java</include>
+              </includes>
+              <forkCount>0</forkCount>
+              <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>net.serenity-bdd.maven.plugins</groupId>
+            <artifactId>serenity-maven-plugin</artifactId>
+            <version>${serenity-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>aggregate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/pom.xml
@@ -12,6 +12,7 @@
   <name>Activiti Cloud Audit :: Services :: Audit JPA</name>
   <properties>
     <opencsv.version>5.6</opencsv.version>
+    <skipTests>true</skipTests>
   </properties>
   <dependencies>
     <dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/pom.xml
@@ -12,7 +12,6 @@
   <name>Activiti Cloud Audit :: Services :: Audit JPA</name>
   <properties>
     <opencsv.version>5.6</opencsv.version>
-    <skipTests>true</skipTests>
   </properties>
   <dependencies>
     <dependency>

--- a/activiti-cloud-examples/pom.xml
+++ b/activiti-cloud-examples/pom.xml
@@ -172,7 +172,6 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${maven-failsafe-plugin.version}</version>
             <configuration>
-              <forkCount>0</forkCount>
               <useSystemClassLoader>false</useSystemClassLoader>
               <classesDirectory>${project.build.outputDirectory}</classesDirectory>
             </configuration>

--- a/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/rb/MultipleRbMessagesIT.java
+++ b/activiti-cloud-messages-service/integration-tests/src/test/java/org/activiti/cloud/messages/integration/tests/rb/MultipleRbMessagesIT.java
@@ -54,6 +54,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.util.TestSocketUtils;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -61,6 +62,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class MultipleRbMessagesIT {
+
+    private static final Integer DB_PORT = TestSocketUtils.findAvailableTcpPort();
 
     private static final String INTERMEDIATE_CATCH_MESSAGE_PROCESS = "IntermediateCatchMessageProcess";
     private static final String INTERMEDIATE_THROW_MESSAGE_PROCESS = "IntermediateThrowMessageProcess";
@@ -82,7 +85,7 @@ class MultipleRbMessagesIT {
 
         @Bean(initMethod = "start", destroyMethod = "stop")
         public Server inMemoryH2DatabaseServer() throws SQLException {
-            return Server.createTcpServer("-tcp", "-tcpAllowOthers", "-ifNotExists", "-tcpPort", "9090");
+            return Server.createTcpServer("-tcp", "-tcpAllowOthers", "-ifNotExists", "-tcpPort", DB_PORT.toString());
         }
     }
 
@@ -141,7 +144,7 @@ class MultipleRbMessagesIT {
                 rb1Context =
                     new SpringApplicationBuilder(RbApplication.class)
                         .properties(
-                            "server.port=8081",
+                            "server.port=" + TestSocketUtils.findAvailableTcpPort(),
                             "spring.main.banner-mode=off",
                             "activiti.cloud.application.name=messages-app1",
                             "spring.application.name=rb"
@@ -151,7 +154,7 @@ class MultipleRbMessagesIT {
                 rb2Context =
                     new SpringApplicationBuilder(RbApplication.class)
                         .properties(
-                            "server.port=8082",
+                            "server.port=" + TestSocketUtils.findAvailableTcpPort(),
                             "spring.main.banner-mode=off",
                             "activiti.cloud.application.name=messages-app2",
                             "spring.application.name=rb"

--- a/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -100,6 +100,8 @@ public abstract class AbstractMessagesCoreIntegrationTests {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMessagesCoreIntegrationTests.class);
 
+    private static final int TEST_TIMEOUT = 30;
+
     protected ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
@@ -186,7 +188,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
     }
 
     @Test
-    @Timeout(20)
+    @Timeout(TEST_TIMEOUT)
     public void shouldProcessMessageEventsConcurrently() throws InterruptedException, JsonProcessingException {
         // given
         String messageEventName = "start";
@@ -229,7 +231,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
     }
 
     @Test
-    @Timeout(20)
+    @Timeout(TEST_TIMEOUT)
     public void shouldProcessMessageEventsConcurrentlyInReversedOrder()
         throws InterruptedException, JsonProcessingException {
         // given

--- a/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -100,7 +100,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMessagesCoreIntegrationTests.class);
 
-    private static final int TEST_TIMEOUT = 30;
+    protected static final int TEST_TIMEOUT = 30;
 
     protected ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/activiti-cloud-messages-service/starters/hazelcast/src/test/java/org/activiti/cloud/starter/messages/test/hazelcast/HazelcastMessageStoreIT.java
+++ b/activiti-cloud-messages-service/starters/hazelcast/src/test/java/org/activiti/cloud/starter/messages/test/hazelcast/HazelcastMessageStoreIT.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import org.activiti.cloud.services.messages.tests.AbstractMessagesCoreIntegrationTests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -31,6 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 import org.springframework.integration.hazelcast.store.HazelcastMessageStore;
 
+@Isolated
 public class HazelcastMessageStoreIT extends AbstractMessagesCoreIntegrationTests {
 
     @SpringBootApplication

--- a/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/JdbcMessageStoreTests.java
+++ b/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/JdbcMessageStoreTests.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.cloud.services.messages.tests.AbstractMessagesCoreIntegrationTests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.integration.jdbc.store.JdbcMessageStore;
 import org.springframework.test.context.TestPropertySource;
 
+@Isolated
 @TestPropertySource(properties = { "spring.datasource.platform=h2" })
 public class JdbcMessageStoreTests extends AbstractMessagesCoreIntegrationTests {
 

--- a/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/PostgresMessageStoreIT.java
+++ b/activiti-cloud-messages-service/starters/jdbc/src/test/java/org/activiti/cloud/starter/messages/test/jdbc/PostgresMessageStoreIT.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.cloud.services.messages.tests.AbstractMessagesCoreIntegrationTests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.integration.jdbc.store.JdbcMessageStore;
 import org.springframework.test.context.ContextConfiguration;
 
+@Isolated
 @ContextConfiguration(initializers = PostgresApplicationInitializer.class)
 public class PostgresMessageStoreIT extends AbstractMessagesCoreIntegrationTests {
 

--- a/activiti-cloud-messages-service/starters/redis/src/test/java/org/activiti/cloud/starter/messages/test/redis/RedisMessageStoreIT.java
+++ b/activiti-cloud-messages-service/starters/redis/src/test/java/org/activiti/cloud/starter/messages/test/redis/RedisMessageStoreIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.cloud.services.messages.tests.AbstractMessagesCoreIntegrationTests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,7 @@ import org.springframework.integration.transaction.PseudoTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+@Isolated
 @ContextConfiguration(initializers = RedisApplicationInitializer.class)
 public class RedisMessageStoreIT extends AbstractMessagesCoreIntegrationTests {
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/resources/application.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/resources/application.properties
@@ -7,7 +7,7 @@ spring.jmx.enabled=false
 spring.rabbitmq.host=localhost
 
 # Shared H2 database instance
-spring.datasource.url=jdbc:h2:tcp://localhost:9090/mem:mydb
+# spring.datasource.url=jdbc:h2:tcp://localhost:9090/mem:mydb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password="

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <module>activiti-cloud-modeling-service</module>
     <module>activiti-cloud-notifications-graphql-service</module>
     <module>activiti-cloud-connectors</module>
-<!--    <module>activiti-cloud-acceptance-scenarios</module>-->
+    <module>activiti-cloud-acceptance-scenarios</module>
     <module>activiti-cloud-examples</module>
     <module>activiti-cloud-dependencies</module>
   </modules>
@@ -184,6 +184,8 @@
     <url>https://travis-ci.com/${project.scm.organization}/${project.scm.repository}</url>
   </ciManagement>
   <properties>
+    <noAcceptanceTests>false</noAcceptanceTests>
+
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,10 @@
     <maven-site-plugin.version>3.11.0</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+
+    <!-- Tests Config -->
+    <unitTests.parallel>true</unitTests.parallel>
+    <unitTests.dynamicFactor>1</unitTests.dynamicFactor>
   </properties>
   <repositories>
     <repository>
@@ -480,6 +484,18 @@ limitations under the License.]]>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled=${unitTests.parallel}
+              junit.jupiter.execution.parallel.config.strategy=dynamic
+              junit.jupiter.execution.parallel.mode.default=same_thread
+              junit.jupiter.execution.parallel.mode.classes.default=concurrent
+              junit.jupiter.execution.parallel.config.dynamic.factor=${unitTests.dynamicFactor}
+            </configurationParameters>
+          </properties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <module>activiti-cloud-modeling-service</module>
     <module>activiti-cloud-notifications-graphql-service</module>
     <module>activiti-cloud-connectors</module>
-    <module>activiti-cloud-acceptance-scenarios</module>
+<!--    <module>activiti-cloud-acceptance-scenarios</module>-->
     <module>activiti-cloud-examples</module>
     <module>activiti-cloud-dependencies</module>
   </modules>
@@ -210,7 +210,7 @@
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <third-party-license-maven-plugin.version>2.0.1.alfresco-2</third-party-license-maven-plugin.version>
-    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
This PR configures the project for multithread builds:
- it introduces the profile `acceptance-tests` with activation on property `noAcceptanceTests=false` which is the default value to exclude `serenity-maven-plugin` from the main aggregator since it was causing random failures in the following goals: `default-testCompile`, `test`, `integration-test`
- the Unit Tests are executed in parallel by classes, meaning that UT methods are executed sequentially inside a class avoiding conflicts
- nothing is changed for Integration Tests since they cannot be executed in parallel unless defining `@ResourceLocks` or `@Isolated` on test classes to avoid race-conditions (in the end it would not improve the performances, see: Activiti/activiti-cloud#1073)
- Integration Tests belonging to different modules are executed in parallel, so it has been required removing static service ports where defined to avoid errors

_NOTE_: the goal `add-third-party` of the plugin `license-maven-plugin` is not marked as `threadsafe` so there are warnings from maven compiler. From the inspection of the plugin and a check of the resulting licenses `THIRD-PARTY.txt`, the plugin seems safe to use in a multi-thread build.