### PR TITLE
[AAE-2549] Incorrect response when completing task using the same correlation key for Intermediate Message Event

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceMessages.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceMessages.java
@@ -15,7 +15,8 @@
  */
 package org.activiti.cloud.qa.story;
 
-import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.*;
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestConflictIsThrownBy;
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceMessages.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceMessages.java
@@ -15,8 +15,7 @@
  */
 package org.activiti.cloud.qa.story;
 
-import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestInternalServerErrorIsThrownBy;
-import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -127,7 +126,7 @@ public class ProcessInstanceMessages {
 
         StartMessagePayload payload = MessagePayloadBuilder.start(messageName).withBusinessKey(variableValue).build();
 
-        assertThatRestInternalServerErrorIsThrownBy(() -> processRuntimeBundleSteps.message(payload))
+        assertThatRestConflictIsThrownBy(() -> processRuntimeBundleSteps.message(payload))
             .withMessageContaining(
                 "Duplicate message subscription 'boundaryMessage' with correlation key '" + variableValue + "'"
             );

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
@@ -54,6 +54,10 @@ public class RestErrorAssert {
         return assertThatFeignExceptionIsThrownBy(throwingCallable).withInternalServerErrorCode();
     }
 
+    public static RestErrorAssert assertThatRestConflictIsThrownBy(final ThrowingCallable throwingCallable) {
+        return assertThatFeignExceptionIsThrownBy(throwingCallable).withConflictCode();
+    }
+
     public RestErrorAssert withErrorCode(int expectedCode) {
         assertThat(exception.status()).isEqualTo(expectedCode);
         return this;
@@ -79,5 +83,9 @@ public class RestErrorAssert {
 
     public RestErrorAssert withInternalServerErrorCode() {
         return withErrorCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    public RestErrorAssert withConflictCode() {
+        return withErrorCode(HttpServletResponse.SC_CONFLICT);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
@@ -15,12 +15,7 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +25,7 @@ import org.activiti.api.runtime.shared.NotFoundException;
 import org.activiti.api.runtime.shared.UnprocessableEntityException;
 import org.activiti.core.common.spring.security.policies.ActivitiForbiddenException;
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.image.exception.ActivitiInterchangeInfoNotFoundException;
 import org.springframework.hateoas.EntityModel;
@@ -92,5 +88,15 @@ public class RuntimeBundleExceptionHandler {
     public EntityModel<ActivitiErrorMessage> handleAppException(ActivitiException ex, HttpServletResponse response) {
         response.setContentType(APPLICATION_JSON_VALUE);
         return EntityModel.of(new ActivitiErrorMessageImpl(INTERNAL_SERVER_ERROR.value(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(ActivitiIllegalArgumentException.class)
+    @ResponseStatus(CONFLICT)
+    public EntityModel<ActivitiErrorMessage> handleAppException(
+        ActivitiIllegalArgumentException ex,
+        HttpServletResponse response
+    ) {
+        response.setContentType(APPLICATION_JSON_VALUE);
+        return EntityModel.of(new ActivitiErrorMessageImpl(CONFLICT.value(), ex.getMessage()));
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/RuntimeBundleExceptionHandler.java
@@ -15,7 +15,13 @@
  */
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import jakarta.servlet.http.HttpServletResponse;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -209,7 +209,7 @@ public class ProcessInstanceIT {
         );
         assertThat(failEntity.getBody().getMessage())
             .isEqualTo("Process instance " + startedProcessInstance.getId() + " has already been started");
-        assertThat(failEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(failEntity.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
     }
 
     @Test


### PR DESCRIPTION
Earlier when same value was being passed in the text field of the form. We were getting status code as 500(Internal Server Error).
This fix resolved this issue and now generating the status code as 409(Conflict).

https://github.com/Activiti/Activiti/issues/4347