### PR TITLE
AAE-25309 Avoid overloading test cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,9 @@ jobs:
     env:
       MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
     strategy:
-      fail-fast: false
+      # avoid overloading test cluster
+      max-parallel: 2
+      fail-fast: true
       matrix:
         messaging-broker: [ rabbitmq, kafka ]
         messaging-partitioned: [ partitioned, non-partitioned ]


### PR DESCRIPTION
activiti-cloud workflow runs acceptance tests on a matrix job with 5 runs in different configurations.

This overloads quickly the cluster, especially when several checks are done in parallel, and the tests end up failing (and need to be rerun).

Setting a max-parallel to 2 should help mitigating this issue for now.