### PR TITLE
AAE-10111 Limit the scope of Audit event export data

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/conf/AuditJPAAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/conf/AuditJPAAutoConfiguration.java
@@ -68,6 +68,7 @@ import org.activiti.cloud.services.audit.jpa.converters.VariableCreatedEventConv
 import org.activiti.cloud.services.audit.jpa.converters.VariableDeletedEventConverter;
 import org.activiti.cloud.services.audit.jpa.converters.VariableUpdatedEventConverter;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.activiti.cloud.services.audit.jpa.service.AuditEventsAdminService;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -446,5 +447,10 @@ public class AuditJPAAutoConfiguration {
         EventContextInfoAppender eventContextInfoAppender
     ) {
         return new ApplicationRollbackEventConverter(eventContextInfoAppender);
+    }
+
+    @Bean
+    public AuditEventsAdminService auditEventsAdminService(EventsRepository eventsRepository) {
+        return new AuditEventsAdminService(eventsRepository);
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/AuditEventsAdminControllerImpl.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/controllers/AuditEventsAdminControllerImpl.java
@@ -21,7 +21,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.services.audit.api.controllers.AuditEventsAdminController;

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/repository/EventsRepository.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/repository/EventsRepository.java
@@ -29,4 +29,6 @@ public interface EventsRepository<T extends AuditEventEntity>
     Optional<T> findByEventId(String eventId);
 
     Collection<T> findAllByOrderByTimestampDesc();
+
+    Collection<AuditEventEntity> findAllByTimestampBetweenOrderByTimestampDesc(Long startDateTime, Long endDateTime);
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminService.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.service;
+
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Objects;
+
+public class AuditEventsAdminService {
+    private final EventsRepository eventsRepository;
+
+    public AuditEventsAdminService(EventsRepository eventsRepository) {
+        this.eventsRepository = eventsRepository;
+    }
+
+    public Collection<AuditEventEntity> findAuditsBetweenDates(LocalDate fromDate, LocalDate toDate) {
+        if(fromDate.isAfter(toDate)) {
+            throw new IllegalArgumentException("From date cannot be after to date");
+        }
+
+        long daysBetween = ChronoUnit.DAYS.between(fromDate, toDate);
+
+        if(daysBetween > 31 || daysBetween < 0) {
+            throw new IllegalArgumentException("Difference between dates cannot be more than 31 days or negative");
+        }
+
+        Long startDateTime = fromDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+        Long endDateTime = toDate.atStartOfDay().plusDays(1).toEpochSecond(ZoneOffset.UTC);
+
+        return eventsRepository.findAllByTimestampBetweenOrderByTimestampDesc(startDateTime, endDateTime);
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminService.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/main/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminService.java
@@ -15,16 +15,15 @@
  */
 package org.activiti.cloud.services.audit.jpa.service;
 
-import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
-
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
-import java.util.Objects;
+import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 
 public class AuditEventsAdminService {
+
     private final EventsRepository eventsRepository;
 
     public AuditEventsAdminService(EventsRepository eventsRepository) {
@@ -32,13 +31,13 @@ public class AuditEventsAdminService {
     }
 
     public Collection<AuditEventEntity> findAuditsBetweenDates(LocalDate fromDate, LocalDate toDate) {
-        if(fromDate.isAfter(toDate)) {
+        if (fromDate.isAfter(toDate)) {
             throw new IllegalArgumentException("From date cannot be after to date");
         }
 
         long daysBetween = ChronoUnit.DAYS.between(fromDate, toDate);
 
-        if(daysBetween > 31 || daysBetween < 0) {
+        if (daysBetween > 31 || daysBetween < 0) {
             throw new IllegalArgumentException("Difference between dates cannot be more than 31 days or negative");
         }
 

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
@@ -109,12 +109,14 @@ class EventsEngineEventsAdminControllerIT {
         List<AuditEventEntity> events = buildEventsData(1);
         events.add(buildVariableAuditEventEntity(2));
 
-        given(eventsRepository.findAllByTimestampBetweenOrderByTimestampDesc(anyLong(),anyLong())).willReturn(events);
+        given(eventsRepository.findAllByTimestampBetweenOrderByTimestampDesc(anyLong(), anyLong())).willReturn(events);
 
         MvcResult response = mockMvc
-            .perform(get("/admin/{version}/events/export/" + CSV_FILENAME, "v1")
-                .param("from","2024-07-22")
-                .param("to","2024-07-24"))
+            .perform(
+                get("/admin/{version}/events/export/" + CSV_FILENAME, "v1")
+                    .param("from", "2024-07-22")
+                    .param("to", "2024-07-24")
+            )
             .andExpect(status().isOk())
             .andReturn();
 

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/controller/EventsEngineEventsAdminControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.audit.jpa.controller;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
@@ -108,10 +109,12 @@ class EventsEngineEventsAdminControllerIT {
         List<AuditEventEntity> events = buildEventsData(1);
         events.add(buildVariableAuditEventEntity(2));
 
-        given(eventsRepository.findAllByOrderByTimestampDesc()).willReturn(events);
+        given(eventsRepository.findAllByTimestampBetweenOrderByTimestampDesc(anyLong(),anyLong())).willReturn(events);
 
         MvcResult response = mockMvc
-            .perform(get("/admin/{version}/events/export/" + CSV_FILENAME, "v1"))
+            .perform(get("/admin/{version}/events/export/" + CSV_FILENAME, "v1")
+                .param("from","2024-07-22")
+                .param("to","2024-07-24"))
             .andExpect(status().isOk())
             .andReturn();
 

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
@@ -15,17 +15,16 @@
  */
 package org.activiti.cloud.services.audit.jpa.service;
 
-import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDate;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class AuditEventsAdminServiceTest {
 
@@ -42,7 +41,10 @@ public class AuditEventsAdminServiceTest {
         LocalDate toDate = LocalDate.of(2019, 1, 1);
 
         // when
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+        IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate)
+        );
 
         // then
         assertEquals("From date cannot be after to date", thrown.getMessage());
@@ -55,7 +57,10 @@ public class AuditEventsAdminServiceTest {
         LocalDate toDate = LocalDate.of(2020, 2, 1);
 
         // when
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+        IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate)
+        );
 
         // then
         assertEquals("Difference between dates cannot be more than 31 days or negative", thrown.getMessage());
@@ -68,7 +73,10 @@ public class AuditEventsAdminServiceTest {
         LocalDate toDate = LocalDate.of(2019, 12, 1);
 
         // when
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+        IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate)
+        );
 
         // then
         assertEquals("Difference between dates cannot be more than 31 days or negative", thrown.getMessage());

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
@@ -23,15 +23,19 @@ import static org.mockito.Mockito.verify;
 import java.time.LocalDate;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@ExtendWith(MockitoExtension.class)
 public class AuditEventsAdminServiceTest {
 
     @Mock
     private EventsRepository eventsRepository;
 
-    @Autowired
+    @InjectMocks
     private AuditEventsAdminService auditEventsAdminService;
 
     @Test

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.service;
+
+import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+
+public class AuditEventsAdminServiceTest {
+
+    @Mock
+    private EventsRepository eventsRepository;
+
+    @Autowired
+    private AuditEventsAdminService auditEventsAdminService;
+
+    @Test
+    void should_throw_exception_when_from_date_is_after_to_date() {
+        // given
+        LocalDate fromDate = LocalDate.of(2020, 1, 1);
+        LocalDate toDate = LocalDate.of(2019, 1, 1);
+
+        // when
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+
+        // then
+        assertEquals("From date cannot be after to date", thrown.getMessage());
+    }
+
+    @Test
+    void should_throw_exception_when_difference_between_dates_is_more_than_31_days() {
+        // given
+        LocalDate fromDate = LocalDate.of(2020, 1, 1);
+        LocalDate toDate = LocalDate.of(2020, 2, 1);
+
+        // when
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+
+        // then
+        assertEquals("Difference between dates cannot be more than 31 days or negative", thrown.getMessage());
+    }
+
+    @Test
+    void should_throw_exception_when_difference_between_dates_is_negative() {
+        // given
+        LocalDate fromDate = LocalDate.of(2020, 1, 1);
+        LocalDate toDate = LocalDate.of(2019, 12, 1);
+
+        // when
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate));
+
+        // then
+        assertEquals("Difference between dates cannot be more than 31 days or negative", thrown.getMessage());
+    }
+
+    @Test
+    void should_return_events_between_dates() {
+        // given
+        LocalDate fromDate = LocalDate.of(2020, 1, 1);
+        LocalDate toDate = LocalDate.of(2020, 1, 2);
+
+        // when
+        auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate);
+
+        // then
+        verify(eventsRepository).findAllByTimestampBetweenOrderByTimestampDesc(anyLong(), anyLong());
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-jpa/src/test/java/org/activiti/cloud/services/audit/jpa/service/AuditEventsAdminServiceTest.java
@@ -58,23 +58,7 @@ public class AuditEventsAdminServiceTest {
     void should_throw_exception_when_difference_between_dates_is_more_than_31_days() {
         // given
         LocalDate fromDate = LocalDate.of(2020, 1, 1);
-        LocalDate toDate = LocalDate.of(2020, 2, 1);
-
-        // when
-        IllegalArgumentException thrown = assertThrows(
-            IllegalArgumentException.class,
-            () -> auditEventsAdminService.findAuditsBetweenDates(fromDate, toDate)
-        );
-
-        // then
-        assertEquals("Difference between dates cannot be more than 31 days or negative", thrown.getMessage());
-    }
-
-    @Test
-    void should_throw_exception_when_difference_between_dates_is_negative() {
-        // given
-        LocalDate fromDate = LocalDate.of(2020, 1, 1);
-        LocalDate toDate = LocalDate.of(2019, 12, 1);
+        LocalDate toDate = LocalDate.of(2020, 3, 1);
 
         // when
         IllegalArgumentException thrown = assertThrows(


### PR DESCRIPTION
In order to prevent from creating and downloading the audit log file with huge amount of data (which can cause system freeze or other issues), we would like to limit the data range that is downloaded at a time to one calendar month.