### PR TITLE
AAE-18268 Fix regression for Hibernate HHH000104 firstResult/maxResults warning in Query

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.QProcessInstanceEntity;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
@@ -57,5 +58,5 @@ public interface ProcessInstanceRepository
     }
 
     @EntityGraph(value = "ProcessInstances.withVariables", type = EntityGraph.EntityGraphType.LOAD)
-    List<ProcessInstanceEntity> findByIdIsIn(Collection<String> ids);
+    List<ProcessInstanceEntity> findByIdIsIn(Collection<String> ids, Sort sort);
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
@@ -24,7 +24,6 @@ import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.QProcessInstanceEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
@@ -58,6 +57,5 @@ public interface ProcessInstanceRepository
     }
 
     @Override
-    @EntityGraph(value = "ProcessInstances.withVariables", type = EntityGraph.EntityGraphType.LOAD)
     Page<ProcessInstanceEntity> findAll(Predicate predicate, Pageable pageable);
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ProcessInstanceRepository.java
@@ -17,13 +17,13 @@ package org.activiti.cloud.services.query.app.repository;
 
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.StringPath;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.QProcessInstanceEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
@@ -56,6 +56,6 @@ public interface ProcessInstanceRepository
         bindings.bind(root.appVersion).first((path, value) -> root.appVersion.in(Arrays.asList(value.split(","))));
     }
 
-    @Override
-    Page<ProcessInstanceEntity> findAll(Predicate predicate, Pageable pageable);
+    @EntityGraph(value = "ProcessInstances.withVariables", type = EntityGraph.EntityGraphType.LOAD)
+    List<ProcessInstanceEntity> findByIdIsIn(Collection<String> ids);
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -87,7 +87,7 @@ public class ProcessInstanceAdminService {
         filter.setParameterList("variableKeys", variableKeys);
         Page<ProcessInstanceEntity> processInstanceEntities = findAll(predicate, pageable);
         var ids = processInstanceEntities.map(ProcessInstanceEntity::getId).toList();
-        var result = processInstanceRepository.findByIdIsIn(ids);
+        var result = processInstanceRepository.findByIdIsIn(ids, pageable.getSort());
 
         return new PageImpl<>(result, pageable, processInstanceEntities.getTotalElements());
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -98,7 +98,7 @@ public class ProcessInstanceService {
         filter.setParameterList("variableKeys", variableKeys);
         Page<ProcessInstanceEntity> processInstanceEntities = findAll(predicate, pageable);
         var ids = processInstanceEntities.map(ProcessInstanceEntity::getId).toList();
-        var result = processInstanceRepository.findByIdIsIn(ids);
+        var result = processInstanceRepository.findByIdIsIn(ids, pageable.getSort());
 
         return new PageImpl<>(result, pageable, processInstanceEntities.getTotalElements());
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -36,11 +36,11 @@ import org.activiti.core.common.spring.security.policies.ActivitiForbiddenExcept
 import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
 import org.activiti.core.common.spring.security.policies.SecurityPolicyAccess;
 import org.hibernate.Filter;
-import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public class ProcessInstanceService {
@@ -97,12 +97,10 @@ public class ProcessInstanceService {
         Filter filter = session.enableFilter("variablesFilter");
         filter.setParameterList("variableKeys", variableKeys);
         Page<ProcessInstanceEntity> processInstanceEntities = findAll(predicate, pageable);
-        // Due to performance issues (e.g. https://github.com/Activiti/Activiti/issues/3139)
-        // we have to explicitly initialize the lazy loaded field to be able to work with disabled Open Session in View
-        processInstanceEntities.forEach(processInstanceEntity ->
-            Hibernate.initialize(processInstanceEntity.getVariables())
-        );
-        return processInstanceEntities;
+        var ids = processInstanceEntities.map(ProcessInstanceEntity::getId).toList();
+        var result = processInstanceRepository.findByIdIsIn(ids);
+
+        return new PageImpl<>(result, pageable, processInstanceEntities.getTotalElements());
     }
 
     public ProcessInstanceEntity findById(String processInstanceId) {

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -1118,7 +1118,7 @@ public class QueryProcessInstancesEntityIT {
         assertThat(responseEntityFiltered.getBody().getContent())
             .flatExtracting(ProcessInstanceEntity::getVariables)
             .extracting(AbstractVariableEntity::getValue)
-            .containsOnly("111", "222");
+            .containsExactly("111", "222");
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -1118,7 +1118,7 @@ public class QueryProcessInstancesEntityIT {
         assertThat(responseEntityFiltered.getBody().getContent())
             .flatExtracting(ProcessInstanceEntity::getVariables)
             .extracting(AbstractVariableEntity::getValue)
-            .containsExactly("111", "222");
+            .containsOnly("111", "222");
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/application-test.properties
@@ -15,3 +15,5 @@ authorizations.security-constraints[1].securityCollections[0].patterns[0]=/admin
 
 activiti.identity.test-user=testuser
 activiti.identity.test-password=password
+
+spring.jpa.properties.hibernate.query.fail_on_pagination_over_collection_fetch=true


### PR DESCRIPTION
Fixing Hibernate HHH000104 firstResult/maxResults warning in Query for process instances rest api requests due to regression for using JOIN FETCH and Pagination together in the same JPA query. This warning is an indication that all process instance records are loaded from database into memory to apply pagination, which cause OOM for large datasets.