### PR TITLE
AAE-25834 Fix start form constants when no form

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImpl.java
@@ -180,7 +180,7 @@ public class ProcessDefinitionControllerImpl implements ProcessDefinitionControl
     @Override
     public Map<String, Object> getProcessModelStaticValuesMappingForStartEvent(String id) {
         Map<String, Object> result = new HashMap<>();
-        ExtensionsStartEventId extensionsStartEventId = getProcessExtensionsForStartEvent(id);
+        ExtensionsStartEventId extensionsStartEventId = getProcessExtensionsForStartEvent(id, true);
         if (
             extensionsStartEventId != null &&
             extensionsStartEventId.extensions() != null &&
@@ -208,7 +208,7 @@ public class ProcessDefinitionControllerImpl implements ProcessDefinitionControl
     @Override
     public Map<String, Object> getProcessModelConstantValuesForStartEvent(String id) {
         Map<String, Object> result = new HashMap<>();
-        ExtensionsStartEventId extensionsStartEventId = getProcessExtensionsForStartEvent(id);
+        ExtensionsStartEventId extensionsStartEventId = getProcessExtensionsForStartEvent(id, false);
         if (
             extensionsStartEventId != null &&
             extensionsStartEventId.extensions() != null &&
@@ -226,13 +226,13 @@ public class ProcessDefinitionControllerImpl implements ProcessDefinitionControl
         return result;
     }
 
-    private ExtensionsStartEventId getProcessExtensionsForStartEvent(String id) {
+    private ExtensionsStartEventId getProcessExtensionsForStartEvent(String id, boolean formRequired) {
         checkUserCanReadProcessDefinition(id);
 
         BpmnModel bpmnModel = repositoryService.getBpmnModel(id);
         Process process = bpmnModel.getMainProcess();
 
-        if (bpmnModel.getStartFormKey(process.getId()) != null) {
+        if (!formRequired || bpmnModel.getStartFormKey(process.getId()) != null) {
             Optional<FlowElement> startEvent = process
                 .getFlowElements()
                 .stream()


### PR DESCRIPTION
When there is no form key in the start event, the constants for it should be retrieved anyway