### PR TITLE
AAE-16625 Stop using global variable to store ids to update

### DIFF
--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -38,6 +38,7 @@ import org.activiti.cloud.services.modeling.rest.assembler.ModelRepresentationMo
 import org.activiti.cloud.services.modeling.rest.assembler.ModelTypeRepresentationModelAssembler;
 import org.activiti.cloud.services.modeling.rest.assembler.PagedModelTypeAssembler;
 import org.activiti.cloud.services.modeling.rest.exceptions.FileSizeException;
+import org.activiti.cloud.services.modeling.service.ImportedModel;
 import org.activiti.cloud.services.modeling.service.ModelTypeService;
 import org.activiti.cloud.services.modeling.service.api.ModelService;
 import org.springframework.beans.factory.annotation.Value;
@@ -157,7 +158,7 @@ public class ModelController implements ModelRestApi {
         if (file.getSize() > maxModelFileSize) {
             throw new FileSizeException("File size exceeded");
         }
-        modelService.updateModelContent(findModelById(modelId), multipartToFileContent(file));
+        modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(findModelById(modelId)), multipartToFileContent(file));
     }
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
@@ -158,10 +159,7 @@ public class ModelController implements ModelRestApi {
         if (file.getSize() > maxModelFileSize) {
             throw new FileSizeException("File size exceeded");
         }
-        modelService.updateModelContent(
-            ImportedModel.modelWithoutIdentifiersToUpdate(findModelById(modelId)),
-            multipartToFileContent(file)
-        );
+        modelService.updateModelContent(findModelById(modelId), multipartToFileContent(file), new HashMap<>());
     }
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -39,7 +39,6 @@ import org.activiti.cloud.services.modeling.rest.assembler.ModelRepresentationMo
 import org.activiti.cloud.services.modeling.rest.assembler.ModelTypeRepresentationModelAssembler;
 import org.activiti.cloud.services.modeling.rest.assembler.PagedModelTypeAssembler;
 import org.activiti.cloud.services.modeling.rest.exceptions.FileSizeException;
