### PR TITLE
Remove model_versions table

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
@@ -46,6 +46,8 @@ import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
 import org.activiti.cloud.services.modeling.jpa.version.VersionedEntity;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * Model model entity
@@ -73,10 +75,11 @@ public class ModelEntity
     private Set<ProjectEntity> projects = new HashSet<>();
 
     @JsonIgnore
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "versionedEntity")
     private List<ModelVersionEntity> versions = new ArrayList<>();
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonIgnore
     private ModelVersionEntity latestVersion = new ModelVersionEntity();
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/05.pg.update.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/05.pg.update.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table if exists model_versions
+  drop constraint FKl24hq09np4hw7g2fwn98jai6b;
+alter table if exists model_versions
+  drop constraint FKq32aa8acvlsih8d4h1flpi7g1;
+drop table if exists model_versions;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
@@ -67,4 +67,13 @@
       splitStatements="true"
       stripComments="true"/>
   </changeSet>
+
+  <changeSet id="model_versions-drop" author="aae-modeling">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/05.pg.update.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
 </databaseChangeLog>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ApplicationAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ApplicationAdminController.java
@@ -61,7 +61,7 @@ public class ApplicationAdminController {
     }
 
     @GetMapping
-    public PagedModel<EntityModel<CloudApplication>> findAll(
+    public PagedModel<EntityModel<CloudApplication>> findAllApplicationAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ApplicationEntity.class
         ) Predicate predicate,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ApplicationController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ApplicationController.java
@@ -58,7 +58,7 @@ public class ApplicationController {
     }
 
     @GetMapping
