### PR TITLE
check if we use snappy library

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
@@ -10,9 +10,6 @@
   <artifactId>activiti-cloud-service-common-dependencies</artifactId>
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Service Common Dependencies BOM (Bill Of Materials)</name>
-  <properties>
-    <snappy.version>1.1.10.1</snappy.version>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -122,11 +119,6 @@
         <groupId>org.activiti.cloud</groupId>
         <artifactId>activiti-cloud-service-messaging-starter</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.xerial.snappy</groupId>
-        <artifactId>snappy-java</artifactId>
-        <version>${snappy.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Yes it is used:
  +- org.springframework.cloud:spring-cloud-starter-stream-kafka:jar:4.0.4:runtime
[INFO] |  |  \- org.springframework.cloud:spring-cloud-stream-binder-kafka:jar:4.0.4:runtime
[INFO] |  |     +- org.springframework.cloud:spring-cloud-stream-binder-kafka-core:jar:4.0.4:runtime
[INFO] |  |     |  \- org.springframework.integration:spring-integration-kafka:jar:6.1.2:runtime
[INFO] |  |     \- org.springframework.kafka:spring-kafka:jar:3.0.10:runtime
[INFO] |  |        +- org.apache.kafka:kafka-clients:jar:3.4.1:runtime
[INFO] |  |        |  +- com.github.luben:zstd-jni:jar:1.5.2-1:runtime
[INFO] |  |        |  +- org.lz4:lz4-java:jar:1.8.0:runtime
[INFO] |  |        |  \- org.xerial.snappy:snappy-java:jar:1.1.10.1:runtime

There is no new version of spring-cloud-starter-stream-kafka, so definition of custom version of snappy is the only way to solve security issue.

Spring boot 3.2 brings new versions, maybe they will release a new version with fix

+- org.springframework.cloud:spring-cloud-starter-stream-kafka:jar:4.1.0-M2:runtime
[INFO] |  |  \- org.springframework.cloud:spring-cloud-stream-binder-kafka:jar:4.1.0-M2:runtime
[INFO] |  |     +- org.springframework.cloud:spring-cloud-stream-binder-kafka-core:jar:4.1.0-M2:runtime
[INFO] |  |     |  \- org.springframework.integration:spring-integration-kafka:jar:6.2.0-RC1:runtime
[INFO] |  |     \- org.springframework.kafka:spring-kafka:jar:3.1.0-RC1:runtime
[INFO] |  |        +- org.apache.kafka:kafka-clients:jar:3.6.0:runtime
[INFO] |  |        |  +- com.github.luben:zstd-jni:jar:1.5.5-1:runtime
[INFO] |  |        |  +- org.lz4:lz4-java:jar:1.8.0:runtime
[INFO] |  |        |  \- org.xerial.snappy:snappy-java:jar:1.1.10.1:runtime
