### PR TITLE
AAE-26198 Fix slow GraphQl query performance due to redundant JPA fetch query with empty keys

### DIFF
--- a/activiti-cloud-notifications-graphql-service/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud Notifications GraphQL Service :: Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <graphql-jpa-query.version>1.2.8</graphql-jpa-query.version>
+    <graphql-jpa-query.version>1.2.10</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Update graphql-jpa-query dependency to version [1.2.10](https://github.com/introproventures/graphql-jpa-query/releases/tag/1.2.10) to fix slow GraphQl query performance