-    public PagedModel<EntityModel<CloudApplication>> findAll(
+    public PagedModel<EntityModel<CloudApplication>> findAllApplications(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ApplicationEntity.class
         ) Predicate predicate,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionAdminController.java
@@ -63,7 +63,7 @@ public class ProcessDefinitionAdminController {
     }
 
     @GetMapping
-    public PagedModel<EntityModel<CloudProcessDefinition>> findAll(
+    public PagedModel<EntityModel<CloudProcessDefinition>> findAllProcessAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessDefinitionEntity.class
         ) Predicate predicate,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessDefinitionController.java
@@ -79,7 +79,7 @@ public class ProcessDefinitionController {
     }
 
     @GetMapping
-    public PagedModel<EntityModel<CloudProcessDefinition>> findAll(
+    public PagedModel<EntityModel<CloudProcessDefinition>> findAllProcess(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessDefinitionEntity.class
         ) Predicate predicate,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -72,10 +72,10 @@ public class ProcessInstanceAdminController {
         this.pagedCollectionModelAssembler = pagedCollectionModelAssembler;
     }
 
-    @Operation(summary = "Find process instances")
+    @Operation(summary = "Find process instances", hidden = true)
     @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
-    public PagedModel<EntityModel<CloudProcessInstance>> findAll(
+    public PagedModel<EntityModel<CloudProcessInstance>> findAllProcessInstanceAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessInstanceEntity.class
         ) Predicate predicate,
@@ -91,7 +91,7 @@ public class ProcessInstanceAdminController {
     @Operation(summary = "Find process instances")
     @JsonView(JsonViews.ProcessVariables.class)
     @RequestMapping(method = RequestMethod.GET, params = "variableKeys")
-    public PagedModel<EntityModel<CloudProcessInstance>> findAllWithVariables(
+    public PagedModel<EntityModel<CloudProcessInstance>> findAllWithVariablesAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessInstanceEntity.class
         ) Predicate predicate,
@@ -110,7 +110,7 @@ public class ProcessInstanceAdminController {
     }
 
     @RequestMapping(method = RequestMethod.POST)
-    public MappingJacksonValue findAllFromBody(
+    public MappingJacksonValue findAllFromBodyProcessAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessInstanceEntity.class
         ) Predicate predicate,
@@ -142,7 +142,7 @@ public class ProcessInstanceAdminController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.GET)
-    public EntityModel<CloudProcessInstance> findById(@PathVariable String processInstanceId) {
+    public EntityModel<CloudProcessInstance> findByIdProcessAdmin(@PathVariable String processInstanceId) {
         return processInstanceRepresentationModelAssembler.toModel(
             processInstanceAdminService.findById(processInstanceId)
         );

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
@@ -67,10 +67,10 @@ public class ProcessInstanceController {
         this.processInstanceService = processInstanceService;
     }
 
-    @Operation(summary = "Find process instances")
+    @Operation(summary = "Find process instances", hidden = true)
     @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
-    public PagedModel<EntityModel<CloudProcessInstance>> findAll(
+    public PagedModel<EntityModel<CloudProcessInstance>> findAllProcessInstances(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessInstanceEntity.class
         ) Predicate predicate,
@@ -106,7 +106,7 @@ public class ProcessInstanceController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.GET)
-    public EntityModel<CloudProcessInstance> findById(@PathVariable String processInstanceId) {
+    public EntityModel<CloudProcessInstance> findByIdProcess(@PathVariable String processInstanceId) {
         return processInstanceRepresentationModelAssembler.toModel(processInstanceService.findById(processInstanceId));
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDiagramAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDiagramAdminController.java
@@ -53,7 +53,7 @@ public class ProcessInstanceDiagramAdminController extends ProcessInstanceDiagra
 
     @GetMapping(produces = IMAGE_SVG_XML)
     @ResponseBody
-    public String getProcessDiagram(@PathVariable String processInstanceId) {
+    public String getProcessDiagramAdmin(@PathVariable String processInstanceId) {
         return generateDiagram(processInstanceId);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
@@ -64,7 +64,7 @@ public class ProcessInstanceServiceTasksAdminController {
     }
 
     @RequestMapping(value = "/service-tasks", method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudServiceTask>> getTasks(
+    public PagedModel<EntityModel<CloudServiceTask>> getServiceTasks(
         @PathVariable String processInstanceId,
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ServiceTaskEntity.class

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceTasksAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceTasksAdminController.java
@@ -61,7 +61,10 @@ public class ProcessInstanceTasksAdminController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/tasks", method = RequestMethod.GET)
-    public PagedModel<EntityModel<QueryCloudTask>> getTasks(@PathVariable String processInstanceId, Pageable pageable) {
+    public PagedModel<EntityModel<QueryCloudTask>> getTasksAdmin(
+        @PathVariable String processInstanceId,
+        Pageable pageable
+    ) {
         Page<TaskEntity> page = taskRepository.findAll(
             QTaskEntity.taskEntity.processInstanceId.eq(processInstanceId),
             pageable

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableAdminController.java
@@ -66,7 +66,7 @@ public class ProcessInstanceVariableAdminController {
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudVariableInstance>> getVariables(
+    public PagedModel<EntityModel<CloudVariableInstance>> getVariablesProcessAdmin(
         @PathVariable String processInstanceId,
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessVariableEntity.class

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceVariableController.java
@@ -67,7 +67,7 @@ public class ProcessInstanceVariableController {
     }
 
     @RequestMapping(value = "/variables", method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudVariableInstance>> getVariables(
+    public PagedModel<EntityModel<CloudVariableInstance>> getVariablesProcess(
         @PathVariable String processInstanceId,
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ProcessVariableEntity.class

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessModelAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessModelAdminController.java
@@ -42,7 +42,7 @@ public class ProcessModelAdminController {
 
     @GetMapping(produces = MediaType.APPLICATION_XML_VALUE)
     @ResponseBody
-    public String getProcessModel(@PathVariable("processDefinitionId") String processDefinitionId) {
+    public String getProcessModelAdmin(@PathVariable("processDefinitionId") String processDefinitionId) {
         return entityFinder
             .findById(
                 processModelRepository,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskAdminController.java
@@ -66,7 +66,7 @@ public class ServiceTaskAdminController {
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudServiceTask>> findAll(
+    public PagedModel<EntityModel<CloudServiceTask>> findAllServiceTasks(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = ServiceTaskEntity.class
         ) Predicate predicate,
@@ -80,7 +80,7 @@ public class ServiceTaskAdminController {
     }
 
     @RequestMapping(value = "/{serviceTaskId}", method = RequestMethod.GET)
-    public EntityModel<CloudServiceTask> findById(@PathVariable String serviceTaskId) {
+    public EntityModel<CloudServiceTask> findByIdServiceTaskAdmin(@PathVariable String serviceTaskId) {
         Predicate filter = QServiceTaskEntity.serviceTaskEntity.id.eq(serviceTaskId);
 
         ServiceTaskEntity entity = entityFinder.findOne(

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -81,10 +81,10 @@ public class TaskAdminController {
         this.taskControllerHelper = taskControllerHelper;
     }
 
-    @Operation(summary = "Find tasks")
+    @Operation(summary = "Find tasks Admin", hidden = true)
     @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
-    public PagedModel<EntityModel<QueryCloudTask>> findAll(
+    public PagedModel<EntityModel<QueryCloudTask>> findAllServiceTaskAdmin(
         @Parameter(description = ROOT_TASKS_DESC) @RequestParam(
             name = "rootTasksOnly",
             defaultValue = "false"
@@ -107,10 +107,10 @@ public class TaskAdminController {
         );
     }
 
-    @Operation(summary = "Find tasks")
+    @Operation(summary = "Find tasks with Process Variables Admin")
     @JsonView(JsonViews.ProcessVariables.class)
     @RequestMapping(method = RequestMethod.GET, params = "variableKeys")
-    public PagedModel<EntityModel<QueryCloudTask>> findAllWithProcessVariables(
+    public PagedModel<EntityModel<QueryCloudTask>> findAllWithProcessVariablesAdmin(
         @Parameter(description = ROOT_TASKS_DESC) @RequestParam(
             name = "rootTasksOnly",
             defaultValue = "false"
@@ -140,7 +140,7 @@ public class TaskAdminController {
     }
 
     @RequestMapping(method = RequestMethod.POST)
-    public MappingJacksonValue findAllFromBody(
+    public MappingJacksonValue findAllFromBodyTaskAdmin(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = TaskEntity.class
         ) Predicate predicate,
@@ -173,7 +173,7 @@ public class TaskAdminController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{taskId}", method = RequestMethod.GET)
-    public EntityModel<QueryCloudTask> findById(@PathVariable String taskId) {
+    public EntityModel<QueryCloudTask> findByIdTaskAdmin(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(
             taskRepository,
             taskId,
@@ -184,7 +184,7 @@ public class TaskAdminController {
     }
 
     @RequestMapping(value = "/{taskId}/candidate-users", method = RequestMethod.GET)
-    public List<String> getTaskCandidateUsers(@PathVariable String taskId) {
+    public List<String> getTaskCandidateUsersAdmin(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(
             taskRepository,
             taskId,
@@ -201,7 +201,7 @@ public class TaskAdminController {
     }
 
     @RequestMapping(value = "/{taskId}/candidate-groups", method = RequestMethod.GET)
-    public List<String> getTaskCandidateGroups(@PathVariable String taskId) {
+    public List<String> getTaskCandidateGroupsAdmin(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(
             taskRepository,
             taskId,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -96,10 +96,10 @@ public class TaskController {
         this.taskPermissionsHelper = taskPermissionsHelper;
     }
 
-    @Operation(summary = "Find tasks")
+    @Operation(summary = "Find tasks", hidden = true)
     @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET, params = "!variableKeys")
-    public PagedModel<EntityModel<QueryCloudTask>> findAll(
+    public PagedModel<EntityModel<QueryCloudTask>> findAllTasks(
         @Parameter(description = ROOT_TASKS_DESC) @RequestParam(
             name = "rootTasksOnly",
             defaultValue = "false"
@@ -138,9 +138,7 @@ public class TaskController {
             name = "standalone",
             defaultValue = "false"
         ) Boolean standalone,
-        @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
-            root = TaskEntity.class
-        ) Predicate predicate,
+        @QuerydslPredicate(root = TaskEntity.class) Predicate predicate,
         @Parameter(description = VARIABLE_KEYS_DESC, example = VARIABLE_KEYS_EXAMPLE) @RequestParam(
             value = "variableKeys",
             required = false,
@@ -164,7 +162,7 @@ public class TaskController {
 
     @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{taskId}", method = RequestMethod.GET)
-    public EntityModel<QueryCloudTask> findById(@PathVariable String taskId) {
+    public EntityModel<QueryCloudTask> findByIdTask(@PathVariable String taskId) {
         TaskEntity taskEntity = entityFinder.findById(
             taskRepository,
             taskId,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableAdminController.java
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(
-    value = "/admin/v1/tasks/{taskId}/variables",
+    value = "/admin/v1/tasks/{td}/variables",
     produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE }
 )
 public class TaskVariableAdminController {
@@ -66,8 +66,8 @@ public class TaskVariableAdminController {
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudVariableInstance>> getVariables(
-        @PathVariable String taskId,
+    public PagedModel<EntityModel<CloudVariableInstance>> getVariablesTaskAdmin(
+        @PathVariable String td,
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = TaskVariableEntity.class
         ) Predicate predicate,
@@ -78,7 +78,7 @@ public class TaskVariableAdminController {
         QTaskVariableEntity variable = QTaskVariableEntity.taskVariableEntity;
 
         //We will show only not deleted variables
-        BooleanExpression expression = variable.taskId.eq(taskId);
+        BooleanExpression expression = variable.taskId.eq(td);
 
         if (predicate != null) {
             expression = expression.and(predicate);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskVariableController.java
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(
-    value = "/v1/tasks/{taskId}/variables",
+    value = "/v1/tasks/{td}/variables",
     produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE }
 )
 public class TaskVariableController {
@@ -67,8 +67,8 @@ public class TaskVariableController {
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public PagedModel<EntityModel<CloudVariableInstance>> getVariables(
-        @PathVariable String taskId,
+    public PagedModel<EntityModel<CloudVariableInstance>> getVariablesTask(
+        @PathVariable String td,
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
             root = TaskVariableEntity.class
         ) Predicate predicate,
@@ -78,7 +78,7 @@ public class TaskVariableController {
 
         QTaskVariableEntity variable = QTaskVariableEntity.taskVariableEntity;
 
-        BooleanExpression expression = variable.taskId.eq(taskId);
+        BooleanExpression expression = variable.taskId.eq(td);
 
         if (predicate != null) {
             expression = expression.and(predicate);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ProcessInstanceRepresentationModelAssembler.java
@@ -32,11 +32,11 @@ public class ProcessInstanceRepresentationModelAssembler
 
     @Override
     public EntityModel<CloudProcessInstance> toModel(ProcessInstanceEntity entity) {
-        Link selfRel = linkTo(methodOn(ProcessInstanceController.class).findById(entity.getId())).withSelfRel();
+        Link selfRel = linkTo(methodOn(ProcessInstanceController.class).findByIdProcess(entity.getId())).withSelfRel();
         Link tasksRel = linkTo(methodOn(ProcessInstanceTasksController.class).getTasks(entity.getId(), null))
             .withRel("tasks");
         Link variablesRel = linkTo(
-            methodOn(ProcessInstanceVariableController.class).getVariables(entity.getId(), null, null)
+            methodOn(ProcessInstanceVariableController.class).getVariablesProcess(entity.getId(), null, null)
         )
             .withRel("variables");
         return EntityModel.of(entity, selfRel, tasksRel, variablesRel);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ServiceTaskRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/ServiceTaskRepresentationModelAssembler.java
@@ -30,7 +30,8 @@ public class ServiceTaskRepresentationModelAssembler
 
     @Override
     public EntityModel<CloudServiceTask> toModel(ServiceTaskEntity entity) {
-        Link selfRel = linkTo(methodOn(ServiceTaskAdminController.class).findById(entity.getId())).withSelfRel();
+        Link selfRel = linkTo(methodOn(ServiceTaskAdminController.class).findByIdServiceTaskAdmin(entity.getId()))
+            .withSelfRel();
 
         return EntityModel.of(entity, selfRel);
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskRepresentationModelAssembler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/assembler/TaskRepresentationModelAssembler.java
@@ -30,7 +30,7 @@ public class TaskRepresentationModelAssembler
 
     @Override
     public EntityModel<QueryCloudTask> toModel(TaskEntity entity) {
-        Link selfRel = linkTo(methodOn(TaskController.class).findById(entity.getId())).withSelfRel();
+        Link selfRel = linkTo(methodOn(TaskController.class).findByIdTask(entity.getId())).withSelfRel();
         return EntityModel.of(entity, selfRel);
     }
 }


### PR DESCRIPTION
This PR removes model_versions table since it is causing issues when cascading delete from `ModelEntity`, probably related with the `EmbeddedId` in `ModelVersionEntity`.
Since the relationship between `ModelEntity` and `ModelVersionEntity` is a one to many, this change will reduce the cost of querying the database since one less table has to be traversed with joins.