### PR TITLE
AAE-23532 Fix race condition for service tasks using connectors

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>8.7.0-alpha.7</activiti.version>
+    <activiti.version>8.7.0-alpha.8</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>8.7.0-alpha.8</activiti.version>
+    <activiti.version>8.7.0-alpha.9</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -18,7 +18,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.7</activiti.version>
+    <activiti.version>8.7.0-alpha.8</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -18,7 +18,7 @@
     <module>activiti-cloud-starter-query</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.8</activiti.version>
+    <activiti.version>8.7.0-alpha.9</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/behavior/MQServiceTaskBehavior.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/behavior/MQServiceTaskBehavior.java
@@ -72,7 +72,7 @@ public class MQServiceTaskBehavior implements DelegateExecutionFunction {
 
             aggregateCloudIntegrationRequestedEvent(integrationContext);
         }
-        return DelegateExecutionOutcome.DO_NOTHING;
+        return DelegateExecutionOutcome.WAIT_FOR_TRIGGER;
     }
 
     private void aggregateCloudIntegrationRequestedEvent(IntegrationContext integrationContext) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/behavior/MQServiceTaskBehavior.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/behavior/MQServiceTaskBehavior.java
@@ -64,14 +64,15 @@ public class MQServiceTaskBehavior implements DelegateExecutionFunction {
         if (defaultServiceTaskBehavior.hasConnectorBean(execution)) {
             // use de default implementation -> directly call a bean
             return defaultServiceTaskBehavior.apply(execution);
-        } else {
-            IntegrationContextEntity integrationContextEntity = storeIntegrationContext(execution);
-
-            IntegrationContext integrationContext = integrationContextBuilder.from(integrationContextEntity, execution);
-            sendIntegrationRequest(integrationContext);
-
-            aggregateCloudIntegrationRequestedEvent(integrationContext);
         }
+
+        IntegrationContext integrationContext = integrationContextBuilder.from(
+            storeIntegrationContext(execution),
+            execution
+        );
+        sendIntegrationRequest(integrationContext);
+        aggregateCloudIntegrationRequestedEvent(integrationContext);
+
         return DelegateExecutionOutcome.WAIT_FOR_TRIGGER;
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/IntegrationRequestReplayer.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/IntegrationRequestReplayer.java
@@ -51,7 +51,7 @@ public class IntegrationRequestReplayer {
             ExecutionEntity execution = (ExecutionEntity) executions.get(0);
             managementService.executeCommand(
                 (Command<Void>) commandContext -> {
-                    mqServiceTaskBehavior.execute(execution);
+                    mqServiceTaskBehavior.apply(execution);
                     return null;
                 }
             );

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/behavior/MQServiceTaskBehaviorTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/behavior/MQServiceTaskBehaviorTest.java
@@ -19,7 +19,6 @@ import static org.activiti.services.test.DelegateExecutionBuilder.anExecution;
 import static org.activiti.test.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -120,10 +119,10 @@ public class MQServiceTaskBehaviorTest {
         given(defaultServiceTaskBehavior.hasConnectorBean(execution)).willReturn(true);
 
         //when
-        behavior.execute(execution);
+        behavior.apply(execution);
 
         //then
-        verify(defaultServiceTaskBehavior).execute(execution);
+        verify(defaultServiceTaskBehavior).apply(execution);
     }
 
     @Test
@@ -147,7 +146,7 @@ public class MQServiceTaskBehaviorTest {
         when(runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()).thenReturn(true);
 
         //when
-        behavior.execute(execution);
+        behavior.apply(execution);
 
         //then
         ((ExecutionEntity) execution).getProcessInstance();
@@ -164,18 +163,5 @@ public class MQServiceTaskBehaviorTest {
         verify(runtimeBundleInfoAppender).appendRuntimeBundleInfoTo(integrationRequest);
 
         verify(processEngineEventsAggregator).add(any(CloudIntegrationRequestedEvent.class));
-    }
-
-    @Test
-    public void triggerShouldCallLeave() {
-        //given
-        DelegateExecution execution = mock(DelegateExecution.class);
-        doNothing().when(behavior).leave(execution);
-
-        //when
-        behavior.trigger(execution, null, null);
-
-        //then
-        verify(behavior).leave(execution);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
@@ -26,6 +26,8 @@ public interface ConnectorIntegrationChannels {
     String CONSTANTS_INTEGRATION_EVENTS_CONSUMER = "constantsIntegrationEventsConsumer";
     String MEALS_CONNECTOR_CONSUMER = "mealsConnectorConsumer";
     String VALUE_PROCESSOR_CONSUMER = "valueProcessorConsumer";
+    String RACE_CONDITIONS_MULTI_INSTANCE_CONSUMER = "raceConditionsMultiInstanceConsumer";
+    String RACE_CONDITION_SINGLE_INSTANCE_CONSUMER = "raceConditionsSingleInstanceConsumer";
 
     @InputBinding(INTEGRATION_EVENTS_CONSUMER)
     default SubscribableChannel integrationEventsConsumer() {
@@ -55,5 +57,15 @@ public interface ConnectorIntegrationChannels {
     @InputBinding(VALUE_PROCESSOR_CONSUMER)
     default SubscribableChannel valueProcessorConsumer() {
         return MessageChannels.publishSubscribe(VALUE_PROCESSOR_CONSUMER).getObject();
+    }
+
+    @InputBinding(RACE_CONDITIONS_MULTI_INSTANCE_CONSUMER)
+    default SubscribableChannel raceConditionsMultiInstanceConsumer() {
+        return MessageChannels.publishSubscribe(RACE_CONDITIONS_MULTI_INSTANCE_CONSUMER).getObject();
+    }
+
+    @InputBinding(RACE_CONDITION_SINGLE_INSTANCE_CONSUMER)
+    default SubscribableChannel raceConditionsSingleInstanceConsumer() {
+        return MessageChannels.publishSubscribe(RACE_CONDITION_SINGLE_INSTANCE_CONSUMER).getObject();
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.services.rest.api.ReplayServiceTaskRequest;
+import org.activiti.cloud.starter.tests.services.audit.AuditProducerIT;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 public class MQServiceTaskIT extends AbstractMQServiceTaskIT {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -58,6 +59,14 @@ public class AuditConsumerStreamHandler {
 
     public List<CloudRuntimeEvent<?, ?>> getAllReceivedEvents() {
         return allReceivedEvents;
+    }
+
+    public <T extends CloudRuntimeEvent<?, ?>> List<T> getAllReceivedEvents(Class<T> eventType) {
+        return allReceivedEvents
+            .stream()
+            .filter(eventType::isInstance)
+            .map(eventType::cast)
+            .collect(Collectors.toList());
     }
 
     public Map<String, Object> getReceivedHeaders() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -133,7 +133,7 @@ import org.springframework.test.context.TestPropertySource;
     initializers = { KeycloakContainerApplicationInitializer.class }
 )
 @Import(TestChannelBinderConfiguration.class)
-class AuditProducerIT {
+public class AuditProducerIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";
     private static final String SIMPLE_SUB_PROCESS2 = "simpleSubProcess2";

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -61,6 +61,14 @@ spring.cloud.stream.bindings.canFailConnector.destination=connector.canFail
 spring.cloud.stream.bindings.canFailConnector.group=integration
 spring.cloud.stream.bindings.canFailConnector.contentType=application/json
 
+# Race condition test connectors
+spring.cloud.stream.bindings.raceConditionsMultiInstanceConsumer.destination=testRaceConditionMultipleInstances
+spring.cloud.stream.bindings.raceConditionsMultiInstanceConsumer.group=integration
+spring.cloud.stream.bindings.raceConditionsMultiInstanceConsumer.contentType=application/json
+
+spring.cloud.stream.bindings.raceConditionsSingleInstanceConsumer.destination=testRaceConditionSingleInstance
+spring.cloud.stream.bindings.raceConditionsSingleInstanceConsumer.group=integration
+spring.cloud.stream.bindings.raceConditionsSingleInstanceConsumer.contentType=application/json
 
 activiti.identity.test-user=hruser
 activiti.identity.test-password=password

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-sequence-servicetask-racecondition.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-sequence-servicetask-racecondition.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="miSequentialServiceTaskRaceCondition">
+        <startEvent id="startevent1" name="Start"></startEvent>
+        <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="miServiceTask"></sequenceFlow>
+
+        <serviceTask id="miServiceTask" name="miServiceTask" implementation="testRaceConditionMultipleInstances">
+            <multiInstanceLoopCharacteristics isSequential="true">
+                <loopCardinality>${2}</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+        </serviceTask>
+
+        <sequenceFlow id="flow3" name="" sourceRef="miServiceTask" targetRef="theEnd"></sequenceFlow>
+        <endEvent id="theEnd"></endEvent>
+    </process>
+
+</definitions>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/service-task-single-racecondition-with-multi-instance.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/service-task-single-racecondition-with-multi-instance.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="serviceTaskSingleInstanceRaceConditionWithOtherProcessWithMultiInstance">
+        <startEvent id="startevent1" name="Start"></startEvent>
+        <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="serviceTask"></sequenceFlow>
+
+        <serviceTask id="serviceTask" name="ServiceTask for race condition" implementation="testRaceConditionSingleInstance">
+        </serviceTask>
+
+        <sequenceFlow id="flow3" name="" sourceRef="serviceTask" targetRef="theEnd"></sequenceFlow>
+        <endEvent id="theEnd"></endEvent>
+    </process>
+
+</definitions>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -18,7 +18,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.8</activiti.version>
+    <activiti.version>8.7.0-alpha.9</activiti.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -18,7 +18,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.7</activiti.version>
+    <activiti.version>8.7.0-alpha.8</activiti.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -34,7 +34,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.7</activiti.version>
+    <activiti.version>8.7.0-alpha.8</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -34,7 +34,7 @@
     <module>activiti-cloud-service-messaging-starter</module>
   </modules>
   <properties>
-    <activiti.version>8.7.0-alpha.8</activiti.version>
+    <activiti.version>8.7.0-alpha.9</activiti.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
Having `MQServiceTaskBehavior ` as an `ActivityBehavior` was causing racing conditions because it's instantiated as a singleton. Given the fact that `MQServiceTaskBehavior` is always wrapped inside a `ServiceTaskDelegateExpressionActivityBehavior` that is already an `ActivityBehavior`, there is no reason to have `MQServiceTaskBehavior` also implementing `ActivityBehavior`. This PR is makes `MQServiceTaskBehavior` implement the new interface `DelegateExecutionFunction` instead of `ActivityBehavior`.

Depends on https://github.com/Activiti/Activiti/pull/4726

<!--
You can also link to an open issue here
-->

- Issue Link: AAE-23532

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
