### PR TITLE
AAE-15527 Update Alfresco DBP REST default media format to application/json

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/main/resources/config/alfresco-rest-config.properties
+++ b/activiti-cloud-service-common/activiti-cloud-services-dbp-rest/src/main/resources/config/alfresco-rest-config.properties
@@ -1,2 +1,3 @@
 spring.data.rest.default-page-size=100
+spring.data.rest.default-media-type=application/json
 spring.hateoas.use-hal-as-default-json-media-type=false

--- a/activiti-cloud-service-common/activiti-cloud-services-swagger/src/test/resources/org/activiti/cloud/common/swagger/apidocs/springdoc-api-docs.json
+++ b/activiti-cloud-service-common/activiti-cloud-services-swagger/src/test/resources/org/activiti/cloud/common/swagger/apidocs/springdoc-api-docs.json
@@ -25,7 +25,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "type": "string"
                 }
@@ -91,7 +91,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentString"
                 }
@@ -126,7 +126,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "type": "string"
                 }
@@ -192,7 +192,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentString"
                 }
@@ -227,7 +227,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EntryResponseContentString"
                 }
@@ -262,7 +262,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentString"
                 }
@@ -297,7 +297,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EntryResponseContentExtendedJsonDeserializerWrapper"
                 }
@@ -332,7 +332,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EntryResponseContentString"
                 }
@@ -367,7 +367,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/hal+json": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentString"
                 }


### PR DESCRIPTION
To mitigate incorrect `application/hal+json` media format used in Swagger docs generation after upgrade to Spring Boot 3.1