-import org.activiti.cloud.services.modeling.service.ImportedModel;
 import org.activiti.cloud.services.modeling.service.ModelTypeService;
 import org.activiti.cloud.services.modeling.service.api.ModelService;
 import org.springframework.beans.factory.annotation.Value;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -158,7 +158,10 @@ public class ModelController implements ModelRestApi {
         if (file.getSize() > maxModelFileSize) {
             throw new FileSizeException("File size exceeded");
         }
-        modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(findModelById(modelId)), multipartToFileContent(file));
+        modelService.updateModelContent(
+            ImportedModel.modelWithoutIdentifiersToUpdate(findModelById(modelId)),
+            multipartToFileContent(file)
+        );
     }
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-rest/src/main/java/org/activiti/cloud/services/modeling/rest/controller/ModelController.java
@@ -158,7 +158,7 @@ public class ModelController implements ModelRestApi {
         if (file.getSize() > maxModelFileSize) {
             throw new FileSizeException("File size exceeded");
         }
-        modelService.updateModelContent(findModelById(modelId), multipartToFileContent(file), new HashMap<>());
+        modelService.updateModelContent(findModelById(modelId), multipartToFileContent(file), null);
     }
 
     @Override

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service;
+
+import org.activiti.cloud.modeling.api.Model;
+
+import java.util.Collections;
+import java.util.Map;
+
+public record ImportedModel(Model model, Map<String, String> identifiersToUpdate) {
+
+    public static ImportedModel modelWithoutIdentifiersToUpdate(Model model) {
+        return new ImportedModel(model, Collections.emptyMap());
+    }
+
+    public boolean hasIdentifiersToUpdate(){
+        return identifiersToUpdate != null && !identifiersToUpdate.isEmpty();
+    }
+
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
@@ -75,7 +75,7 @@ public final class ImportedModel {
             "model=" +
             model +
             ", " +
-            "orignialId=" +
+            "originalId=" +
             originalId +
             ", " +
             "updatedId=" +

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
@@ -16,16 +16,71 @@
 
 package org.activiti.cloud.services.modeling.service;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Objects;
 import org.activiti.cloud.modeling.api.Model;
 
-public record ImportedModel(Model model, Map<String, String> identifiersToUpdate) {
-    public static ImportedModel modelWithoutIdentifiersToUpdate(Model model) {
-        return new ImportedModel(model, Collections.emptyMap());
+public final class ImportedModel {
+
+    private final Model model;
+    private final String originalId;
+    private final String updatedId;
+
+    public ImportedModel(Model model) {
+        this(model, null, null);
+    }
+
+    public ImportedModel(Model model, String originalId, String updatedId) {
+        this.model = model;
+        this.originalId = originalId;
+        this.updatedId = updatedId;
     }
 
     public boolean hasIdentifiersToUpdate() {
-        return identifiersToUpdate != null && !identifiersToUpdate.isEmpty();
+        return originalId != null && updatedId != null;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public String getOrignialId() {
+        return originalId;
+    }
+
+    public String getUpdatedId() {
+        return updatedId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (ImportedModel) obj;
+        return (
+            Objects.equals(this.model, that.model) &&
+            Objects.equals(this.originalId, that.originalId) &&
+            Objects.equals(this.updatedId, that.updatedId)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(model, originalId, updatedId);
+    }
+
+    @Override
+    public String toString() {
+        return (
+            "ImportedModel[" +
+            "model=" +
+            model +
+            ", " +
+            "orignialId=" +
+            originalId +
+            ", " +
+            "updatedId=" +
+            updatedId +
+            ']'
+        );
     }
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ImportedModel.java
@@ -16,19 +16,16 @@
 
 package org.activiti.cloud.services.modeling.service;
 
-import org.activiti.cloud.modeling.api.Model;
-
 import java.util.Collections;
 import java.util.Map;
+import org.activiti.cloud.modeling.api.Model;
 
 public record ImportedModel(Model model, Map<String, String> identifiersToUpdate) {
-
     public static ImportedModel modelWithoutIdentifiersToUpdate(Model model) {
         return new ImportedModel(model, Collections.emptyMap());
     }
 
-    public boolean hasIdentifiersToUpdate(){
+    public boolean hasIdentifiersToUpdate() {
         return identifiersToUpdate != null && !identifiersToUpdate.isEmpty();
     }
-
 }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -360,7 +360,9 @@ public class ModelServiceImpl implements ModelService {
     public FileContent overrideModelContentId(ImportedModel importedModel, FileContent fileContent) {
         return modelContentService
             .findModelContentConverter(importedModel.model().getType())
-            .map(modelContentConverter -> modelContentConverter.overrideModelId(fileContent, importedModel.identifiersToUpdate()))
+            .map(modelContentConverter ->
+                modelContentConverter.overrideModelId(fileContent, importedModel.identifiersToUpdate())
+            )
             .orElse(fileContent);
     }
 
@@ -416,7 +418,10 @@ public class ModelServiceImpl implements ModelService {
     private String resolveConvertedId(ModelType modelType, FileContent fileContent, Model model) {
         String convertedId = model.getId();
 
-        if (model.getId() == null && (modelTypeService.isJson(modelType) == isJsonContentType(fileContent.getContentType()))) {
+        if (
+            model.getId() == null &&
+            (modelTypeService.isJson(modelType) == isJsonContentType(fileContent.getContentType()))
+        ) {
             convertedId = retrieveModelIdFromModelContent(model, fileContent);
         }
         return convertedId;

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ModelServiceImpl.java
@@ -351,7 +351,7 @@ public class ModelServiceImpl implements ModelService {
         return modelRepository.updateModelContent(model, sanitizedFileContent);
     }
 
-    private static boolean hasIdentifiersToUpdate(Map<String, String> identifiersToUpdate) {
+    private boolean hasIdentifiersToUpdate(Map<String, String> identifiersToUpdate) {
         return identifiersToUpdate != null && !identifiersToUpdate.isEmpty();
     }
 
@@ -416,7 +416,7 @@ public class ModelServiceImpl implements ModelService {
         return new ImportedModel(model);
     }
 
-    private static String buildModelTypeAwareIdentifier(Model model) {
+    private String buildModelTypeAwareIdentifier(Model model) {
         return String.join(MODEL_IDENTIFIER_SEPARATOR, model.getType().toLowerCase(), model.getId());
     }
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectHolder.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectHolder.java
@@ -16,6 +16,9 @@
 package org.activiti.cloud.services.modeling.service;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.activiti.cloud.modeling.api.Model;
 import org.activiti.cloud.modeling.api.ModelType;
@@ -40,6 +43,8 @@ public class ProjectHolder {
     private final MultiKeyMap<String, ModelXmlFile> modelContent = new MultiKeyMap<>();
 
     private final MultiKeyMap<String, FileContent> extensionFilesMap = new MultiKeyMap<>();
+
+    private final Map<String, String> identifiersToUpdate = new HashMap<>();
 
     public ProjectHolder setProject(Project project, @Nullable String name) {
         if (this.project == null) {
@@ -97,6 +102,14 @@ public class ProjectHolder {
 
     private MultiKey<String> key(String name, String type) {
         return new MultiKey<>(name, type);
+    }
+
+    public void addIdentifierToUpdate(String from, String to) {
+        identifiersToUpdate.put(from, to);
+    }
+
+    public Map<String, String> getIdentifiersToUpdate() {
+        return Collections.unmodifiableMap(identifiersToUpdate);
     }
 
     class ModelXmlFile {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/ProjectServiceImpl.java
@@ -397,7 +397,11 @@ public class ProjectServiceImpl implements ProjectService {
         updateModelProcessImported(projectHolder, createdModel, fileContent);
     }
 
-    private void updateModelProcessImported(ProjectHolder projectHolder, ImportedModel importedModel, FileContent fileContent) {
+    private void updateModelProcessImported(
+        ProjectHolder projectHolder,
+        ImportedModel importedModel,
+        FileContent fileContent
+    ) {
         modelService.updateModelContent(importedModel, fileContent);
 
         Model model = importedModel.model();
@@ -530,7 +534,6 @@ public class ProjectServiceImpl implements ProjectService {
         createdProcesses
             .keySet()
             .forEach(model -> updateModelProcessImported(projectHolder, model, createdProcesses.get(model)));
-
     }
 
     private ProjectHolder getProjectHolderFromZipStream(ZipStream stream, String name) throws IOException {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.modeling.service.api;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.activiti.bpmn.model.Process;
@@ -49,7 +50,7 @@ public interface ModelService {
 
     Model updateModel(Model modelToBeUpdated, Model newModel);
 
-    Model copyModel(Model modelToBeCopied, Project project);
+    Model copyModel(Model modelToBeCopied, Project project, Map<String, String> identifiersToUpdate);
 
     void deleteModel(Model model);
 
@@ -65,9 +66,9 @@ public interface ModelService {
 
     FileContent exportModel(Model model);
 
-    Model updateModelContent(ImportedModel importedModel, FileContent fileContent);
+    Model updateModelContent(Model model, FileContent fileContent, Map<String, String> identifiersToUpdate);
 
-    FileContent overrideModelContentId(ImportedModel importedModel, FileContent fileContent);
+    FileContent overrideModelContentId(Model model, FileContent fileContent, Map<String, String> identifiersToUpdate);
 
     Optional<ModelContent> createModelContentFromModel(Model model, FileContent fileContent);
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/main/java/org/activiti/cloud/services/modeling/service/api/ModelService.java
@@ -28,6 +28,7 @@ import org.activiti.cloud.modeling.api.ModelValidationError;
 import org.activiti.cloud.modeling.api.Project;
 import org.activiti.cloud.modeling.api.ValidationContext;
 import org.activiti.cloud.services.common.file.FileContent;
+import org.activiti.cloud.services.modeling.service.ImportedModel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.NonNull;
@@ -56,8 +57,6 @@ public interface ModelService {
 
     Optional<FileContent> getModelExtensionsFileContent(Model model);
 
-    void cleanModelIdList();
-
     Optional<FileContent> getModelDiagramFile(String modelId);
 
     String getExtensionsFilename(Model model);
@@ -66,17 +65,17 @@ public interface ModelService {
 
     FileContent exportModel(Model model);
 
-    Model updateModelContent(Model modelToBeUpdate, FileContent fileContent);
+    Model updateModelContent(ImportedModel importedModel, FileContent fileContent);
 
-    FileContent overrideModelContentId(Model model, FileContent fileContent);
+    FileContent overrideModelContentId(ImportedModel importedModel, FileContent fileContent);
 
     Optional<ModelContent> createModelContentFromModel(Model model, FileContent fileContent);
 
     Model importSingleModel(Project project, ModelType modelType, FileContent fileContent);
 
-    Model importModel(Project project, ModelType modelType, FileContent fileContent);
+    ImportedModel importModel(Project project, ModelType modelType, FileContent fileContent);
 
-    Model importModelFromContent(Project project, ModelType modelType, FileContent fileContent);
+    ImportedModel importModelFromContent(Project project, ModelType modelType, FileContent fileContent);
 
     <T extends Task> List<T> getTasksBy(Project project, ModelType processModelType, @NonNull Class<T> clazz);
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
@@ -26,22 +26,22 @@ import org.junit.jupiter.api.Test;
 public class ImportedModelTest {
 
     @Test
-    void hasIdentifiersToUpdate_shouldReturnTrue_when_mapContainsEntries() {
-        ImportedModel importedModel = new ImportedModel(new ModelImpl(), Map.of("from", "to"));
+    void hasIdentifiersToUpdate_shouldReturnTrue_when_originalIdAndUpdatedIdAreSet() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), "from", "to");
 
         assertThat(importedModel.hasIdentifiersToUpdate()).isTrue();
     }
 
     @Test
-    void hasIdentifiersToUpdate_shouldReturnFalse_when_mapIsEmpty() {
-        ImportedModel importedModel = new ImportedModel(new ModelImpl(), Collections.emptyMap());
+    void hasIdentifiersToUpdate_shouldReturnFalse_when_originalIdIsNotSet() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), null, "any");
 
         assertThat(importedModel.hasIdentifiersToUpdate()).isFalse();
     }
 
     @Test
-    void hasIdentifiersToUpdate_shouldReturnFalse_when_mapIsNull() {
-        ImportedModel importedModel = new ImportedModel(new ModelImpl(), null);
+    void hasIdentifiersToUpdate_shouldReturnFalse_when_UpdateIdIsNotSet() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), "from", null);
 
         assertThat(importedModel.hasIdentifiersToUpdate()).isFalse();
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.modeling.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.modeling.api.impl.ModelImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ImportedModelTest {
+
+    @Test
+    void hasIdentifiersToUpdate_shouldReturnTrue_when_mapContainsEntries() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), Map.of("from", "to"));
+
+        assertThat(importedModel.hasIdentifiersToUpdate()).isTrue();
+    }
+
+    @Test
+    void hasIdentifiersToUpdate_shouldReturnFalse_when_mapIsEmpty() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), Collections.emptyMap());
+
+        assertThat(importedModel.hasIdentifiersToUpdate()).isFalse();
+    }
+
+    @Test
+    void hasIdentifiersToUpdate_shouldReturnFalse_when_mapIsNull() {
+        ImportedModel importedModel = new ImportedModel(new ModelImpl(), null);
+
+        assertThat(importedModel.hasIdentifiersToUpdate()).isFalse();
+    }
+}

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
@@ -18,11 +18,10 @@ package org.activiti.cloud.services.modeling.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.modeling.api.impl.ModelImpl;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
 import java.util.Map;
+import org.activiti.cloud.modeling.api.impl.ModelImpl;
+import org.junit.jupiter.api.Test;
 
 public class ImportedModelTest {
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.activiti.cloud.modeling.api.impl.ModelImpl;
 import org.junit.jupiter.api.Test;
 
-public class ImportedModelTest {
+class ImportedModelTest {
 
     @Test
     void hasIdentifiersToUpdate_shouldReturnTrue_when_originalIdAndUpdatedIdAreSet() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ImportedModelTest.java
@@ -18,8 +18,6 @@ package org.activiti.cloud.services.modeling.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
-import java.util.Map;
 import org.activiti.cloud.modeling.api.impl.ModelImpl;
 import org.junit.jupiter.api.Test;
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.modeling.service;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -455,7 +456,7 @@ public class ModelServiceImplTest {
         FileContent fileContent = new FileContent("a.exe", null, "mockContent".getBytes(StandardCharsets.UTF_8));
         when(fileMagicNumberValidator.checkFileIsExecutable(any())).thenReturn(true);
 
-        assertThatThrownBy(() -> modelService.updateModelContent(modelTwo, fileContent))
+        assertThatThrownBy(() -> modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent))
             .hasMessage("Import the executable file a.exe for type PROCESS is forbidden.");
     }
 
@@ -473,7 +474,7 @@ public class ModelServiceImplTest {
 
         assertThat(modelTwo.getCategory()).isEqualTo(PROCESS_MODEL_DEFAULT_CATEGORY);
 
-        Model updatedModel = modelService.updateModelContent(modelTwo, fileContent);
+        Model updatedModel = modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent);
 
         assertThat(updatedModel.getCategory()).isEqualTo(PROCESS_MODEL_TEST_CATEGORY);
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -22,7 +22,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -35,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.activiti.bpmn.model.BpmnModel;
@@ -43,6 +46,7 @@ import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.UserTask;
 import org.activiti.cloud.modeling.api.ConnectorModelType;
 import org.activiti.cloud.modeling.api.Model;
+import org.activiti.cloud.modeling.api.ModelContentConverter;
 import org.activiti.cloud.modeling.api.ModelContentValidator;
 import org.activiti.cloud.modeling.api.ModelExtensionsValidator;
 import org.activiti.cloud.modeling.api.ModelUpdateListener;
@@ -124,6 +128,9 @@ public class ModelServiceImplTest {
 
     @Mock
     private FileContentSanitizer fileContentSanitizer;
+
+    @Mock
+    private ModelContentConverter<?> modelContentConverter;
 
     private Model modelTwo;
 
@@ -456,9 +463,7 @@ public class ModelServiceImplTest {
         FileContent fileContent = new FileContent("a.exe", null, "mockContent".getBytes(StandardCharsets.UTF_8));
         when(fileMagicNumberValidator.checkFileIsExecutable(any())).thenReturn(true);
 
-        assertThatThrownBy(() ->
-                modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent)
-            )
+        assertThatThrownBy(() -> modelService.updateModelContent(modelTwo, fileContent, emptyMap()))
             .hasMessage("Import the executable file a.exe for type PROCESS is forbidden.");
     }
 
@@ -476,10 +481,7 @@ public class ModelServiceImplTest {
 
         assertThat(modelTwo.getCategory()).isEqualTo(PROCESS_MODEL_DEFAULT_CATEGORY);
 
-        Model updatedModel = modelService.updateModelContent(
-            ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo),
-            fileContent
-        );
+        Model updatedModel = modelService.updateModelContent(modelTwo, fileContent, emptyMap());
 
         assertThat(updatedModel.getCategory()).isEqualTo(PROCESS_MODEL_TEST_CATEGORY);
     }
@@ -581,6 +583,55 @@ public class ModelServiceImplTest {
         assertThatThrownBy(() -> modelService.validateModelExtensions(modelOne, fileContent, projectOne))
             .isInstanceOf(SemanticModelValidationException.class)
             .hasMessage("Semantic model validation errors encountered: 1 schema violations found");
+    }
+
+    @Test
+    public void overrideModelContentId_should_returnUpdatedContent_when_aConverterIsFound() {
+        //given
+        ModelImpl model = new ModelImpl();
+        model.setType("any");
+
+        Map<String, String> identifiersToUpdate = Map.of("from", "to");
+
+        given(modelContentService.findModelContentConverter(model.getType()))
+            .willReturn(Optional.of(modelContentConverter));
+
+        FileContent originalContent = mock(FileContent.class);
+        FileContent updatedContent = mock(FileContent.class);
+        given(modelContentConverter.overrideModelId(originalContent, identifiersToUpdate)).willReturn(updatedContent);
+
+        //when
+        FileContent overriddenContent = modelService.overrideModelContentId(
+            model,
+            originalContent,
+            identifiersToUpdate
+        );
+
+        //then
+        assertThat(overriddenContent).isEqualTo(updatedContent);
+    }
+
+    @Test
+    public void overrideModelContentId_should_returnOrignalContent_when_noConverterIsFoundForType() {
+        //given
+        ModelImpl model = new ModelImpl();
+        model.setType("any");
+
+        Map<String, String> identifiersToUpdate = Map.of("from", "to");
+
+        given(modelContentService.findModelContentConverter(model.getType())).willReturn(Optional.empty());
+
+        FileContent originalContent = mock(FileContent.class);
+
+        //when
+        FileContent overriddenContent = modelService.overrideModelContentId(
+            model,
+            originalContent,
+            identifiersToUpdate
+        );
+
+        //then
+        assertThat(overriddenContent).isEqualTo(originalContent);
     }
 
     private ModelImpl createModelImpl() {

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -80,7 +80,7 @@ import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class ModelServiceImplTest {
+class ModelServiceImplTest {
 
     private ModelServiceImpl modelService;
 
@@ -121,7 +121,7 @@ public class ModelServiceImplTest {
     private ModelExtensionsValidator modelExtensionsValidator;
 
     @Mock
-    public Set<ModelUpdateListener> modelUpdateListeners;
+    private Set<ModelUpdateListener> modelUpdateListeners;
 
     @Mock
     private FileMagicNumberValidator fileMagicNumberValidator;
@@ -143,7 +143,7 @@ public class ModelServiceImplTest {
     private final String PROCESS_MODEL_DEFAULT_CATEGORY = "default-category";
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         projectOne = new ProjectImpl();
         projectOne.setId("projectOneId");
         projectOne.setName("projectOne");
@@ -173,7 +173,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_returnTasksInAProjectByModelTypeAndTaskType() {
+    void should_returnTasksInAProjectByModelTypeAndTaskType() {
         UserTask userTaskOne = new UserTask();
         UserTask userTaskTwo = new UserTask();
         UserTask userTaskThree = new UserTask();
@@ -198,14 +198,14 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_returnException_when_classTypeIsNotSpecified() {
+    void should_returnException_when_classTypeIsNotSpecified() {
         assertThatThrownBy(() -> modelService.getTasksBy(projectOne, modelType, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Class task type it must not be null");
     }
 
     @Test
-    public void should_returnProcessesInAProjectByTypeAndModelType() {
+    void should_returnProcessesInAProjectByTypeAndModelType() {
         Page page = new PageImpl(asList(modelOne));
         Process processOne = new Process();
 
@@ -223,7 +223,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_returnProcessExtensionsFileForTheModelGiven() throws IOException {
+    void should_returnProcessExtensionsFileForTheModelGiven() throws IOException {
         ModelImpl extensionModelImpl = createModelImpl();
         when(modelRepository.getModelType()).thenReturn(ModelImpl.class);
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -240,7 +240,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwModelNameConflictException_when_creatingAModelWithSameNameInAProject() {
+    void should_throwModelNameConflictException_when_creatingAModelWithSameNameInAProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
         when(modelRepository.findModelByNameInProject(projectOne, "name", modelType.getName()))
             .thenReturn(Optional.of(modelOne));
@@ -254,7 +254,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwModelNameConflictException_when_updatingAModelWithSameNameInAProject() {
+    void should_throwModelNameConflictException_when_updatingAModelWithSameNameInAProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
 
         when(modelOne.getId()).thenReturn("modelOneId");
@@ -269,7 +269,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwModelScopeIntegrityException_when_creatingModelWithProjectScopeAndBelongsToMoreThanOneProject() {
+    void should_throwModelScopeIntegrityException_when_creatingModelWithProjectScopeAndBelongsToMoreThanOneProject() {
         ModelImpl model = new ModelImpl();
         model.setScope(ModelScope.PROJECT);
         model.addProject(new ProjectImpl());
@@ -280,7 +280,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwModelScopeIntegrityException_when_updatingModelWithProjectScopeAndBelongsToMoreThanOneProject() {
+    void should_throwModelScopeIntegrityException_when_updatingModelWithProjectScopeAndBelongsToMoreThanOneProject() {
         ModelImpl model = new ModelImpl();
         model.setScope(ModelScope.PROJECT);
         model.addProject(new ProjectImpl());
@@ -291,7 +291,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidModelContentInProjectContext() {
+    void should_throwException_when_validatingAnInvalidModelContentInProjectContext() {
         when(modelOne.getType()).thenReturn(modelType.getName());
 
         when(modelContentService.findModelValidators(modelType.getName()))
@@ -305,7 +305,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidModelContentFileInProjectContext() {
+    void should_throwException_when_validatingAnInvalidModelContentFileInProjectContext() {
         FileContent fileContent = new FileContent("testFile.txt", "txt", "".getBytes());
 
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -321,7 +321,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidJSONModelContentFileInProjectContext() {
+    void should_throwException_when_validatingAnInvalidJSONModelContentFileInProjectContext() {
         FileContent fileContent = new FileContent("testFile.json", "application/json", "".getBytes());
 
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -337,7 +337,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_returnErrors_when_gettingValidationErrorOfAnInvalidModel() {
+    void should_returnErrors_when_gettingValidationErrorOfAnInvalidModel() {
         when(modelOne.getType()).thenReturn(modelType.getName());
 
         List<ModelValidationError> validationErrors = List.of(
@@ -354,7 +354,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidModelExtensionsInProjectContext() {
+    void should_throwException_when_validatingAnInvalidModelExtensionsInProjectContext() {
         when(modelOne.getType()).thenReturn(modelType.getName());
 
         when(modelExtensionsService.findExtensionsValidators(modelType.getName()))
@@ -368,7 +368,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_returnErrors_when_validatingAnInvalidModelExtensionsFileInProjectContext() {
+    void should_returnErrors_when_validatingAnInvalidModelExtensionsFileInProjectContext() {
         ConnectorModelType modelType = new ConnectorModelType();
         when(modelRepository.getModelType()).thenReturn(ModelImpl.class);
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -390,7 +390,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidModelExtensionsFileInProjectContext() {
+    void should_throwException_when_validatingAnInvalidModelExtensionsFileInProjectContext() {
         FileContent fileContent = new FileContent("testFile.json", "application/json", "".getBytes());
 
         ConnectorModelType modelType = new ConnectorModelType();
@@ -408,7 +408,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_when_validatingAnInvalidJSONModelExtensionsFileInProjectContext() {
+    void should_throwException_when_validatingAnInvalidJSONModelExtensionsFileInProjectContext() {
         FileContent fileContent = new FileContent("testFile.json", "application/json", "".getBytes());
 
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -425,7 +425,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_allowModelsWithAndWithoutProject_when_creatingAModelWithProject() {
+    void should_allowModelsWithAndWithoutProject_when_creatingAModelWithProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
         when(modelRepository.findModelByNameInProject(projectOne, "name", modelType.getName()))
             .thenReturn(Optional.of(modelTwo));
@@ -487,7 +487,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_updateModelSuccessfully_when_updatingAValidModelWithProject() {
+    void should_updateModelSuccessfully_when_updatingAValidModelWithProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
 
         when(modelOne.getId()).thenReturn("modelOneId");
@@ -505,7 +505,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_updateModelSuccessfully_when_updatingAValidModelWithoutProject() {
+    void should_updateModelSuccessfully_when_updatingAValidModelWithoutProject() {
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
 
         when(modelOne.getId()).thenReturn("modelOneId");
@@ -528,7 +528,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_getModels_when_searchingByName() {
+    void should_getModels_when_searchingByName() {
         when(modelRepository.getModelsByName(eq(projectOne), eq(modelTwo.getName()), any(Pageable.class)))
             .thenReturn(new PageImpl(asList(modelTwo)));
 
@@ -541,7 +541,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_getEmptyList_when_searchingWithEmptyString() {
+    void should_getEmptyList_when_searchingWithEmptyString() {
         Page<Model> models = modelService.getModelsByName(projectOne, "", PageRequest.of(0, 50));
 
         assertThat(models.getContent()).hasSize(0);
@@ -550,7 +550,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_not_return_duplicated_Errors_when_having_more_validators_registered() {
+    void should_not_return_duplicated_Errors_when_having_more_validators_registered() {
         when(modelOne.getType()).thenReturn(modelType.getName());
 
         List<ModelValidationError> validationErrors = List.of(
@@ -568,7 +568,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void should_throwException_with_single_validation_issue_when_havingMoreValidatorsRegistered() {
+    void should_throwException_with_single_validation_issue_when_havingMoreValidatorsRegistered() {
         FileContent fileContent = new FileContent("testFile.json", "application/json", "".getBytes());
 
         when(modelTypeService.findModelTypeByName(any())).thenReturn(Optional.of(modelType));
@@ -586,7 +586,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void overrideModelContentId_should_returnUpdatedContent_when_aConverterIsFound() {
+    void overrideModelContentId_should_returnUpdatedContent_when_aConverterIsFound() {
         //given
         ModelImpl model = new ModelImpl();
         model.setType("any");
@@ -612,7 +612,7 @@ public class ModelServiceImplTest {
     }
 
     @Test
-    public void overrideModelContentId_should_returnOrignalContent_when_noConverterIsFoundForType() {
+    void overrideModelContentId_should_returnOrignalContent_when_noConverterIsFoundForType() {
         //given
         ModelImpl model = new ModelImpl();
         model.setType("any");

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ModelServiceImplTest.java
@@ -456,7 +456,9 @@ public class ModelServiceImplTest {
         FileContent fileContent = new FileContent("a.exe", null, "mockContent".getBytes(StandardCharsets.UTF_8));
         when(fileMagicNumberValidator.checkFileIsExecutable(any())).thenReturn(true);
 
-        assertThatThrownBy(() -> modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent))
+        assertThatThrownBy(() ->
+                modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent)
+            )
             .hasMessage("Import the executable file a.exe for type PROCESS is forbidden.");
     }
 
@@ -474,7 +476,10 @@ public class ModelServiceImplTest {
 
         assertThat(modelTwo.getCategory()).isEqualTo(PROCESS_MODEL_DEFAULT_CATEGORY);
 
-        Model updatedModel = modelService.updateModelContent(ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo), fileContent);
+        Model updatedModel = modelService.updateModelContent(
+            ImportedModel.modelWithoutIdentifiersToUpdate(modelTwo),
+            fileContent
+        );
 
         assertThat(updatedModel.getCategory()).isEqualTo(PROCESS_MODEL_TEST_CATEGORY);
     }

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -208,13 +209,12 @@ public class ProjectServiceImplTest {
         Project projectToCopy = new ProjectImpl("id", "copied-project");
 
         when(projectRepository.copyProject(projectToCopy, copiedProjectName)).thenReturn(projectToCopy);
-        when(modelService.getAllModels(any())).thenReturn(asList(modelOne));
+        when(modelService.getAllModels(projectToCopy)).thenReturn(asList(modelOne));
+        when(modelService.copyModel(eq(modelOne), eq(projectToCopy), any())).thenReturn(modelOne);
 
-        Project copiedProject = projectService.copyProject(projectToCopy, copiedProjectName);
+        Project projectCopy = projectService.copyProject(projectToCopy, copiedProjectName);
 
-        assertThat(copiedProject.getName()).isEqualTo(copiedProjectName);
-        verify(projectRepository, times(1)).copyProject(projectToCopy, copiedProjectName);
-        verify(modelService, times(1)).copyModel(modelOne, projectToCopy);
+        assertThat(projectCopy.getName()).isEqualTo(copiedProjectName);
     }
 
     @Test
@@ -271,7 +271,7 @@ public class ProjectServiceImplTest {
         when(modelService.contentFilenameToModelName("process-y.bpmn20.xml", processModelType))
             .thenReturn(Optional.of("process-y"));
         when(modelService.importModel(eq(project), eq(processModelType), any()))
-            .thenReturn(ImportedModel.modelWithoutIdentifiersToUpdate(new ModelImpl()));
+            .thenReturn(new ImportedModel(new ModelImpl()));
 
         projectService.replaceProjectContentWithProvidedModelsInFile(project, file.get());
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -214,7 +215,6 @@ public class ProjectServiceImplTest {
         assertThat(copiedProject.getName()).isEqualTo(copiedProjectName);
         verify(projectRepository, times(1)).copyProject(projectToCopy, copiedProjectName);
         verify(modelService, times(1)).copyModel(modelOne, projectToCopy);
-        verify(modelService, times(1)).cleanModelIdList();
     }
 
     @Test
@@ -270,7 +270,7 @@ public class ProjectServiceImplTest {
             .thenReturn(Optional.of("process-x"));
         when(modelService.contentFilenameToModelName("process-y.bpmn20.xml", processModelType))
             .thenReturn(Optional.of("process-y"));
-        when(modelService.importModel(eq(project), eq(processModelType), any())).thenReturn(new ModelImpl());
+        when(modelService.importModel(eq(project), eq(processModelType), any())).thenReturn(ImportedModel.modelWithoutIdentifiersToUpdate(new ModelImpl()));
 
         projectService.replaceProjectContentWithProvidedModelsInFile(project, file.get());
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -270,7 +270,8 @@ public class ProjectServiceImplTest {
             .thenReturn(Optional.of("process-x"));
         when(modelService.contentFilenameToModelName("process-y.bpmn20.xml", processModelType))
             .thenReturn(Optional.of("process-y"));
-        when(modelService.importModel(eq(project), eq(processModelType), any())).thenReturn(ImportedModel.modelWithoutIdentifiersToUpdate(new ModelImpl()));
+        when(modelService.importModel(eq(project), eq(processModelType), any()))
+            .thenReturn(ImportedModel.modelWithoutIdentifiersToUpdate(new ModelImpl()));
 
         projectService.replaceProjectContentWithProvidedModelsInFile(project, file.get());
 

--- a/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
+++ b/activiti-cloud-modeling-service/activiti-cloud-services-modeling/activiti-cloud-services-modeling-service/src/test/java/org/activiti/cloud/services/modeling/service/ProjectServiceImplTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
Pass it as parameter where it's needed. This avoids race conditons on parallel imports