### PR TITLE
[AAE-15956] Write zip content to file

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/ZipBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/ZipBuilder.java
@@ -19,7 +19,6 @@ import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_T
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -53,8 +52,8 @@ public class ZipBuilder {
     }
 
     /**
-     * Append a folder to the zip content.
-     * The path of the folder to be appended is given as an array of folder names.
+     * Append a folder to the zip content. The path of the folder to be appended is given as an array of folder names.
+     *
      * @param path the path of the folder
      * @return this
      */
@@ -65,10 +64,11 @@ public class ZipBuilder {
     }
 
     /**
-     * Append a file to the zip content.
-     * The path of the file to be appended is given as an array of folder names ended with the file name.
+     * Append a file to the zip content. The path of the file to be appended is given as an array of folder names ended
+     * with the file name.
+     *
      * @param content the file content
-     * @param path the path of the file
+     * @param path    the path of the file
      * @return this
      */
     public ZipBuilder appendFile(byte[] content, String... path) {
@@ -79,11 +79,11 @@ public class ZipBuilder {
     }
 
     /**
-     * Append a file to the zip content.
-     * The path of the file to be appended is given as an array of folder names.
-     * The file name will be appended to this path.
+     * Append a file to the zip content. The path of the file to be appended is given as an array of folder names. The
+     * file name will be appended to this path.
+     *
      * @param fileContent the file content
-     * @param path the folders path
+     * @param path        the folders path
      * @return this
      */
     public ZipBuilder appendFile(FileContent fileContent, String... path) {
@@ -94,6 +94,7 @@ public class ZipBuilder {
 
     /**
      * Build the zip content stream based on collected folder and files.
+     *
      * @return the zip content as byte array output stream
      * @throws IOException in case of I/O error
      */
@@ -117,17 +118,19 @@ public class ZipBuilder {
 
     /**
      * Write the zip content into the provided file.
+     *
      * @param file the file where the zip file will be written to
      * @throws IOException in case of I/O error
      */
     public void writeToFile(File file) throws IOException {
-        try(OutputStream outputStream = new FileOutputStream(file)) {
+        try (OutputStream outputStream = new FileOutputStream(file)) {
             toByteArrayOutputStream().writeTo(outputStream);
         }
     }
 
     /**
      * Build the zip content based on collected folder and files.
+     *
      * @return the zip content as byte array
      * @throws IOException in case of I/O error
      */
@@ -137,6 +140,7 @@ public class ZipBuilder {
 
     /**
      * Build the zip content as {@link FileContent}
+     *
      * @return the {@link FileContent}
      * @throws IOException in case of I/O error
      */

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/ZipBuilder.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/ZipBuilder.java
@@ -18,7 +18,11 @@ package org.activiti.cloud.services.common.zip;
 import static org.activiti.cloud.services.common.util.ContentTypeUtils.CONTENT_TYPE_ZIP;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,11 +93,11 @@ public class ZipBuilder {
     }
 
     /**
-     * Build the zip content based on collected folder and files.
-     * @return the zip content as byte array
+     * Build the zip content stream based on collected folder and files.
+     * @return the zip content as byte array output stream
      * @throws IOException in case of I/O error
      */
-    public byte[] toZipBytes() throws IOException {
+    public ByteArrayOutputStream toByteArrayOutputStream() throws IOException {
         try (
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)
@@ -107,8 +111,28 @@ public class ZipBuilder {
                 zipOutputStream.closeEntry();
             }
             zipOutputStream.close();
-            return outputStream.toByteArray();
+            return outputStream;
         }
+    }
+
+    /**
+     * Write the zip content into the provided file.
+     * @param file the file where the zip file will be written to
+     * @throws IOException in case of I/O error
+     */
+    public void writeToFile(File file) throws IOException {
+        try(OutputStream outputStream = new FileOutputStream(file)) {
+            toByteArrayOutputStream().writeTo(outputStream);
+        }
+    }
+
+    /**
+     * Build the zip content based on collected folder and files.
+     * @return the zip content as byte array
+     * @throws IOException in case of I/O error
+     */
+    public byte[] toZipBytes() throws IOException {
+        return toByteArrayOutputStream().toByteArray();
     }
 
     /**

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipBuilderTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipBuilderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.common.zip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+class ZipBuilderTest {
+
+    @Test
+    void should_createFileContent_when_writeToFile() throws IOException {
+        File tempFile = Files.createTempFile("test", ".zip").toFile();
+
+        ZipBuilder zipBuilder = new ZipBuilder("projectArchive");
+        byte[] manifestFileFake = "manifestFile".getBytes();
+        zipBuilder.appendFile(manifestFileFake, "projectName.json");
+
+        zipBuilder.writeToFile(tempFile);
+
+        byte[] tempFileContent = FileUtils.readFileToByteArray(tempFile);
+
+        assertThat(zipBuilder.toZipBytes()).isEqualTo(tempFileContent);
+    }
+}


### PR DESCRIPTION
Enable the zip builder util to write the zip content to a file using a stream so we don't need to load the whole byte array in memory to do so.