### PR TITLE
AAE-22485 Update graphql-jpa-query.version to 1.2.5

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>1.2.4</graphql-jpa-query.version>
+    <graphql-jpa-query.version>1.2.5</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Update GraphQl JPA Query dependency to version https://github.com/introproventures/graphql-jpa-query/releases/tag/1.2.5 with [Fix where query criteria with multiple associations joins](https://github.com/introproventures/graphql-jpa-query/pull/485#top) 

Fixes https://hyland.atlassian.net/browse/AAE-22485