### PR TITLE
AAE-20417 reduce logging on websocket connection errors

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
+++ b/activiti-cloud-notifications-graphql-service/services/ws/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/transport/GraphQLBrokerSubProtocolHandler.java
@@ -184,24 +184,19 @@ public class GraphQLBrokerSubProtocolHandler implements SubProtocolHandler, Appl
                     SimpAttributesContextHolder.resetAttributes();
                 }
             } catch (Throwable ex) {
-                if (logger.isErrorEnabled()) {
-                    logger.error(
-                        "Failed to send client message to application via MessageChannel" +
-                        " in session " +
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                        "Failed to send client message to application via MessageChannel in session " +
                         session.getId() +
-                        ". Sending CONNECTION_ERROR to client. Cause: {}:{}",
+                        ". Sending CONNECTION_ERROR to client. The client should reestablish a new connection. Cause: {}:{}",
                         ex.getMessage(),
                         ex.getCause().getMessage()
                     );
-                }
-                if (logger.isDebugEnabled()) {
                     logger.debug("Exception stacktrace: ", ex);
                 }
                 sendErrorMessage(session, ex, sourceMessage);
             }
         }
-
-        return;
     }
 
     @Override
@@ -273,15 +268,13 @@ public class GraphQLBrokerSubProtocolHandler implements SubProtocolHandler, Appl
 
             outputChannel.send(message);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(
-                    "Failed to send WebSocket message to client after session {}. Cause: {}:{}",
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                    "Failed to send WebSocket message to client after session {}. The client might have closed the connection. Cause: {}:{}",
                     session.getId(),
                     e.getMessage(),
                     e.getCause().getMessage()
                 );
-            }
-            if (logger.isDebugEnabled()) {
                 logger.debug("Exception stacktrace: ", e);
             }
         } finally {


### PR DESCRIPTION
The websocket server produces a number of ERROR logs in case the client close the connection or uses an invalid token. We're reducing the excessive logging by switching from ERROR to DEBUG level.