### PR TITLE
AAE-25309 Delete test namespaces even on preview PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,16 +279,9 @@ jobs:
 
       - name: Delete Helm chart for ${{ matrix.messaging-broker }}
         if: always()
-        env:
-          IS_PREVIEW: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'preview') }}
         run: |
-          if [ $IS_PREVIEW = true ]
-          then
-              echo "Skipping delete Helm release for preview"
-          else
-              echo "Delete Helm release"
-              make delete
-          fi
+          echo "Delete Helm release"
+          make delete
 
   delete-test-images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Preview does not seem to be used for test namespaces to stay up -> clean them up after tests to avoid overloading the test cluster