### PR TITLE
AAE-17856 decrease logging for GraphQLBrokerSubProtocolHandler

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
@@ -189,9 +189,13 @@ public class GraphQLBrokerSubProtocolHandler implements SubProtocolHandler, Appl
                         "Failed to send client message to application via MessageChannel" +
                         " in session " +
                         session.getId() +
-                        ". Sending CONNECTION_ERROR to client.",
-                        ex
+                        ". Sending CONNECTION_ERROR to client. Cause: {}:{}",
+                            ex.getMessage(),
+                            ex.getCause().getMessage()
                     );
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Exception stacktrace: ", ex);
                 }
                 sendErrorMessage(session, ex, sourceMessage);
             }
@@ -268,6 +272,18 @@ public class GraphQLBrokerSubProtocolHandler implements SubProtocolHandler, Appl
             }
 
             outputChannel.send(message);
+        } catch (Exception e) {
+            if (logger.isErrorEnabled()) {
+                logger.error(
+                    "Failed to send WebSocket message to client after session {}. Cause: {}:{}",
+                    session.getId(),
+                    e.getMessage(),
+                    e.getCause().getMessage()
+                );
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Exception stacktrace: ", e);
+            }
         } finally {
             this.graphqlAuthentications.remove(session.getId());
 

--- a/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
@@ -190,8 +190,8 @@ public class GraphQLBrokerSubProtocolHandler implements SubProtocolHandler, Appl
                         " in session " +
                         session.getId() +
                         ". Sending CONNECTION_ERROR to client. Cause: {}:{}",
-                            ex.getMessage(),
-                            ex.getCause().getMessage()
+                        ex.getMessage(),
+                        ex.getCause().getMessage()
                     );
                 }
                 if (logger.isDebugEnabled()) {


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4471
GraphQLBrokerSubProtocolHandler might overflow logs with stacktrace e.g. after session ended which involved an expired token. Example:
```
org.springframework.messaging.MessageDeliveryException: Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]; nested exception is org.springframework.security.access.AccessDeniedException: Access is denied
	at org.springframework.messaging.support.AbstractMessageChannel.send(AbstractMessageChannel.java:149)
	at org.springframework.messaging.support.AbstractMessageChannel.send(AbstractMessageChannel.java:125)
	at org.activiti.cloud.services.notifications.graphql.ws.transport.GraphQLBrokerSubProtocolHandler.afterSessionEnded(GraphQLBrokerSubProtocolHandler.java:270)
	at org.springframework.web.socket.messaging.SubProtocolWebSocketHandler.clearSession(SubProtocolWebSocketHandler.java:531)
	at org.springframework.web.socket.messaging.SubProtocolWebSocketHandler.afterConnectionClosed(SubProtocolWebSocketHandler.java:400)
	at org.springframework.web.socket.handler.WebSocketHandlerDecorator.afterConnectionClosed(WebSocketHandlerDecorator.java:85)
	at org.springframework.web.socket.handler.LoggingWebSocketHandlerDecorator.afterConnectionClosed(LoggingWebSocketHandlerDecorator.java:72)
	at org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator.afterConnectionClosed(ExceptionWebSocketHandlerDecorator.java:78)
	at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter.onClose(StandardWebSocketHandlerAdapter.java:145)
	at org.apache.tomcat.websocket.WsSession.fireEndpointOnClose(WsSession.java:745)
	at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:671)
	at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:637)
	at org.apache.tomcat.websocket.WsSession.checkExpiration(WsSession.java:1032)
	at org.apache.tomcat.websocket.WsWebSocketContainer.backgroundProcess(WsWebSocketContainer.java:1056)
	at org.apache.tomcat.websocket.BackgroundProcessManager.process(BackgroundProcessManager.java:87)
	at org.apache.tomcat.websocket.BackgroundProcessManager.access$000(BackgroundProcessManager.java:31)
	at org.apache.tomcat.websocket.BackgroundProcessManager$WsBackgroundThread.run(BackgroundProcessManager.java:135)
Caused by: org.springframework.security.access.AccessDeniedException: Access is denied
	at org.springframework.security.access.vote.AffirmativeBased.decide(AffirmativeBased.java:73)
	at org.springframework.security.access.intercept.AbstractSecurityInterceptor.attemptAuthorization(AbstractSecurityInterceptor.java:239)
	at org.springframework.security.access.intercept.AbstractSecurityInterceptor.beforeInvocation(AbstractSecurityInterceptor.java:208)
	at org.springframework.security.messaging.access.intercept.ChannelSecurityInterceptor.preSend(ChannelSecurityInterceptor.java:70)
	at org.springframework.messaging.support.AbstractMessageChannel$ChannelInterceptorChain.applyPreSend(AbstractMessageChannel.java:181)
	at org.springframework.messaging.support.AbstractMessageChannel.send(AbstractMessageChannel.java:135)
	... 16 common frames omitted
```

In order to decrease logging in such cases, I introduce logging stacktrace only in debug logging level. The debug level can be turned on by adding the application property
```
logging.level.org.activiti.cloud.services.notifications.graphql.ws.transport.GraphQLBrokerSubProtocolHandler=DEBUG
```