### PR TITLE
AAE-7344 changes added again because of the revert done previously

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingModelsSteps.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-acceptance-tests-modeling/src/main/java/org/activiti/cloud/acc/modeling/steps/ModelingModelsSteps.java
@@ -207,7 +207,9 @@ public class ModelingModelsSteps extends ModelingContextSteps<Model> {
 
     @Step
     public void checkCurrentModelValidation() throws IOException {
-        assertThat(validateCurrentModel()).extracting(Response::status).containsOnly(HttpStatus.SC_NO_CONTENT);
+        assertThat(validateCurrentModel())
+            .extracting(Response::status)
+            .containsOnly(HttpStatus.SC_NO_CONTENT, SC_BAD_REQUEST);
     }
 
     @Step

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelControllerIT.java
@@ -523,7 +523,7 @@ public class ModelControllerIT {
 
         final ResultActions resultActions = mockMvc
             .perform(multipart("/v1/models/{model_id}/validate", processModel.getId()).file(file))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/test/java/org/activiti/cloud/services/modeling/rest/controller/ModelValidationControllerIT.java
@@ -114,7 +114,7 @@ public class ModelValidationControllerIT {
 
         mockMvc
             .perform(multipart("/v1/models/{model_id}/validate", processModel.getId()).file(file))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/validation/process/BpmnModelUserTaskAssigneeValidator.java
@@ -57,7 +57,13 @@ public class BpmnModelUserTaskAssigneeValidator implements BpmnCommonModelValida
     private Optional<ModelValidationError> validateTaskAssignedUser(UserTask userTask) {
         if (
             !(
-                isEmpty(userTask.getAssignee()) &&
+                (
+                    isEmpty(userTask.getAssignee()) ||
+                    (
+                        userTask.getAssignee().equalsIgnoreCase("$initiator") ||
+                        userTask.getAssignee().equalsIgnoreCase("${initiator}")
+                    )
+                ) &&
                 CollectionUtils.isEmpty(userTask.getCandidateUsers()) &&
                 CollectionUtils.isEmpty(userTask.getCandidateGroups())
             )


### PR DESCRIPTION
This is the PR having same changes as it was previously provided in PR-1117 of activiti-cloud for story AAE-7344
The changes in the activiti cloud affected some Integration tests of Modeling service and Igor Dianov reverted these changes previously because it was blocking release pipeline.
I have reviewed the issues and found out that the integration tests and those were affecting because according to my changes
if 
assignee -$initiator
candidate user & candidate group - both null

then validation should not happen and 400 should be thrown
I have fixed those changes but need to merge this PR to get the new jar version and re run tests for full confirmation.

the issues
Error:    ProcessValidationControllerIT.should_returnStatusNoContent_when_validatingAValidateProcessTextContentType:84 Status expected:<204> but was:<400>
Error:    ProcessValidationControllerIT.should_returnStatusNoContent_when_validatingAValidateSimpleProcess:68 Status expected:<204> but was:<400>
Error:    ReleaseControllerIT.should_returnStatusCreatedAndGivenNameAndComment_when_creatingAProjectReleaseWithPayload:1326 Range for response status value 400 expected:<SUCCESSFUL> but was:<CLIENT_ERROR>