### PR TITLE
AAE-20229 Fix for error message when launching /graphiql from Query service

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/graphiql/src/main/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLIndexController.java
+++ b/activiti-cloud-notifications-graphql-service/services/graphiql/src/main/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLIndexController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @ConditionalOnWebApplication
 public class GraphiQLIndexController {
 
-    @Value("${graphiql.index:/graphiql/graphiql.html}")
+    @Value("${graphiql.index:graphiql/graphiql.html}")
     private String graphiqlHtml;
 
     @GetMapping("/graphiql")

--- a/activiti-cloud-notifications-graphql-service/services/graphiql/src/test/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLAutoConfigurationTest.java
+++ b/activiti-cloud-notifications-graphql-service/services/graphiql/src/test/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLAutoConfigurationTest.java
@@ -36,20 +36,23 @@ public class GraphiQLAutoConfigurationTest {
     @Autowired
     private GraphiQLConfigController graphiQLConfigController;
 
+    @Autowired
+    private GraphiQLIndexController graphiQLIndexController;
+
     @SpringBootApplication
     static class Application {
         //
     }
 
     @Test
-    public void contextLoads() {
+    void contextLoads() {
         assertThat(keycloakJsonController.get().getBody()).isNotNull();
         assertThat(graphiQLConfigController.getGraphQLWebPath()).isEqualTo("/default-app/graphql");
         assertThat(graphiQLConfigController.getGraphQLWsPath()).isEqualTo("/default-app/ws/graphql");
     }
 
     @Test
-    public void testContextPath() {
+    void testContextPath() {
         assertThat(graphiQLConfigController.appendSegmentToPath("", "/graphql")).isEqualTo("/graphql");
         assertThat(graphiQLConfigController.appendSegmentToPath("/", "/graphql")).isEqualTo("/graphql");
         assertThat(graphiQLConfigController.appendSegmentToPath(null, "/graphql")).isEqualTo("/graphql");
@@ -59,5 +62,10 @@ public class GraphiQLAutoConfigurationTest {
             .isEqualTo("/default-app/graphql");
         assertThat(graphiQLConfigController.appendSegmentToPath("/default-app", "graphql"))
             .isEqualTo("/default-app/graphql");
+    }
+
+    @Test
+    void testGraphiQLIndexController() {
+        assertThat(graphiQLIndexController.getIndex()).isEqualTo("forward:/graphiql/graphiql.html");
     }
 }


### PR DESCRIPTION
This PR fixes regression caused by upgrading to Spring Security 6.x.  The double forward slash is tripping the Spring Security request firewall to reject the request.

Fixes https://alfresco.atlassian.net/browse/AAE-20229