### PR TITLE
AAE-15056 Fix GraphQL Query Service to format date with time in ISO-8061

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
@@ -44,7 +44,9 @@ import org.springframework.context.annotation.Bean;
 public class ActivitiGraphQLSchemaAutoConfiguration {
 
     @Bean
-    GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer(@Value("${activiti.cloud.graphql.jpa-query.date-format:yyyy-MM-dd'T'HH:mm:ss.SSSX}") String dateFormatString) {
+    GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer(
+        @Value("${activiti.cloud.graphql.jpa-query.date-format:yyyy-MM-dd'T'HH:mm:ss.SSSX}") String dateFormatString
+    ) {
         return builder ->
             builder
                 .name("Query")

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
@@ -22,8 +22,10 @@ import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuil
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLSchemaBuilderAutoConfiguration;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import graphql.GraphQL;
+import java.util.Date;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.VariableValue;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -42,7 +44,7 @@ import org.springframework.context.annotation.Bean;
 public class ActivitiGraphQLSchemaAutoConfiguration {
 
     @Bean
-    GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer() {
+    GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer(@Value("${activiti.cloud.graphql.jpa-query.date-format:yyyy-MM-dd'T'HH:mm:ss.SSSX}") String dateFormatString) {
         return builder ->
             builder
                 .name("Query")
@@ -53,6 +55,14 @@ public class ActivitiGraphQLSchemaAutoConfiguration {
                         .name("VariableValue")
                         .description("VariableValue type")
                         .coercing(new JavaScalars.GraphQLObjectCoercing())
+                        .build()
+                )
+                .scalar(
+                    Date.class,
+                    newScalar()
+                        .name("Date")
+                        .description("Date type with '" + dateFormatString + "' format")
+                        .coercing(new JavaScalars.GraphQLDateCoercing(dateFormatString))
                         .build()
                 );
     }

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
@@ -17,9 +17,14 @@ package org.activiti.cloud.services.notifications.graphql.jpa.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import graphql.Scalars;
 import graphql.scalars.ExtendedScalars;
+import graphql.schema.Coercing;
 import graphql.schema.GraphQLSchema;
+import java.time.Instant;
+import java.util.Date;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -119,5 +124,24 @@ class ActivitiGraphQLSchemaAutoConfigurationTest {
         assertThat(schema.getQueryType().getFieldDefinition("TaskVariables").getArguments())
             .describedAs("Ensure query has correct number of arguments")
             .hasSize(2);
+    }
+
+    @Test
+    void correctlyCoercesDateToISO8601FormatWithTimeAndZoneOffset() {
+        TimeZone timeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+        try {
+            // given
+            Coercing<?, ?> subject = JavaScalars.of(Date.class).getCoercing();
+
+            // when
+            Object result = subject.parseValue(Date.from(Instant.EPOCH));
+
+            // then
+            assertThat(result).isEqualTo("1970-01-01T00:00:00.000Z");
+        } finally {
+          TimeZone.setDefault(timeZone);
+        }
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/test/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfigurationTest.java
@@ -141,7 +141,7 @@ class ActivitiGraphQLSchemaAutoConfigurationTest {
             // then
             assertThat(result).isEqualTo("1970-01-01T00:00:00.000Z");
         } finally {
-          TimeZone.setDefault(timeZone);
+            TimeZone.setDefault(timeZone);
         }
     }
 }


### PR DESCRIPTION
This PR fixes Query service to return date with time formatted using ISO-8601 standard pattern, i.e. `yyyy-MM-dd'T'HH:mm:ss.SSSX`.

The date format can be customized using `activiti.cloud.graphql.jpa-query.date-format` configuration property.

Fixes https://alfresco.atlassian.net/browse/AAE-15056