### PR TITLE
AAE-19924 Add label 'be-propagation' to propagation PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -393,7 +393,7 @@ jobs:
         with:
           version: ${{ needs.build.outputs.version }}
           auto-merge: 'true'
-          labels: ${{ env.DEVELOPMENT_BRANCH }}
+          labels: 'be-propagation,${{ env.DEVELOPMENT_BRANCH }}'
           base-branch-name: ${{ env.DEVELOPMENT_BRANCH }}
           git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
           git-token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This is needed for consistency on labels used for propagations on BE side for AAE-19924, otherwise multiple PRs could be created instead of just one.