### PR TITLE
Revert "[AAE-9137] Fix imported project version (#1104)"

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/main/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImpl.java
@@ -112,12 +112,6 @@ public class ModelRepositoryImpl implements ModelRepository<ProjectEntity, Model
         return modelJpaRepository.save(modelToBeUpdated);
     }
 
-    public ModelEntity resetVersion(ModelEntity model) {
-        model.getVersions().remove(model.getVersions().size() - 1);
-        model.setLatestVersion(model.getVersions().get(0));
-        return modelJpaRepository.save(model);
-    }
-
     @Override
     public ModelEntity copyModel(ModelEntity model, ProjectEntity project) {
         ModelEntity modelEntityClone = new ModelEntity(model.getName(), model.getType());

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-jpa/src/test/java/org/activiti/cloud/services/modeling/jpa/ModelRepositoryImplTest.java
@@ -20,16 +20,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import org.activiti.cloud.modeling.api.ProcessModelType;
 import org.activiti.cloud.modeling.api.process.ModelScope;
 import org.activiti.cloud.services.modeling.entity.ModelEntity;
-import org.activiti.cloud.services.modeling.entity.ModelVersionEntity;
 import org.activiti.cloud.services.modeling.entity.ProjectEntity;
-import org.activiti.cloud.services.modeling.jpa.version.VersionIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -204,32 +200,5 @@ public class ModelRepositoryImplTest {
         verify(modelJpaRepository, times(1))
             .findModelByNameAndScopeAndTypeEquals(model.getName(), ModelScope.GLOBAL, processModelType.getName());
         assertThat(result.isPresent()).isFalse();
-    }
-
-    @Test
-    public void should_returnModel_when_resetVersion() {
-        ModelVersionEntity version1 = new ModelVersionEntity();
-        version1.setVersionIdentifier(new VersionIdentifier("versionIdentifierId", "0.0.1"));
-        ModelVersionEntity version2 = new ModelVersionEntity();
-        version2.setVersionIdentifier(new VersionIdentifier("versionIdentifierId", "0.0.2"));
-
-        List<ModelVersionEntity> versions = new ArrayList<ModelVersionEntity>();
-        versions.add(version1);
-
-        ModelEntity model1 = new ModelEntity();
-        model1.setVersions(versions);
-        model1.setLatestVersion(version1);
-
-        versions.add(version2);
-        model.setVersions(versions);
-        model.setLatestVersion(version2);
-
-        when(modelJpaRepository.save(model)).thenReturn(model1);
-
-        ModelEntity resModel = repository.resetVersion(model);
-
-        assertThat(resModel.getVersions().size()).isEqualTo(1);
-        assertThat(resModel.getVersions().get(0).getVersion()).isEqualTo("0.0.1");
-        assertThat(resModel.getLatestVersion().getVersion()).isEqualTo("0.0.1");
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-repository/src/main/java/org/activiti/cloud/modeling/repository/ModelRepository.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-repository/src/main/java/org/activiti/cloud/modeling/repository/ModelRepository.java
@@ -45,8 +45,6 @@ public interface ModelRepository<P extends Project, M extends Model<P, ?>> {
 
     M updateModel(M modelToUpdate, M newModel);
 
-    M resetVersion(M model);
-
     M copyModel(M model, P project);
 
     M updateModelContent(M modelToBeUpdate, FileContent fileContent);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -406,11 +406,6 @@ public class ModelServiceImpl implements ModelService {
     }
 
     @Override
-    public Model resetVersion(Model model) {
-        return modelRepository.resetVersion(model);
-    }
-
-    @Override
     public Model importModelFromContent(Project project, ModelType modelType, FileContent fileContent) {
         throwExceptionIfFileIsExecutable(modelType.getName(), fileContent);
         Model model = null;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
@@ -386,7 +386,6 @@ public class ProjectServiceImpl implements ProjectService {
                 );
                 createdModels.put(createdModel, modelProcessFile.getFileContent());
             });
-
         return createdModels;
     }
 
@@ -531,7 +530,7 @@ public class ProjectServiceImpl implements ProjectService {
         createdProcesses
             .keySet()
             .forEach(model -> updateModelProcessImported(projectHolder, model, createdProcesses.get(model)));
-        createdProcesses.keySet().forEach(model -> modelService.resetVersion(model));
+
         modelService.cleanModelIdList();
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
@@ -76,8 +76,6 @@ public interface ModelService {
 
     Model importModel(Project project, ModelType modelType, FileContent fileContent);
 
-    Model resetVersion(Model model);
-
     Model importModelFromContent(Project project, ModelType modelType, FileContent fileContent);
 
     <T extends Task> List<T> getTasksBy(Project project, ModelType processModelType, @NonNull Class<T> clazz);

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -533,14 +533,6 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_resetVersion() {
-        when(modelRepository.resetVersion(eq(modelTwo))).thenReturn(modelTwo);
-        modelService.resetVersion(modelTwo);
-
-        verify(modelRepository).resetVersion(eq(modelTwo));
-    }
-
-    @Test
     public void should_getEmptyList_when_searchingWithEmptyString() {
         Page<Model> models = modelService.getModelsByName(projectOne, "", PageRequest.of(0, 50));
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -284,27 +284,4 @@ public class ProjectServiceImplTest {
         Optional<Project> foundProjectOptional = projectService.findProjectById("projectId", null);
         assertThat(foundProjectOptional.get()).isEqualTo(givenProject);
     }
-
-    @Test
-    public void should_resetModelVersion_when_importingProject() throws IOException {
-        InputStream file = resourceAsStream("project/project-xy.zip").get();
-        Project proj = new ProjectImpl();
-        when(projectRepository.createProject(eq(proj))).thenReturn(proj);
-        when(jsonConverter.tryConvertToEntity(any(byte[].class))).thenReturn(Optional.of(proj));
-        ProcessModelType processModelType = new ProcessModelType();
-        when(modelTypeService.findModelTypeByFolderName("processes")).thenReturn(Optional.of(processModelType));
-        when(modelService.contentFilenameToModelName("process-x.bpmn20.xml", processModelType))
-            .thenReturn(Optional.of("process-x"));
-        when(modelService.contentFilenameToModelName("process-y.bpmn20.xml", processModelType))
-            .thenReturn(Optional.of("process-y"));
-
-        Model model = new ModelImpl();
-
-        when(modelService.importModel(eq(proj), eq(processModelType), any())).thenReturn(model);
-        when(modelService.resetVersion(eq(model))).thenReturn(model);
-
-        projectService.importProject(file, "new-project-name");
-
-        verify(modelService).resetVersion(eq(model));
-    }
 }


### PR DESCRIPTION
This reverts commit b70a93a570cfa39e8cfbc3c3eda941fe61d343a8 for Activiti/Activiti#4348
The method is causing strange behavior by `spring-data` on tables `model`, `model_versions` and `model_version`, i.e. it leaves pending records in `model_version` that are not attached to any `model` causing foreign key violations in every delete of imported models/projects.