### PR TITLE
Update graphql-jpa-query dependency version to 1.2.3

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>1.2.1</graphql-jpa-query.version>
+    <graphql-jpa-query.version>1.2.3</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Update graphql-jpa-query dependency version from 1.2.1 to the latest release [1.2.3](https://github.com/introproventures/graphql-jpa-query/releases/tag/1.2.3) compatible with SB 3.2.x, bug fixes and improvements.