### PR TITLE
Remove nimbus-jose-jwt shaded dependencies

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/mapper/KeycloakTokenToUserRoles.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/mapper/KeycloakTokenToUserRoles.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.services.identity.keycloak.mapper;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class KeycloakTokenToUserRoles {
             .map(Map::entrySet)
             .orElse(Collections.emptySet())
             .stream()
-            .map(e -> new UserApplicationAccess(e.getKey(), getRoles((JSONObject) e.getValue())))
+            .map(e -> new UserApplicationAccess(e.getKey(), getRoles((Map<String, Object>) e.getValue())))
             .collect(Collectors.toList());
     }
 
@@ -63,7 +62,7 @@ public class KeycloakTokenToUserRoles {
         }
     }
 
-    private static List<String> getRoles(JSONObject getRolesParent) {
+    private static List<String> getRoles(Map<String, Object> getRolesParent) {
         return Optional.ofNullable((List<String>) getRolesParent.get(ROLES)).orElse(Collections.emptyList());
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/mapper/KeycloakTokenToUserRolesTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/mapper/KeycloakTokenToUserRolesTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import java.util.List;
 import java.util.Map;
 import org.activiti.cloud.identity.model.UserApplicationAccess;
@@ -73,25 +73,24 @@ public class KeycloakTokenToUserRolesTest {
     }
 
     private void mockJwt(boolean withResourceRoleMappings, boolean withRealmRoleMappings) {
-        JSONObject resourceRoleMappings;
-        JSONObject realmRoleMappings;
+        Map<String, Object> resourceRoleMappings;
+        Map<String, Object> realmRoleMappings;
 
         if (withResourceRoleMappings) {
-            resourceRoleMappings =
-                new JSONObject(
-                    Map.of(
-                        "resource1",
-                        new JSONObject(Map.of("roles", List.of("role1"))),
-                        "resource2",
-                        new JSONObject(Map.of("roles", List.of("role1", "role2")))
-                    )
-                );
+            resourceRoleMappings = JSONObjectUtils.newJSONObject();
+            Map<String, Object> resource1Roles = JSONObjectUtils.newJSONObject();
+            resource1Roles.put("roles", List.of("role1"));
+            Map<String, Object> resource2Roles = JSONObjectUtils.newJSONObject();
+            resource2Roles.put("roles", List.of("role1", "role2"));
+            resourceRoleMappings.put("resource1", resource1Roles);
+            resourceRoleMappings.put("resource2", resource2Roles);
         } else {
             resourceRoleMappings = null;
         }
 
         if (withRealmRoleMappings) {
-            realmRoleMappings = new JSONObject(Map.of("roles", List.of("role1", "role2", "role3")));
+            realmRoleMappings = JSONObjectUtils.newJSONObject();
+            realmRoleMappings.putAll(Map.of("roles", List.of("role1", "role2", "role3")));
         } else {
             realmRoleMappings = null;
         }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakJwtAdapter.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakJwtAdapter.java
@@ -15,9 +15,9 @@
  */
 package org.activiti.cloud.services.common.security.keycloak;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.activiti.cloud.services.common.security.jwt.JwtAdapter;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -56,7 +56,7 @@ public class KeycloakJwtAdapter implements JwtAdapter {
         }
     }
 
-    private List<String> getRoles(JSONObject getRolesParent) {
+    private List<String> getRoles(Map<String, Object> getRolesParent) {
         return (List<String>) getRolesParent.get("roles");
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapter.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapter.java
@@ -15,9 +15,9 @@
  */
 package org.activiti.cloud.services.common.security.keycloak;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.activiti.cloud.services.common.security.jwt.JwtAdapter;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -57,15 +57,15 @@ public class KeycloakResourceJwtAdapter implements JwtAdapter {
 
     private List<String> getFromClient(String clientId, Jwt jwt) {
         if (jwt.hasClaim("resource_access")) {
-            JSONObject resourceAccess = jwt.getClaim("resource_access");
+            Map<String, Object> resourceAccess = jwt.getClaim("resource_access");
             if (resourceAccess.get(clientId) != null) {
-                return getRoles((JSONObject) resourceAccess.get(clientId));
+                return getRoles((Map<String, Object>) resourceAccess.get(clientId));
             }
         }
         return Collections.emptyList();
     }
 
-    private List<String> getRoles(JSONObject getRolesParent) {
+    private List<String> getRoles(Map<String, Object> getRolesParent) {
         return (List<String>) getRolesParent.get("roles");
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakJwtAdapterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakJwtAdapterTest.java
@@ -19,8 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -45,7 +46,7 @@ public class KeycloakJwtAdapterTest {
 
     @Test
     public void shouldNotThrowAnyExceptionWhenRolesIsNull() {
-        JSONObject rolesParent = new JSONObject();
+        Map<String, Object> rolesParent = JSONObjectUtils.newJSONObject();
         rolesParent.put("roles", null);
         when(jwt.hasClaim("realm_access")).thenReturn(true);
         when(jwt.getClaim("realm_access")).thenReturn(rolesParent);
@@ -55,7 +56,7 @@ public class KeycloakJwtAdapterTest {
 
     @Test
     public void shouldReturnRoles() {
-        JSONObject rolesParent = new JSONObject();
+        Map<String, Object> rolesParent = JSONObjectUtils.newJSONObject();
         rolesParent.put("roles", List.of("roleA", "roleB"));
         when(jwt.hasClaim("realm_access")).thenReturn(true);
         when(jwt.getClaim("realm_access")).thenReturn(rolesParent);

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security-keycloak/src/test/java/org/activiti/cloud/services/common/security/keycloak/KeycloakResourceJwtAdapterTest.java
@@ -19,8 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,7 +53,7 @@ public class KeycloakResourceJwtAdapterTest {
 
     @Test
     public void shouldNotThrowAnyExceptionWhenRolesIsNull() {
-        JSONObject rolesParent = new JSONObject();
+        Map<String, Object> rolesParent = JSONObjectUtils.newJSONObject();
         rolesParent.put("roles", null);
         when(jwt.hasClaim("resource_access")).thenReturn(true);
         when(jwt.getClaim("resource_access")).thenReturn(rolesParent);
@@ -62,8 +63,8 @@ public class KeycloakResourceJwtAdapterTest {
 
     @Test
     public void shouldReturnRoles() {
-        JSONObject client = new JSONObject();
-        JSONObject roles = new JSONObject();
+        Map<String, Object> client = JSONObjectUtils.newJSONObject();
+        Map<String, Object> roles = JSONObjectUtils.newJSONObject();
         roles.put("roles", List.of("roleA", "roleB"));
         client.put("app", roles);
         when(jwt.hasClaim("resource_access")).thenReturn(true);

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/WithActivitiMockUserSecurityContextFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/WithActivitiMockUserSecurityContextFactory.java
@@ -15,7 +15,7 @@
  */
 package org.activiti.cloud.services.common.security.test.support;
 
-import com.nimbusds.jose.shaded.json.JSONArray;
+import com.nimbusds.jose.util.JSONArrayUtils;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.impl.TextCodec;
@@ -95,7 +95,7 @@ public class WithActivitiMockUserSecurityContextFactory implements WithSecurityC
         rolesClaimProvider.setGlobalRoles(globalRoles, claims);
         rolesClaimProvider.setResourceRoles(resourceRoles, claims);
 
-        JSONArray groupsArray = new JSONArray();
+        List<Object> groupsArray = JSONArrayUtils.newJSONArray();
         groupsArray.addAll(groups);
         claims.put("groups", groupsArray);
 

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/keycloak/KeycloakRolesClaimProvider.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/keycloak/KeycloakRolesClaimProvider.java
@@ -15,9 +15,10 @@
  */
 package org.activiti.cloud.services.common.security.test.support.keycloak;
 
-import com.nimbusds.jose.shaded.json.JSONArray;
-import com.nimbusds.jose.shaded.json.JSONObject;
+import com.nimbusds.jose.util.JSONArrayUtils;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.activiti.cloud.services.common.security.test.support.RolesClaimProvider;
@@ -34,10 +35,10 @@ public class KeycloakRolesClaimProvider implements RolesClaimProvider {
 
     @Override
     public void setResourceRoles(Map<String, String[]> resourceRoles, Map<String, Object> claims) {
-        JSONObject resourceAccess = new JSONObject();
+        Map<String, Object> resourceAccess = JSONObjectUtils.newJSONObject();
         for (String key : resourceRoles.keySet()) {
-            JSONObject resourceRolesJSON = new JSONObject();
-            JSONArray resourceRolesArray = new JSONArray();
+            Map<String, Object> resourceRolesJSON = JSONObjectUtils.newJSONObject();
+            List<Object> resourceRolesArray = JSONArrayUtils.newJSONArray();
             resourceRolesArray.addAll(Arrays.asList(resourceRoles.get(key)));
             resourceRolesJSON.put("roles", resourceRolesArray);
             resourceAccess.put(key, resourceRolesJSON);
@@ -47,8 +48,8 @@ public class KeycloakRolesClaimProvider implements RolesClaimProvider {
 
     @Override
     public void setGlobalRoles(Set<String> globalRoles, Map<String, Object> claims) {
-        JSONObject realmAccess = new JSONObject();
-        JSONArray globalRolesArray = new JSONArray();
+        Map<String, Object> realmAccess = JSONObjectUtils.newJSONObject();
+        List<Object> globalRolesArray = JSONArrayUtils.newJSONArray();
         globalRolesArray.addAll(globalRoles);
         realmAccess.put("roles", globalRolesArray);
         claims.put("realm_access", realmAccess);


### PR DESCRIPTION
This PR closes Activiti/Activiti#4335 since it removes the shaded dependencies of `nimbus-jose-jwt`: `JSONObject` and `JSONArray`.
As suggested by the [release notes](https://connect2id.com/blog/nimbus-jose-jwt-9), they have been respectively replaced with `Map<String, Object>` and `List<Object>` using `JSONObjectUtils` and `JSONArrayUtils` to instantiate them.