### PR TITLE
AAE-22508 Add capability to query aggregated data in GraphQL queries

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>1.2.5</graphql-jpa-query.version>
+    <graphql-jpa-query.version>1.2.6</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
@@ -64,7 +64,7 @@ public class ActivitiGraphQLSchemaAutoConfiguration {
                                         .filter(VariableValue.class::isInstance)
                                         .map(VariableValue.class::cast)
                                         .map(it -> Optional.ofNullable(it.getValue()).orElse(Optional.empty()))
-                                        .orElse(input);
+                                        .orElseGet(() -> super.serialize(input));
                                 }
                             }
                         )

--- a/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/jpa-query/src/main/java/org/activiti/cloud/services/notifications/graphql/jpa/query/ActivitiGraphQLSchemaAutoConfiguration.java
@@ -21,8 +21,10 @@ import com.introproventures.graphql.jpa.query.autoconfigure.EnableGraphQLJpaQuer
 import com.introproventures.graphql.jpa.query.autoconfigure.GraphQLJPASchemaBuilderCustomizer;
 import com.introproventures.graphql.jpa.query.schema.JavaScalars;
 import graphql.GraphQL;
+import java.util.Optional;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.VariableValue;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -40,18 +42,32 @@ import org.springframework.context.annotation.Bean;
 @EnableGraphQLJpaQuerySchema(basePackageClasses = ProcessInstanceEntity.class)
 public class ActivitiGraphQLSchemaAutoConfiguration {
 
+    @Value("${spring.activiti.cloud.services.notifications.graphql.jpa-query.aggregate.enabled:true}")
+    private boolean isAggregateEnabled;
+
     @Bean
     GraphQLJPASchemaBuilderCustomizer graphQLJPASchemaBuilderCustomizer() {
         return builder ->
             builder
                 .name("Query")
                 .description("Activiti Cloud Query Schema")
+                .enableAggregate(isAggregateEnabled)
                 .scalar(
                     VariableValue.class,
                     newScalar()
                         .name("VariableValue")
-                        .description("VariableValue type")
-                        .coercing(new JavaScalars.GraphQLObjectCoercing())
+                        .coercing(
+                            new JavaScalars.GraphQLObjectCoercing() {
+                                public Object serialize(final Object input) {
+                                    return Optional
+                                        .ofNullable(input)
+                                        .filter(VariableValue.class::isInstance)
+                                        .map(VariableValue.class::cast)
+                                        .map(it -> Optional.ofNullable(it.getValue()).orElse(Optional.empty()))
+                                        .orElse(input);
+                                }
+                            }
+                        )
                         .build()
                 );
     }

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
@@ -1418,6 +1418,109 @@ public class ActivitiGraphQLStarterIT {
         assertThat("{Tasks={select=[{id=1, assignee=assignee, priority=5}]}}").isEqualTo(result.getData().toString());
     }
 
+    @Test
+    public void testGraphqlAggregateTaskVariablesQuery() {
+        GraphQLQueryRequest query = new GraphQLQueryRequest(
+            """
+                query {
+                  TaskVariables(
+                    # Apply filter criteria
+                    where: {name: {IN: ["variable1", "variable2", "variable3"]}}
+                  ) {
+                    aggregate {
+                      # count by variables
+                      variables: count
+                      # Count by associated tasks
+                      groupByVariableName: group {
+                        name: by(field: name)
+                        count
+                      }
+                      groupByTaskStatus: task {
+                        status: by(field: status)
+                        count
+                      }
+                      # Count by associated tasks
+                      groupByTaskAssignee: task {
+                        assignee: by(field: assignee)
+                        count
+                      }
+                    }
+                  }
+                }
+            """
+        );
+
+        ResponseEntity<GraphQLQueryResult> entity = rest.postForEntity(
+            GRAPHQL_URL,
+            new HttpEntity<>(query, authHeaders),
+            GraphQLQueryResult.class
+        );
+
+        assertThat(entity.getStatusCode()).describedAs(entity.toString()).isEqualTo(HttpStatus.OK);
+
+        GraphQLQueryResult result = entity.getBody();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getErrors()).isNull();
+
+        var expected =
+            "{TaskVariables={aggregate={variables=3, groupByVariableName=[{name=variable1, count=1}, {name=variable2, count=1}, {name=variable3, count=1}], groupByTaskStatus=[{status=COMPLETED, count=2}, {status=CREATED, count=1}], groupByTaskAssignee=[{assignee=assignee, count=3}]}}}";
+
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testGraphqlAggregateTasksQuery() {
+        GraphQLQueryRequest query = new GraphQLQueryRequest(
+            """
+                query {
+                  Tasks {
+                    aggregate {
+                      countTasks: count
+                      countProcessVariables: count(of: processVariables)
+                      countTaskVariables: count(of: variables)
+                      countTasksGroupedByStatus: group {
+                        status: by(field: status)
+                        count
+                      }
+                      countProcessVariablesGroupedByTaskName: group {
+                        name: by(field: name)
+                        count(of: processVariables)
+                      }
+                      countTaskProcessVariablesGroupedByVariableNameAndValue: processVariables {
+                        name: by(field: name)
+                        value: by(field: value)
+                        count
+                      }
+                      countTaskVariablesGroupedByVariableName: variables {
+                        name: by(field: name)
+                        count
+                      }
+                    }
+                  }
+                }
+            """
+        );
+
+        ResponseEntity<GraphQLQueryResult> entity = rest.postForEntity(
+            GRAPHQL_URL,
+            new HttpEntity<>(query, authHeaders),
+            GraphQLQueryResult.class
+        );
+
+        assertThat(entity.getStatusCode()).describedAs(entity.toString()).isEqualTo(HttpStatus.OK);
+
+        GraphQLQueryResult result = entity.getBody();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getErrors()).isNull();
+
+        var expected =
+            "{Tasks={aggregate={countTasks=6, countProcessVariables=2, countTaskVariables=6, countTasksGroupedByStatus=[{status=ASSIGNED, count=1}, {status=COMPLETED, count=2}, {status=CREATED, count=3}], countProcessVariablesGroupedByTaskName=[{name=task4, count=1}, {name=task5, count=1}], countTaskProcessVariablesGroupedByVariableNameAndValue=[{name=initiator, value={key=[1, 2, 3, 4, 5]}, count=2}], countTaskVariablesGroupedByVariableName=[{name=variable1, count=1}, {name=variable2, count=1}, {name=variable3, count=1}, {name=variable4, count=1}, {name=variable5, count=1}, {name=variable6, count=1}]}}}";
+
+        assertThat(result.getData().toString()).isEqualTo(expected);
+    }
+
     public static StringObjectMapBuilder mapBuilder() {
         return new StringObjectMapBuilder();
     }

--- a/activiti-cloud-notifications-graphql-service/starter/src/test/resources/data.sql
+++ b/activiti-cloud-notifications-graphql-service/starter/src/test/resources/data.sql
@@ -20,3 +20,7 @@ insert into TASK_VARIABLE (id, create_time, execution_id, last_updated_time, nam
   (5, CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable4', 0, '2', 'map', '{"value": { "key" : "data" }}'),
   (6, CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '4', 'String', '{"value": 1.0}'),
   (7, CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable6', 1, '4', 'list', '{"value": [1,2,3,4,5]}');
+
+insert into TASK_PROCESS_VARIABLE (task_id, process_variable_id) values
+  (4,1),
+  (5,1);


### PR DESCRIPTION
Update GraphQL JPA Query dependency version to [1.2.6](https://github.com/introproventures/graphql-jpa-query/releases/tag/1.2.6) and add capability to query aggregated data for Activiti Cloud Query service GraphQL Api.

Fixes https://hyland.atlassian.net/browse/AAE-22508