### PR TITLE
AAE-17632 Fix GraphQL JPA query result set is not consistent 

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>1.1.0</graphql-jpa-query.version>
+    <graphql-jpa-query.version>1.1.1</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR fixes inconsistent Graphql JPA query results when executing query requests concurrently. 

The GraphQL JPA Query dependency version has been upgraded to v1.1.1 with the fix for this regression: https://github.com/introproventures/graphql-jpa-query/releases/tag/1.1.1

Fixes https://alfresco.atlassian.net/browse/AAE-17632