### PR TITLE
AAE-22831 Fix status is changed to 'Cancelled' when deleting process instance

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceTasks.java
@@ -404,6 +404,11 @@ public class ProcessInstanceTasks {
         processRuntimeAdminSteps.deleteProcessInstance(processInstance.getId());
     }
 
+    @When("the admin force destroys the process")
+    public void adminForceDeleteCurrentProcessInstance() throws Exception {
+        processRuntimeAdminSteps.destroyProcessInstance(processInstance.getId(), true);
+    }
+
     @When("the user suspends the process instance")
     public void suspendProcessInstance() throws Exception {
         processRuntimeBundleSteps.suspendProcessInstance(processInstance.getId());
@@ -420,6 +425,16 @@ public class ProcessInstanceTasks {
         auditSteps.checkProcessInstanceEvent(
             processInstance.getId(),
             ProcessRuntimeEvent.ProcessEvents.PROCESS_CANCELLED
+        );
+    }
+
+    @Then("the process instance is destroyed")
+    public void verifyProcessInstanceIsForceDestroyed() throws Exception {
+        processRuntimeBundleSteps.checkProcessInstanceNotFound(processInstance.getId());
+        processQuerySteps.checkProcessInstanceNotFound(processInstance.getId());
+        auditSteps.checkProcessInstanceEvent(
+            processInstance.getId(),
+            ProcessRuntimeEvent.ProcessEvents.PROCESS_DELETED
         );
     }
 

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -120,6 +120,12 @@ When the user starts an instance of the process called PROCESS_INSTANCE_WITH_VAR
 And the admin deletes the process
 Then the process instance is deleted
 
+Scenario: admin force destroy a process instance
+Given the user is authenticated as testadmin
+When the user starts an instance of the process called PROCESS_INSTANCE_WITH_VARIABLES
+And the admin force destroys the process
+Then the process instance is destroyed
+
 Scenario: check sequence number and message id for events
 Given the user is authenticated as testuser
 When the user starts an instance of the process called SIMPLE_PROCESS_INSTANCE

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import feign.FeignException;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Optional;
 import net.thucydides.core.steps.StepEventBus;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
@@ -39,9 +38,7 @@ public class RestErrorAssert {
         Throwable throwable = catchThrowable(throwingCallable);
         assertThat(throwable).isInstanceOf(FeignException.class);
 
-        Optional
-            .ofNullable(StepEventBus.getEventBus().getBaseStepListener())
-            .ifPresent(baseStepListener -> baseStepListener.exceptionExpected(FeignException.class));
+        StepEventBus.getEventBus().getBaseStepListener().exceptionExpected(FeignException.class);
 
         return new RestErrorAssert((FeignException) throwable);
     }

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/assertions/RestErrorAssert.java
@@ -15,10 +15,12 @@
  */
 package org.activiti.cloud.acc.core.assertions;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import feign.FeignException;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import net.thucydides.core.steps.StepEventBus;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
@@ -37,7 +39,9 @@ public class RestErrorAssert {
         Throwable throwable = catchThrowable(throwingCallable);
         assertThat(throwable).isInstanceOf(FeignException.class);
 
-        StepEventBus.getEventBus().getBaseStepListener().exceptionExpected(FeignException.class);
+        Optional
+            .ofNullable(StepEventBus.getEventBus().getBaseStepListener())
+            .ifPresent(baseStepListener -> baseStepListener.exceptionExpected(FeignException.class));
 
         return new RestErrorAssert((FeignException) throwable);
     }

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/admin/ProcessRuntimeAdminService.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/services/runtime/admin/ProcessRuntimeAdminService.java
@@ -31,6 +31,9 @@ public interface ProcessRuntimeAdminService {
     @RequestLine("DELETE /admin/v1/process-instances/{id}")
     void deleteProcess(@Param("id") String id);
 
+    @RequestLine("DELETE /admin/v1/process-instances/{id}/destroy?force={force}")
+    void destroyProcess(@Param("id") String id, @Param("force") boolean force);
+
     @RequestLine("POST /admin/v1/process-instances/message")
     @Headers("Content-Type: application/json")
     CloudProcessInstance message(StartMessagePayload startProcess);

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -179,6 +179,7 @@ public class ProcessQuerySteps {
     @Step
     public void checkProcessInstanceNotFound(String processInstanceId) {
         await()
+            .pollInSameThread()
             .untilAsserted(() ->
                 assertThatRestNotFoundErrorIsThrownBy(() -> processQueryService.getProcessInstance(processInstanceId))
             );

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.acc.core.steps.query;
 
+import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatRestNotFoundErrorIsThrownBy;
 import static org.activiti.cloud.services.common.util.ImageUtils.svgToPng;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -173,5 +174,13 @@ public class ProcessQuerySteps {
     @Step
     public void checkProcessInstanceNoDiagram(String diagram) {
         assertThat(diagram).isEmpty();
+    }
+
+    @Step
+    public void checkProcessInstanceNotFound(String processInstanceId) {
+        await()
+            .untilAsserted(() ->
+                assertThatRestNotFoundErrorIsThrownBy(() -> processQueryService.getProcessInstance(processInstanceId))
+            );
     }
 }

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/admin/ProcessRuntimeAdminSteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/runtime/admin/ProcessRuntimeAdminSteps.java
@@ -55,6 +55,11 @@ public class ProcessRuntimeAdminSteps {
     }
 
     @Step
+    public void destroyProcessInstance(String id, boolean force) {
+        processRuntimeAdminService.destroyProcess(id, force);
+    }
+
+    @Step
     public CloudProcessInstance message(StartMessagePayload payload) throws IOException {
         return processRuntimeAdminService.message(payload);
     }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeletedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeletedEventConverter.java
@@ -15,22 +15,14 @@
  */
 package org.activiti.cloud.services.audit.jpa.converters;
 
-import java.util.List;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeletedEvent;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.AuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.events.ProcessAuditEventEntity;
 import org.activiti.cloud.services.audit.jpa.events.ProcessDeletedAuditEventEntity;
-import org.activiti.cloud.services.audit.jpa.repository.EventSpecificationsBuilder;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
-import org.activiti.cloud.services.audit.jpa.repository.SearchOperation;
-import org.activiti.cloud.services.audit.jpa.repository.SpecSearchCriteria;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Order;
-import org.springframework.data.jpa.domain.Specification;
 
 public class ProcessDeletedEventConverter extends BaseEventToEntityConverter {
 
@@ -57,8 +49,7 @@ public class ProcessDeletedEventConverter extends BaseEventToEntityConverter {
 
     @Override
     protected ProcessDeletedAuditEventEntity createEventEntity(CloudRuntimeEvent cloudRuntimeEvent) {
-        ProcessAuditEventEntity event = findEvent(cloudRuntimeEvent.getProcessInstanceId());
-        return new ProcessDeletedAuditEventEntity(event, (CloudProcessDeletedEvent) cloudRuntimeEvent);
+        return new ProcessDeletedAuditEventEntity((CloudProcessDeletedEvent) cloudRuntimeEvent);
     }
 
     @Override
@@ -70,17 +61,5 @@ public class ProcessDeletedEventConverter extends BaseEventToEntityConverter {
             processDeletedAuditEventEntity.getTimestamp(),
             processDeletedAuditEventEntity.getProcessInstance()
         );
-    }
-
-    protected ProcessAuditEventEntity findEvent(String processInstanceId) {
-        Specification<AuditEventEntity> specification = new EventSpecificationsBuilder()
-            .with(new SpecSearchCriteria(PROCESS_INSTANCE_ID, SearchOperation.EQUALITY, processInstanceId))
-            .build();
-        List<AuditEventEntity> events = eventsRepository.findAll(specification, Sort.by(Order.desc(TIMESTAMP)));
-        AuditEventEntity lastEvent = events
-            .stream()
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException(String.format(MISSING_PROCESS_INSTANCE, processInstanceId)));
-        return ProcessAuditEventEntity.class.cast(lastEvent);
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeletedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/ProcessDeletedEventConverterTest.java
@@ -16,8 +16,6 @@
 package org.activiti.cloud.services.audit.jpa.converters;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 public class ProcessDeletedEventConverterTest {
@@ -65,10 +62,8 @@ public class ProcessDeletedEventConverterTest {
         //given
         String processDefinitionId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
-        given(eventsRepository.findAll(any(), any(Sort.class)))
-            .willReturn(buildCompletedEntities(processDefinitionId, processInstanceId));
 
-        CloudRuntimeEvent<?, ?> runtimeEvent = buildEvent(processInstanceId);
+        CloudRuntimeEvent<?, ?> runtimeEvent = buildEvent(processInstanceId, processDefinitionId);
 
         //when
         ProcessDeletedAuditEventEntity event = converter.createEventEntity(runtimeEvent);
@@ -83,10 +78,8 @@ public class ProcessDeletedEventConverterTest {
         //given
         String processDefinitionId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
-        given(eventsRepository.findAll(any(), any(Sort.class)))
-            .willReturn(buildCompletedEntities(processDefinitionId, processInstanceId));
 
-        CloudRuntimeEvent<?, ?> runtimeEvent = buildEvent(processInstanceId);
+        CloudRuntimeEvent<?, ?> runtimeEvent = buildEvent(processInstanceId, processDefinitionId);
 
         //when
         ProcessDeletedAuditEventEntity event = converter.createEventEntity(runtimeEvent);
@@ -97,9 +90,10 @@ public class ProcessDeletedEventConverterTest {
         assertThat(apiEvent.getProcessInstanceId()).isEqualTo(processInstanceId);
     }
 
-    private CloudRuntimeEvent<?, ?> buildEvent(String processInstanceId) {
+    private CloudRuntimeEvent<?, ?> buildEvent(String processInstanceId, String processDefinitionId) {
         ProcessInstanceImpl instance = new ProcessInstanceImpl();
         instance.setId(processInstanceId);
+        instance.setProcessDefinitionId(processDefinitionId);
 
         CloudProcessDeletedEventImpl event = new CloudProcessDeletedEventImpl(instance);
         event.setProcessInstanceId(processInstanceId);

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/src/test/java/org/activiti/cloud/starter/audit/tests/it/AuditServiceIT.java
@@ -85,6 +85,7 @@ import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateSta
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterUserAddedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterUserRemovedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
@@ -142,6 +143,7 @@ public class AuditServiceIT {
     public void findAllShouldReturnAllAvailableEvents() {
         //given
         List<CloudRuntimeEvent> coveredEvents = getTestEvents();
+
         producer.send(coveredEvents.toArray(new CloudRuntimeEvent[coveredEvents.size()]));
 
         await()
@@ -1125,6 +1127,14 @@ public class AuditServiceIT {
         testEvents.add(
             new CloudProcessSuspendedEventImpl(
                 "ProcessSuspendedEventId",
+                System.currentTimeMillis(),
+                processInstanceStarted
+            )
+        );
+
+        testEvents.add(
+            new CloudProcessDeletedEventImpl(
+                "ProcessDeletedEventId",
                 System.currentTimeMillis(),
                 processInstanceStarted
             )

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessDeletedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/ProcessDeletedEventHandler.java
@@ -16,14 +16,19 @@
 package org.activiti.cloud.services.query.events.handlers;
 
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import java.util.Set;
-import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.ProcessInstance.ProcessInstanceStatus;
 import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessDeletedEvent;
+import org.activiti.cloud.services.query.model.BPMNActivityEntity;
+import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.query.model.QueryException;
+import org.activiti.cloud.services.query.model.ServiceTaskEntity;
+import org.activiti.cloud.services.query.model.TaskEntity;
 
 public class ProcessDeletedEventHandler implements QueryEventHandler {
 
@@ -37,33 +42,30 @@ public class ProcessDeletedEventHandler implements QueryEventHandler {
     );
 
     private final EntityManager entityManager;
-    private final EntityManagerFinder entityManagerFinder;
 
     public ProcessDeletedEventHandler(EntityManager entityManager) {
         this.entityManager = entityManager;
-        this.entityManagerFinder = new EntityManagerFinder(entityManager);
     }
 
     @Override
     public void handle(CloudRuntimeEvent<?, ?> event) {
         CloudProcessDeletedEvent deletedEvent = (CloudProcessDeletedEvent) event;
 
-        ProcessInstance eventProcessInstance = deletedEvent.getEntity();
+        var eventProcessInstanceId = deletedEvent.getEntity().getId();
 
-        ProcessInstanceEntity processInstanceEntity = entityManagerFinder
-            .findProcessInstanceWithRelatedEntities(eventProcessInstance.getId())
+        ProcessInstanceEntity processInstanceEntity = Optional
+            .ofNullable(entityManager.find(ProcessInstanceEntity.class, eventProcessInstanceId))
             .orElseThrow(() ->
-                new QueryException("Unable to find process instance with the given id: " + eventProcessInstance.getId())
+                new QueryException("Unable to find process instance with the given id: " + eventProcessInstanceId)
             );
 
         if (ALLOWED_STATUS.contains(processInstanceEntity.getStatus())) {
-            processInstanceEntity.getTasks().stream().forEach(entityManager::remove);
-            processInstanceEntity.getVariables().stream().forEach(entityManager::remove);
-            processInstanceEntity.getServiceTasks().stream().forEach(entityManager::remove);
-            processInstanceEntity.getActivities().stream().forEach(entityManager::remove);
-            processInstanceEntity.getSequenceFlows().stream().forEach(entityManager::remove);
-
-            entityManager.remove(processInstanceEntity);
+            remove(TaskEntity.class, "processInstanceId", eventProcessInstanceId);
+            remove(ProcessVariableEntity.class, "processInstanceId", eventProcessInstanceId);
+            remove(ServiceTaskEntity.class, "processInstanceId", eventProcessInstanceId);
+            remove(BPMNActivityEntity.class, "processInstanceId", eventProcessInstanceId);
+            remove(BPMNSequenceFlowEntity.class, "processInstanceId", eventProcessInstanceId);
+            remove(ProcessInstanceEntity.class, "id", eventProcessInstanceId);
         } else {
             throw new IllegalStateException(
                 String.format(
@@ -73,6 +75,17 @@ public class ProcessDeletedEventHandler implements QueryEventHandler {
                 )
             );
         }
+    }
+
+    <T> void remove(Class<T> entityClass, String attributeName, Object attributeValue) {
+        var criteriaBuilder = entityManager.getCriteriaBuilder();
+
+        var delete = criteriaBuilder.createCriteriaDelete(entityClass);
+        var from = delete.from(entityClass);
+
+        delete.where(criteriaBuilder.equal(from.get(attributeName), attributeValue));
+
+        entityManager.createQuery(delete).executeUpdate();
     }
 
     @Override

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/QueryEventHandlerContextOptimizer.java
@@ -50,6 +50,7 @@ import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateSta
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCandidateStarterUserRemovedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessUpdatedEventImpl;
@@ -114,7 +115,8 @@ public class QueryEventHandlerContextOptimizer {
         Map.entry(CloudProcessCandidateStarterUserAddedEventImpl.class, 17),
         Map.entry(CloudProcessCandidateStarterGroupAddedEventImpl.class, 17),
         Map.entry(CloudProcessCandidateStarterUserRemovedEventImpl.class, 18),
-        Map.entry(CloudProcessCandidateStarterGroupRemovedEventImpl.class, 18)
+        Map.entry(CloudProcessCandidateStarterGroupRemovedEventImpl.class, 18),
+        Map.entry(CloudProcessDeletedEventImpl.class, 19)
     );
 
     private Comparator<CloudRuntimeEvent<?, ?>> byTimestamp = Comparator.comparingLong(CloudRuntimeEvent::getTimestamp);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/EntityFinder.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/EntityFinder.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.query.app.repository;
 
 import com.querydsl.core.types.Predicate;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
@@ -28,7 +29,7 @@ public class EntityFinder {
     }
 
     private <T> T getEntity(Optional<T> result, String notFoundMessage) {
-        return result.orElseThrow(() -> new IllegalStateException(notFoundMessage));
+        return result.orElseThrow(() -> new EntityNotFoundException(notFoundMessage));
     }
 
     public <T> T findOne(QuerydslPredicateExecutor<T> predicateExecutor, Predicate predicate, String notFoundMessage) {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
@@ -18,9 +18,10 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 import com.querydsl.core.types.Predicate;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,7 @@ public class EntityFinderTest {
 
         //then
         //when
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatExceptionOfType(EntityNotFoundException.class)
             .isThrownBy(() -> entityFinder.findById(repository, processInstanceId, "Error"))
             .withMessageContaining("Error");
     }
@@ -91,7 +92,7 @@ public class EntityFinderTest {
 
         //then
         //when
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatExceptionOfType(EntityNotFoundException.class)
             .isThrownBy(() -> entityFinder.findOne(repository, predicate, "Error"))
             .withMessageContaining("Error");
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.query.rest;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.activiti.api.model.shared.model.ActivitiErrorMessage;
 import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
@@ -48,5 +49,15 @@ public class CommonExceptionHandlerQuery {
     ) {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public EntityModel<ActivitiErrorMessage> handleAppException(
+        EntityNotFoundException ex,
+        HttpServletResponse response
+    ) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -107,7 +107,7 @@ public class ProcessInstanceAdminService {
         return entityFinder.findById(
             processInstanceRepository,
             processInstanceId,
-            "Unable to find task for the given id:'" + processInstanceId + "'"
+            "Unable to find process instance for the given id:'" + processInstanceId + "'"
         );
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryProcessInstancesEntityIT.java
@@ -266,7 +266,7 @@ public class QueryProcessInstancesEntityIT {
     @Test
     public void shouldDeleteProcessInfo() {
         //given
-        ProcessInstance process = processInstanceBuilder.aRunningProcessInstance("running");
+        ProcessInstance process = processInstanceBuilder.startSimpleProcessInstance("simple");
 
         eventsAggregator.sendAll();
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -97,8 +97,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -613,8 +620,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1004,8 +1018,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1339,8 +1360,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1437,8 +1465,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1748,8 +1783,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2052,8 +2094,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2318,8 +2367,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2834,8 +2890,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2945,8 +3008,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3012,8 +3082,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3085,8 +3162,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3158,8 +3242,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3469,8 +3560,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3536,8 +3634,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3654,8 +3759,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3764,8 +3876,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4072,8 +4191,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4134,8 +4260,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4286,8 +4419,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4348,8 +4488,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4457,8 +4604,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4568,8 +4722,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4635,8 +4796,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4708,8 +4876,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4781,8 +4956,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4869,8 +5051,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -4936,8 +5125,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5003,8 +5199,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5070,8 +5273,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5188,8 +5398,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5284,8 +5501,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5380,8 +5604,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5442,8 +5673,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5718,8 +5956,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5870,8 +6115,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5932,8 +6184,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -6041,8 +6300,15 @@
           "401": {
             "description": "Unauthorized"
           },
-          "404": {
-            "description": "Not Found"
+          "404":{
+            "description":"Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -203,7 +203,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Not Found"
+            "description": "Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -2473,7 +2480,14 @@
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Not Found"
+            "description": "Not Found",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -594,18 +594,9 @@ public class CloudEventsAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public CloudProcessDeletedService cloudProcessDeletedProducer(
-        ProcessEngineChannels processEngineChannels,
-        RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
-        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
         ManagementService managementService,
         ProcessEngineEventsAggregator processEngineEventsAggregator
     ) {
-        return new CloudProcessDeletedService(
-            processEngineChannels,
-            runtimeBundleMessageBuilderFactory,
-            runtimeBundleInfoAppender,
-            managementService,
-            processEngineEventsAggregator
-        );
+        return new CloudProcessDeletedService(managementService, processEngineEventsAggregator);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -17,7 +17,6 @@ package org.activiti.cloud.services.events.configuration;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
-import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -75,6 +74,7 @@ import org.activiti.cloud.services.events.message.CloudRuntimeEventMessageBuilde
 import org.activiti.cloud.services.events.message.ExecutionContextMessageBuilderFactory;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
 import org.activiti.cloud.services.events.services.CloudProcessDeletedService;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.spring.process.CachingProcessExtensionService;
@@ -597,13 +597,15 @@ public class CloudEventsAutoConfiguration {
         ProcessEngineChannels processEngineChannels,
         RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
         RuntimeBundleInfoAppender runtimeBundleInfoAppender,
-        ProcessAdminRuntime processAdminRuntime
+        ManagementService managementService,
+        ProcessEngineEventsAggregator processEngineEventsAggregator
     ) {
         return new CloudProcessDeletedService(
             processEngineChannels,
             runtimeBundleMessageBuilderFactory,
             runtimeBundleInfoAppender,
-            processAdminRuntime
+            managementService,
+            processEngineEventsAggregator
         );
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.events.configuration;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -595,12 +596,14 @@ public class CloudEventsAutoConfiguration {
     public CloudProcessDeletedService cloudProcessDeletedProducer(
         ProcessEngineChannels processEngineChannels,
         RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
-        RuntimeBundleInfoAppender runtimeBundleInfoAppender
+        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+        ProcessAdminRuntime processAdminRuntime
     ) {
         return new CloudProcessDeletedService(
             processEngineChannels,
             runtimeBundleMessageBuilderFactory,
-            runtimeBundleInfoAppender
+            runtimeBundleInfoAppender,
+            processAdminRuntime
         );
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CloudProcessDeletedService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CloudProcessDeletedService.java
@@ -15,41 +15,48 @@
  */
 package org.activiti.cloud.services.events.services;
 
-import static org.activiti.api.process.model.builders.ProcessPayloadBuilder.delete;
-
 import java.util.List;
-import java.util.Optional;
 import org.activiti.api.process.model.ProcessInstance;
-import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.impl.CloudProcessInstanceImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
 import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFactory;
+import org.activiti.engine.ManagementService;
 
 public class CloudProcessDeletedService {
 
     private final ProcessEngineChannels producer;
     private final RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory;
     private final RuntimeBundleInfoAppender runtimeBundleInfoAppender;
-    private final ProcessAdminRuntime processAdminRuntime;
+    private final ManagementService managementService;
+    private final ProcessEngineEventsAggregator processEngineEventsAggregator;
 
     public CloudProcessDeletedService(
         ProcessEngineChannels producer,
         RuntimeBundleMessageBuilderFactory runtimeBundleMessageBuilderFactory,
         RuntimeBundleInfoAppender runtimeBundleInfoAppender,
-        ProcessAdminRuntime processAdminRuntime
+        ManagementService managementService,
+        ProcessEngineEventsAggregator processEngineEventsAggregator
     ) {
         this.producer = producer;
         this.runtimeBundleMessageBuilderFactory = runtimeBundleMessageBuilderFactory;
         this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
-        this.processAdminRuntime = processAdminRuntime;
+        this.managementService = managementService;
+        this.processEngineEventsAggregator = processEngineEventsAggregator;
+    }
+
+    public void delete(String processInstanceId) {
+        var processInstance = buildProcessInstance(processInstanceId);
+        managementService.executeCommand(
+            new DeleteCloudProcessInstanceCmd(processInstance, processEngineEventsAggregator)
+        );
     }
 
     public void sendDeleteEvent(String processInstanceId) {
-        Optional
-            .ofNullable(processAdminRuntime.delete(delete().withProcessInstanceId(processInstanceId).build()))
-            .ifPresent(this::sendEvent);
+        this.sendEvent(buildProcessInstance(processInstanceId));
     }
 
     protected void sendEvent(ProcessInstance processInstance) {
@@ -61,5 +68,11 @@ public class CloudProcessDeletedService {
     protected List<CloudRuntimeEvent<?, ?>> buildEvents(ProcessInstance processInstance) {
         CloudProcessDeletedEventImpl event = new CloudProcessDeletedEventImpl(processInstance);
         return List.of(runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(event));
+    }
+
+    protected ProcessInstance buildProcessInstance(String processInstanceId) {
+        CloudProcessInstanceImpl processInstance = new CloudProcessInstanceImpl();
+        processInstance.setId(processInstanceId);
+        return processInstance;
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/DeleteCloudProcessInstanceCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/DeleteCloudProcessInstanceCmd.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.events.services;
+
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
+import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
+import org.activiti.engine.impl.cmd.DeleteProcessInstanceCmd;
+import org.activiti.engine.impl.interceptor.CommandContext;
+
+public class DeleteCloudProcessInstanceCmd extends DeleteProcessInstanceCmd {
+
+    private final ProcessEngineEventsAggregator processEngineEventsAggregator;
+    private final ProcessInstance processInstance;
+
+    public DeleteCloudProcessInstanceCmd(
+        ProcessInstance processInstance,
+        ProcessEngineEventsAggregator processEngineEventsAggregator
+    ) {
+        super(processInstance.getId(), null);
+        this.processInstance = processInstance;
+        this.processEngineEventsAggregator = processEngineEventsAggregator;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        super.execute(commandContext);
+
+        processEngineEventsAggregator.add(new CloudProcessDeletedEventImpl(processInstance));
+
+        return null;
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/SendDeleteCloudProcessInstanceEventCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/SendDeleteCloudProcessInstanceEventCmd.java
@@ -15,31 +15,32 @@
  */
 package org.activiti.cloud.services.events.services;
 
+import org.activiti.cloud.api.process.model.impl.CloudProcessInstanceImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
-import org.activiti.engine.ManagementService;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
 
-public class CloudProcessDeletedService {
+class SendDeleteCloudProcessInstanceEventCmd implements Command<Void> {
 
-    private final ManagementService managementService;
     private final ProcessEngineEventsAggregator processEngineEventsAggregator;
+    private final String processInstanceId;
 
-    public CloudProcessDeletedService(
-        ManagementService managementService,
+    public SendDeleteCloudProcessInstanceEventCmd(
+        String processInstanceId,
         ProcessEngineEventsAggregator processEngineEventsAggregator
     ) {
-        this.managementService = managementService;
+        this.processInstanceId = processInstanceId;
         this.processEngineEventsAggregator = processEngineEventsAggregator;
     }
 
-    public void delete(String processInstanceId) {
-        managementService.executeCommand(
-            new DeleteCloudProcessInstanceCmd(processInstanceId, processEngineEventsAggregator)
-        );
-    }
+    @Override
+    public Void execute(CommandContext commandContext) {
+        CloudProcessInstanceImpl processInstance = new CloudProcessInstanceImpl();
+        processInstance.setId(processInstanceId);
 
-    public void sendDeleteEvent(String processInstanceId) {
-        managementService.executeCommand(
-            new SendDeleteCloudProcessInstanceEventCmd(processInstanceId, processEngineEventsAggregator)
-        );
+        processEngineEventsAggregator.add(new CloudProcessDeletedEventImpl(processInstance));
+
+        return null;
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CloudProcessDeletedServiceTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CloudProcessDeletedServiceTest.java
@@ -15,11 +15,18 @@
  */
 package org.activiti.cloud.services.events.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import org.activiti.api.process.model.payloads.DeleteProcessPayload;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeletedEventImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
@@ -27,6 +34,7 @@ import org.activiti.cloud.services.events.message.RuntimeBundleMessageBuilderFac
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.MessageChannel;
@@ -45,6 +53,9 @@ public class CloudProcessDeletedServiceTest {
     @Mock
     private MessageChannel auditProducer;
 
+    @Mock
+    private ProcessAdminRuntime processAdminRuntime;
+
     @BeforeEach
     public void setUp() {
         RuntimeBundleInfoAppender runtimeBundleInfoAppender = new RuntimeBundleInfoAppender(properties);
@@ -52,7 +63,12 @@ public class CloudProcessDeletedServiceTest {
             properties
         );
         cloudProcessDeletedService =
-            new CloudProcessDeletedService(producer, runtimeBundleMessageBuilderFactory, runtimeBundleInfoAppender);
+            new CloudProcessDeletedService(
+                producer,
+                runtimeBundleMessageBuilderFactory,
+                runtimeBundleInfoAppender,
+                processAdminRuntime
+            );
     }
 
     private void setProperties() {
@@ -69,10 +85,33 @@ public class CloudProcessDeletedServiceTest {
         //given
         setProperties();
 
+        var processInstance = new ProcessInstanceImpl();
+        processInstance.setId("1");
+
+        when(processAdminRuntime.delete(any())).thenReturn(processInstance);
+
         //when
         cloudProcessDeletedService.sendDeleteEvent("1");
 
+        ArgumentCaptor<DeleteProcessPayload> deleteProcessPayloadArgument = ArgumentCaptor.forClass(
+            DeleteProcessPayload.class
+        );
+
         //then
-        verify(auditProducer, times(1)).send(any());
+        verify(processAdminRuntime).delete(deleteProcessPayloadArgument.capture());
+
+        assertThat(deleteProcessPayloadArgument.getValue())
+            .extracting(DeleteProcessPayload::getProcessInstanceId)
+            .isEqualTo("1");
+
+        verify(auditProducer)
+            .send(
+                argThat(arg ->
+                    ((List<CloudRuntimeEvent>) arg.getPayload()).stream()
+                        .filter(CloudProcessDeletedEventImpl.class::isInstance)
+                        .map(CloudProcessDeletedEventImpl.class::cast)
+                        .anyMatch(it -> it.getEntity().equals(processInstance))
+                )
+            );
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceAdminController.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceAdminController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequestMapping(
     value = "/admin/v1/process-instances",
@@ -68,8 +69,13 @@ public interface ProcessInstanceAdminController {
     @RequestMapping(value = "/{processInstanceId}/destroy", method = RequestMethod.DELETE)
     ResponseEntity<Void> destroyProcessInstance(
         @Parameter(
-            description = "Enter the processInstanceId to delete a process instance"
-        ) @PathVariable String processInstanceId
+            description = "Enter the processInstanceId to destroy a process instance"
+        ) @PathVariable String processInstanceId,
+        @Parameter(description = "Enable force delete if the process is still running") @RequestParam(
+            value = "force",
+            required = false,
+            defaultValue = "false"
+        ) boolean force
     );
 
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.PUT)

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -148,11 +148,16 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
     }
 
     @Override
-    public ResponseEntity<Void> destroyProcessInstance(@PathVariable String processInstanceId) {
+    public ResponseEntity<Void> destroyProcessInstance(@PathVariable String processInstanceId, boolean force) {
         try {
             ProcessInstance processInstance = processAdminRuntime.processInstance(processInstanceId);
             if (processInstance != null && !deleteStatuses.contains(processInstance.getStatus())) {
-                throw new IllegalStateException(String.format(DELETE_PROCESS_NOT_ALLOWED, processInstanceId));
+                if (force) {
+                    cloudProcessDeletedService.delete(processInstanceId);
+                    return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+                } else {
+                    throw new IllegalStateException(String.format(DELETE_PROCESS_NOT_ALLOWED, processInstanceId));
+                }
             }
         } catch (NotFoundException e) {
             LOGGER.debug("Process Instance " + processInstanceId + " not found. Sending PROCESS_DELETE event.");

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -154,7 +154,7 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
             if (processInstance != null && !deleteStatuses.contains(processInstance.getStatus())) {
                 if (force) {
                     cloudProcessDeletedService.delete(processInstanceId);
-                    return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+                    return ResponseEntity.status(HttpStatus.OK).build();
                 } else {
                     throw new IllegalStateException(String.format(DELETE_PROCESS_NOT_ALLOWED, processInstanceId));
                 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupAdminControllerImplIT.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -104,6 +105,9 @@ class CandidateGroupAdminControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupAdminControllerImplIT.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
@@ -100,6 +101,9 @@ class CandidateGroupAdminControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupControllerImplIT.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
@@ -100,6 +101,9 @@ class CandidateGroupControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateGroupControllerImplIT.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -104,6 +105,9 @@ class CandidateGroupControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserAdminControllerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserAdminControllerIT.java
@@ -37,6 +37,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -101,6 +102,9 @@ class CandidateUserAdminControllerIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserAdminControllerIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserAdminControllerIT.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
@@ -94,6 +95,9 @@ class CandidateUserAdminControllerIT {
 
     @MockBean
     private RuntimeService runtimeService;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserControllerImplIT.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -104,6 +105,9 @@ class CandidateUserControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/CandidateUserControllerImplIT.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
@@ -100,6 +101,9 @@ class CandidateUserControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
@@ -38,6 +38,7 @@ import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
 import org.activiti.core.common.model.connector.ConnectorDefinition;
 import org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.runtime.api.conf.ConnectorsAutoConfiguration;
@@ -95,6 +96,9 @@ class ConnectorDefinitionControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setup() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.ArrayList;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -91,6 +92,9 @@ class ConnectorDefinitionControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @BeforeEach
     void setup() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -45,6 +45,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
@@ -120,6 +121,9 @@ class ProcessDefinitionAdminControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
@@ -59,6 +59,7 @@ import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
 import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.image.exception.ActivitiInterchangeInfoNotFoundException;
@@ -145,6 +146,9 @@ class ProcessDefinitionControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     private final ObjectMapper om = new ObjectMapper();
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -224,7 +224,7 @@ class ProcessInstanceAdminControllerImplIT {
         when(processAdminRuntime.processInstance("1")).thenReturn(processInstance);
 
         this.mockMvc.perform(delete("/admin/v1/process-instances/{processInstanceId}/destroy?force=true", 1))
-            .andExpect(status().isAccepted());
+            .andExpect(status().isOk());
 
         verify(cloudProcessDeletedService).delete("1");
         verify(cloudProcessDeletedService, never()).sendDeleteEvent("1");

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -19,6 +19,7 @@ import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSample
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -193,6 +194,8 @@ class ProcessInstanceAdminControllerImplIT {
     void destroyProcessInstance() throws Exception {
         this.mockMvc.perform(delete("/admin/v1/process-instances/{processInstanceId}/destroy", 1))
             .andExpect(status().isOk());
+
+        verify(cloudProcessDeletedService).sendDeleteEvent("1");
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -71,6 +71,7 @@ import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
 import org.activiti.core.common.spring.security.policies.ActivitiForbiddenException;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.image.exception.ActivitiInterchangeInfoNotFoundException;
@@ -143,6 +144,9 @@ class ProcessInstanceControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @Test
     void getProcessInstances() throws Exception {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
@@ -41,6 +41,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.runtime.api.query.impl.PageImpl;
@@ -111,6 +112,9 @@ class ProcessInstanceTasksControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableAdminControllerImplIT.java
@@ -47,6 +47,7 @@ import org.activiti.cloud.services.rest.assemblers.ProcessInstanceVariableRepres
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -127,6 +128,9 @@ class ProcessInstanceVariableAdminControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -46,6 +46,7 @@ import org.activiti.cloud.services.rest.assemblers.CollectionModelAssembler;
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.DateFormatterProvider;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.CachingProcessExtensionService;
@@ -126,6 +127,9 @@ class ProcessInstanceVariableControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -49,6 +49,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.runtime.api.query.impl.PageImpl;
@@ -116,6 +117,9 @@ class TaskAdminControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
@@ -112,6 +113,9 @@ class TaskAdminControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -64,6 +64,7 @@ import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.runtime.api.query.impl.PageImpl;
@@ -146,6 +147,9 @@ class TaskControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableAdminControllerImplIT.java
@@ -46,6 +46,7 @@ import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceRepresent
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -116,6 +117,9 @@ class TaskVariableAdminControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ManagementService managementService;
 
     private static final String TASK_ID = UUID.randomUUID().toString();
     private static final String PROCESS_INSTANCE_ID = UUID.randomUUID().toString();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
@@ -46,6 +46,7 @@ import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceRepresent
 import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.rest.config.StreamConfig;
 import org.activiti.common.util.conf.ActivitiCoreCommonUtilAutoConfiguration;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -115,6 +116,9 @@ class TaskVariableControllerImplIT {
 
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+
+    @MockBean
+    private ManagementService managementService;
 
     private static final String TASK_ID = UUID.randomUUID().toString();
     private static final String PROCESS_INSTANCE_ID = UUID.randomUUID().toString();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.UUID;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
@@ -111,6 +112,9 @@ class TaskVariableControllerImplIT {
 
     @MockBean
     private PrincipalIdentityProvider principalIdentityProvider;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
 
     private static final String TASK_ID = UUID.randomUUID().toString();
     private static final String PROCESS_INSTANCE_ID = UUID.randomUUID().toString();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -366,6 +366,24 @@ public class ProcessInstanceRestTemplate {
         return responseEntity;
     }
 
+    public ResponseEntity<CloudProcessInstance> adminDestroy(
+        ResponseEntity<CloudProcessInstance> processInstanceEntity,
+        boolean force
+    ) {
+        assertThat(processInstanceEntity.getBody()).isNotNull();
+        ResponseEntity<CloudProcessInstance> responseEntity = testRestTemplate.exchange(
+            PROCESS_INSTANCES_ADMIN_RELATIVE_URL
+                .concat("/")
+                .concat(processInstanceEntity.getBody().getId())
+                .concat("/destroy?force=" + force),
+            HttpMethod.DELETE,
+            null,
+            new ParameterizedTypeReference<CloudProcessInstance>() {}
+        );
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return responseEntity;
+    }
+
     public ResponseEntity<Void> suspend(ResponseEntity<CloudProcessInstance> processInstanceEntity) {
         assertThat(processInstanceEntity.getBody()).isNotNull();
         return suspend(PROCESS_INSTANCES_RELATIVE_URL, processInstanceEntity.getBody().getId());

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -697,7 +697,8 @@ class ProcessInstanceIT {
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         assertThatExceptionOfType(AssertionError.class)
-            .isThrownBy(() -> processInstanceRestTemplate.getProcessInstance(processEntity));
+            .isThrownBy(() -> processInstanceRestTemplate.getProcessInstance(processEntity))
+            .withMessageContaining("404 NOT_FOUND");
 
         verify(this.processEngineEventsAggregator, atLeast(1)).add(this.cloudRuntimeEventArgumentCaptor.capture());
         assertThat(cloudRuntimeEventArgumentCaptor.getAllValues())

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -15,8 +15,10 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_DELETED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
@@ -34,6 +36,7 @@ import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.converter.util.InputStreamProvider;
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.events.CloudProcessStartedEvent;
@@ -109,6 +112,9 @@ class ProcessInstanceIT {
 
     @Captor
     private ArgumentCaptor<CloudProcessStartedEvent> processStartedEventArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<CloudRuntimeEvent<?, ?>> cloudRuntimeEventArgumentCaptor;
 
     @BeforeEach
     void setUp() {
@@ -664,6 +670,40 @@ class ProcessInstanceIT {
 
         assertThatExceptionOfType(AssertionError.class)
             .isThrownBy(() -> processInstanceRestTemplate.getProcessInstance(processEntity));
+    }
+
+    @Test
+    void adminShouldForceDestroyProcessInstance() {
+        //given
+        ResponseEntity<CloudProcessInstance> processEntity = processInstanceRestTemplate.startProcess(
+            processDefinitionIds.get(SIMPLE_PROCESS),
+            null,
+            "business_key"
+        );
+
+        assertThat(processEntity).isNotNull();
+        assertThat(processEntity.getBody()).isNotNull();
+        assertThat(processEntity.getBody().getId()).isNotNull();
+        assertThat(processEntity.getBody().getProcessDefinitionId()).contains("SimpleProcess:");
+
+        //when
+        identityTokenProducer.withTestUser("testadmin");
+        ResponseEntity<CloudProcessInstance> responseEntity = processInstanceRestTemplate.adminDestroy(
+            processEntity,
+            true
+        );
+
+        //then
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        assertThatExceptionOfType(AssertionError.class)
+            .isThrownBy(() -> processInstanceRestTemplate.getProcessInstance(processEntity));
+
+        verify(this.processEngineEventsAggregator, atLeast(1)).add(this.cloudRuntimeEventArgumentCaptor.capture());
+        assertThat(cloudRuntimeEventArgumentCaptor.getAllValues())
+            .isNotEmpty()
+            .extracting("eventType")
+            .contains(PROCESS_DELETED);
     }
 
     private void assertEventActorIsSet(String processInstanceId) {


### PR DESCRIPTION
The client is chaining two api calls for Process Instance DELETE which cancels the process followed by DESTROY, which sends a PROCESS_DELETED event to Query servicd.

After that, the client is trying to refresh the list of the processes, and if the DESTROY event is lagging, so it will get an intermediate CANCELLED status, but after refreshing the list again, the process will disappear from the Query database.

https://hyland.atlassian.net/browse/AAE-22831

This PR extends the destroy process instance REST api call to actually cancel the process execution in the Runtime in one transaction which will send the delete process instance cloud event to the Query service in one message. 

The extended Runtime Admin API call will support a new `force=true` parameter to be able to destroy the process in one command:

```curl
DELETE /admin/v1/process-instances/{id}/destroy?force=true
```

The existing destroy process api command without `force` parameter will work as before by declining to destroy if the status of the process is not CANCELLED or COMPLETED.
