### PR TITLE
AAE-15817 Refactor activiti-cloud-services-tracing transitive dependencies from starter modules

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
@@ -86,10 +86,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-logging</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
+++ b/activiti-cloud-connectors/activiti-cloud-starter-connector/pom.xml
@@ -37,10 +37,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-service-messaging-config</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-examples/activiti-cloud-query/starter/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/pom.xml
@@ -18,6 +18,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-tracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-test-containers</artifactId>
       <scope>test</scope>
     </dependency>

--- a/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
+++ b/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
@@ -17,6 +17,10 @@
       <artifactId>activiti-cloud-service-messaging-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-tracing</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-stream-test-binder</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
@@ -18,6 +18,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-tracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-test-containers</artifactId>
       <scope>test</scope>
     </dependency>

--- a/activiti-cloud-messages-service/starters/pom.xml
+++ b/activiti-cloud-messages-service/starters/pom.xml
@@ -34,10 +34,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-logging</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-notifications-graphql-service/starter/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/starter/pom.xml
@@ -26,10 +26,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-logging</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/pom.xml
@@ -26,10 +26,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-service-messaging-config</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -56,10 +56,6 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
-      <artifactId>activiti-cloud-services-tracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-logging</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
So, that it will be used directly in the example applications to avoid pulling transitive `micrometer-tracing` and `micrometer-tracing-bridge-brave` dependencies onto the class path when using application starter modules in AAE projects.