### PR TITLE
Remove model_versions table

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/entity/ModelEntity.java
@@ -46,6 +46,8 @@ import org.activiti.cloud.services.modeling.jpa.audit.AuditableEntity;
 import org.activiti.cloud.services.modeling.jpa.version.VersionedEntity;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * Model model entity
@@ -73,10 +75,11 @@ public class ModelEntity
     private Set<ProjectEntity> projects = new HashSet<>();
 
     @JsonIgnore
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "versionedEntity")
     private List<ModelVersionEntity> versions = new ArrayList<>();
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonIgnore
     private ModelVersionEntity latestVersion = new ModelVersionEntity();
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/05.pg.update.sql
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/changelog/05.pg.update.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+alter table if exists model_versions
+  drop constraint FKl24hq09np4hw7g2fwn98jai6b;
+alter table if exists model_versions
+  drop constraint FKq32aa8acvlsih8d4h1flpi7g1;
+drop table if exists model_versions;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-liquibase/src/main/resources/config/modeling/liquibase/master.xml
@@ -67,4 +67,13 @@
       splitStatements="true"
       stripComments="true"/>
   </changeSet>
+
+  <changeSet id="model_versions-drop" author="aae-modeling">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/05.pg.update.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR removes model_versions table since it is causing issues when cascading delete from `ModelEntity`, probably related with the `EmbeddedId` in `ModelVersionEntity`.
Since the relationship between `ModelEntity` and `ModelVersionEntity` is a one to many, this change will reduce the cost of querying the database since one less table has to be traversed with joins.