### PR TITLE
[AAE-16572] - upgrade spring-boot to 3.1.3 and spring-cloud to 2022.0.4 to fix vulnerability in spring-kafka 3.0.8

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Dependencies Parent</name>
   <properties>
-    <spring-cloud.version>2022.0.3</spring-cloud.version>
+    <spring-cloud.version>2022.0.4</spring-cloud.version>
     <testcontainers.version>1.18.0</testcontainers.version>
     <h2.version>1.4.200</h2.version>
     <graphql-java.version>20.2</graphql-java.version>

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/pom.xml
@@ -87,10 +87,5 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
@@ -93,11 +93,6 @@
       <artifactId>activiti-spring-connector</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <project.scm.repository>activiti-cloud</project.scm.repository>
     <project.year>2020</project.year>
 
-    <spring-boot.version>3.1.2</spring-boot.version>
+    <spring-boot.version>3.1.3</spring-boot.version>
 
     <!-- configuration properties for tests-->
     <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4427
By bumping spring-boot and spring-cloud we bump also spring-kafka vulnerable version (3.0.8) to a fixed one (3.0.10).