### PR TITLE
AAE-20974 Fix Idempotent Bpmn messages receiver interceptor configuration from discarding duplicate messages into the error channel

### DIFF
--- a/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
+++ b/activiti-cloud-messages-service/services/core/src/main/java/org/activiti/cloud/services/messages/core/config/MessagesCoreAutoConfiguration.java
@@ -229,7 +229,8 @@ public class MessagesCoreAutoConfiguration {
     public IdempotentReceiverInterceptor idempotentReceiverInterceptor(MetadataStoreSelector metadataStoreSelector) {
         IdempotentReceiverInterceptor interceptor = new IdempotentReceiverInterceptor(metadataStoreSelector);
 
-        interceptor.setDiscardChannelName("errorChannel");
+        interceptor.setDiscardChannelName(DISCARD_CHANNEL);
+        interceptor.setThrowExceptionOnRejection(false);
 
         return interceptor;
     }

--- a/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
+++ b/activiti-cloud-messages-service/services/tests/src/test/java/org/activiti/cloud/services/messages/tests/AbstractMessagesCoreIntegrationTests.java
@@ -639,7 +639,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
         // then
         assertThat(peek()).isNull();
 
-        assertThat(errorQueue.receive(0)).isNotNull();
+        assertThat(discardQueue.receive(0)).isNotNull();
 
         assertThat(messageGroup(correlationId).getMessages()).isNotNull().hasSize(1);
         // given
@@ -652,7 +652,7 @@ public abstract class AbstractMessagesCoreIntegrationTests {
         // then
         assertThat(peek()).isNull();
 
-        assertThat(errorQueue.receive(0)).isNotNull();
+        assertThat(discardQueue.receive(0)).isNotNull();
 
         assertThat(messageGroup(correlationId).getMessages()).hasSize(0);
     }


### PR DESCRIPTION
This PR fixes idempotent Bpmn messages receiver interceptor configuration to use the discard channel instead of the error channel to remove the following log error is printed on runtime application start-up: `11:31:21.410 ERROR o.s.i.handler.LoggingHandler - [B@60f966e2`

Fixes https://alfresco.atlassian.net/browse/AAE-20974