### PR TITLE
AAE-26860 Enforce dependencies for Query Consumer and Rest applications

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
@@ -31,5 +31,34 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.activiti.cloud:activiti-cloud-services-query-rest</exclude>
+                    <exclude>org.activiti.cloud:activiti-cloud-services-audit-rest</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>Query and Audit Rest Api modules should not be used in the Query Consumer application.</message>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/activiti-cloud-examples/activiti-cloud-query/rest/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/pom.xml
@@ -40,4 +40,34 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.activiti.cloud:activiti-cloud-services-query-consumer</exclude>
+                    <exclude>org.activiti.cloud:activiti-cloud-services-audit-consumer</exclude>
+                  </excludes>
+                  <searchTransitive>true</searchTransitive>
+                  <message>Query and Audit event consumer modules should not be used in the Query Rest application.</message>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/AAE-26860

This PR will enforce banned dependencies for Query Rest and Consumer apps:

```
[INFO] --- enforcer:3.0.0:enforce (enforce-banned-dependencies) @ activiti-cloud-query-starter-rest ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Query and Audit event consumer modules should not be used in the Query Rest application.
Found Banned Dependency: org.activiti.cloud:activiti-cloud-services-audit-consumer:jar:8.7.0-SNAPSHOT
Found Banned Dependency: org.activiti.cloud:activiti-cloud-services-query-consumer:jar:8.7.0-SNAPSHOT
Use 'mvn dependency:tree' to locate the source of the banned dependencies.

```