### PR TITLE
AAE-26100 Synchronize process definitions between runtime bundle and query services

### DIFF
--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -34,6 +34,7 @@ import org.activiti.cloud.acc.core.services.query.ProcessQueryService;
 import org.activiti.cloud.acc.shared.service.BaseService;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.hateoas.PagedModel;
@@ -128,8 +129,12 @@ public class ProcessQuerySteps {
                         .stream()
                         .filter(it -> it.getName().equals(variableName))
                         .map(CloudVariableInstance::getValue)
-                        .toList()
+                        .map(value -> value instanceof List<?> listOfValues ? listOfValues : List.of(value))
+                        .findFirst()
                 )
+                    .isNotEmpty()
+                    .get()
+                    .asInstanceOf(InstanceOfAssertFactories.LIST)
                     .containsExactlyInAnyOrderElementsOf(
                         variableValue instanceof List<?> variableValues ? variableValues : List.of(variableValue)
                     );

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -19,11 +19,10 @@ import static org.activiti.cloud.acc.core.assertions.RestErrorAssert.assertThatR
 import static org.activiti.cloud.services.common.util.ImageUtils.svgToPng;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import net.thucydides.core.annotations.Step;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
@@ -113,7 +112,6 @@ public class ProcessQuerySteps {
         Object variableValue
     ) {
         await()
-            .atMost(Duration.ofSeconds(30))
             .untilAsserted(() -> {
                 assertThat(variableName).isNotNull();
                 final Collection<CloudVariableInstance> variableInstances = processQueryService
@@ -122,9 +120,19 @@ public class ProcessQuerySteps {
                 assertThat(variableInstances).isNotNull();
                 assertThat(variableInstances).isNotEmpty();
                 //one of the variables should have name matching variableName and value
-                assertThat(variableInstances)
-                    .extracting(VariableInstance::getName, VariableInstance::getValue)
-                    .contains(tuple(variableName, variableValue));
+
+                assertThat(variableInstances).extracting(VariableInstance::getName).contains(variableName);
+
+                assertThat(
+                    variableInstances
+                        .stream()
+                        .filter(it -> it.getName().equals(variableName))
+                        .map(CloudVariableInstance::getValue)
+                        .toList()
+                )
+                    .containsExactlyInAnyOrderElementsOf(
+                        variableValue instanceof List<?> variableValues ? variableValues : List.of(variableValue)
+                    );
             });
     }
 

--- a/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
+++ b/activiti-cloud-acceptance-tests/activiti-cloud-acceptance-tests-core/src/main/java/org/activiti/cloud/acc/core/steps/query/ProcessQuerySteps.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Duration;
 import java.util.Collection;
 import net.thucydides.core.annotations.Step;
 import org.activiti.api.model.shared.model.VariableInstance;
@@ -112,6 +113,7 @@ public class ProcessQuerySteps {
         Object variableValue
     ) {
         await()
+            .atMost(Duration.ofSeconds(30))
             .untilAsserted(() -> {
                 assertThat(variableName).isNotNull();
                 final Collection<CloudVariableInstance> variableInstances = processQueryService

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsPayload.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsPayload.java
@@ -13,21 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.activiti.cloud.api.process.model.impl;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
+import org.activiti.api.model.shared.Payload;
 
-public class SyncProcessDefinitionRequestImpl implements SyncProcessDefinitionRequest {
+public class SyncCloudProcessDefinitionsPayload implements Payload {
 
     private final String id = UUID.randomUUID().toString();
     private List<String> excludedProcessDefinitionIds;
 
-    public SyncProcessDefinitionRequestImpl() {}
+    public SyncCloudProcessDefinitionsPayload() {}
 
-    public SyncProcessDefinitionRequestImpl(List<String> excludedProcessDefinitionIds) {
+    public SyncCloudProcessDefinitionsPayload(List<String> excludedProcessDefinitionIds) {
         this.excludedProcessDefinitionIds = excludedProcessDefinitionIds;
     }
 
@@ -43,24 +44,15 @@ public class SyncProcessDefinitionRequestImpl implements SyncProcessDefinitionRe
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof SyncProcessDefinitionRequest that)) return false;
+        if (!(o instanceof SyncCloudProcessDefinitionsPayload that)) return false;
         return (
-            Objects.equals(id, that.getId()) &&
-            Objects.equals(excludedProcessDefinitionIds, that.getExcludedProcessDefinitionIds())
+            Objects.equals(id, that.id) &&
+            Objects.equals(excludedProcessDefinitionIds, that.excludedProcessDefinitionIds)
         );
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, excludedProcessDefinitionIds);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuffer sb = new StringBuffer("SyncProcessDefinitionRequest{");
-        sb.append("id='").append(id).append('\'');
-        sb.append(", excludeProcessDefinitionIds=").append(excludedProcessDefinitionIds);
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsPayload.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsPayload.java
@@ -24,21 +24,30 @@ import org.activiti.api.model.shared.Payload;
 public class SyncCloudProcessDefinitionsPayload implements Payload {
 
     private final String id = UUID.randomUUID().toString();
+    private List<String> processDefinitionKeys;
     private List<String> excludedProcessDefinitionIds;
 
     public SyncCloudProcessDefinitionsPayload() {}
-
-    public SyncCloudProcessDefinitionsPayload(List<String> excludedProcessDefinitionIds) {
-        this.excludedProcessDefinitionIds = excludedProcessDefinitionIds;
-    }
 
     @Override
     public String getId() {
         return id;
     }
 
+    public List<String> getProcessDefinitionKeys() {
+        return processDefinitionKeys;
+    }
+
     public List<String> getExcludedProcessDefinitionIds() {
         return excludedProcessDefinitionIds;
+    }
+
+    public void setProcessDefinitionKeys(List<String> processDefinitionKeys) {
+        this.processDefinitionKeys = List.copyOf(processDefinitionKeys);
+    }
+
+    public void setExcludedProcessDefinitionIds(List<String> excludedProcessDefinitionIds) {
+        this.excludedProcessDefinitionIds = List.copyOf(excludedProcessDefinitionIds);
     }
 
     @Override
@@ -47,12 +56,61 @@ public class SyncCloudProcessDefinitionsPayload implements Payload {
         if (!(o instanceof SyncCloudProcessDefinitionsPayload that)) return false;
         return (
             Objects.equals(id, that.id) &&
+            Objects.equals(processDefinitionKeys, that.processDefinitionKeys) &&
             Objects.equals(excludedProcessDefinitionIds, that.excludedProcessDefinitionIds)
         );
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder builder(SyncCloudProcessDefinitionsPayload payload) {
+        return new Builder(payload);
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(id, excludedProcessDefinitionIds);
+        return Objects.hash(id, processDefinitionKeys, excludedProcessDefinitionIds);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("SyncCloudProcessDefinitionsPayload{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", processDefinitionKeys=").append(processDefinitionKeys);
+        sb.append(", excludedProcessDefinitionIds=").append(excludedProcessDefinitionIds);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public static final class Builder {
+
+        private List<String> processDefinitionKeys;
+        private List<String> excludedProcessDefinitionIds;
+
+        public Builder() {}
+
+        public Builder(SyncCloudProcessDefinitionsPayload other) {
+            this.processDefinitionKeys = other.processDefinitionKeys;
+            this.excludedProcessDefinitionIds = other.excludedProcessDefinitionIds;
+        }
+
+        public Builder processDefinitionKeys(List<String> processDefinitionKeys) {
+            this.processDefinitionKeys = List.copyOf(processDefinitionKeys);
+            return this;
+        }
+
+        public Builder excludedProcessDefinitionIds(List<String> excludedProcessDefinitionIds) {
+            this.excludedProcessDefinitionIds = List.copyOf(excludedProcessDefinitionIds);
+            return this;
+        }
+
+        public SyncCloudProcessDefinitionsPayload build() {
+            SyncCloudProcessDefinitionsPayload syncCloudProcessDefinitionsPayload = new SyncCloudProcessDefinitionsPayload();
+            syncCloudProcessDefinitionsPayload.excludedProcessDefinitionIds = this.excludedProcessDefinitionIds;
+            syncCloudProcessDefinitionsPayload.processDefinitionKeys = this.processDefinitionKeys;
+            return syncCloudProcessDefinitionsPayload;
+        }
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsResult.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncCloudProcessDefinitionsResult.java
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.api.process.model;
+package org.activiti.cloud.api.process.model.impl;
 
 import java.util.List;
-import org.activiti.api.model.shared.Payload;
+import org.activiti.api.model.shared.Result;
 
-public interface SyncProcessDefinitionRequest extends Payload {
-    List<String> getExcludedProcessDefinitionIds();
+public class SyncCloudProcessDefinitionsResult extends Result<List<String>> {
+
+    SyncCloudProcessDefinitionsResult() {}
+
+    public SyncCloudProcessDefinitionsResult(SyncCloudProcessDefinitionsPayload payload, List<String> result) {
+        super(payload, result);
+    }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncProcessDefinitionRequestImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/SyncProcessDefinitionRequestImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.api.process.model.impl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
+
+public class SyncProcessDefinitionRequestImpl implements SyncProcessDefinitionRequest {
+
+    private final String id = UUID.randomUUID().toString();
+    private List<String> excludedProcessDefinitionIds;
+
+    public SyncProcessDefinitionRequestImpl() {}
+
+    public SyncProcessDefinitionRequestImpl(List<String> excludedProcessDefinitionIds) {
+        this.excludedProcessDefinitionIds = excludedProcessDefinitionIds;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public List<String> getExcludedProcessDefinitionIds() {
+        return excludedProcessDefinitionIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SyncProcessDefinitionRequest that)) return false;
+        return (
+            Objects.equals(id, that.getId()) &&
+            Objects.equals(excludedProcessDefinitionIds, that.getExcludedProcessDefinitionIds())
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, excludedProcessDefinitionIds);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("SyncProcessDefinitionRequest{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", excludeProcessDefinitionIds=").append(excludedProcessDefinitionIds);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
@@ -50,6 +50,7 @@ import org.activiti.cloud.api.process.model.CloudStartMessageDeploymentDefinitio
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
+import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
 import org.activiti.cloud.api.process.model.impl.CloudApplicationImpl;
 import org.activiti.cloud.api.process.model.impl.CloudBPMNActivityImpl;
 import org.activiti.cloud.api.process.model.impl.CloudIntegrationContextImpl;
@@ -60,6 +61,7 @@ import org.activiti.cloud.api.process.model.impl.CloudStartMessageDeploymentDefi
 import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
+import org.activiti.cloud.api.process.model.impl.SyncProcessDefinitionRequestImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudApplicationDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCompletedEventImpl;
@@ -292,6 +294,7 @@ public class CloudProcessModelAutoConfiguration {
         resolver.addMapping(IntegrationRequest.class, IntegrationRequestImpl.class);
         resolver.addMapping(IntegrationResult.class, IntegrationResultImpl.class);
         resolver.addMapping(IntegrationError.class, IntegrationErrorImpl.class);
+        resolver.addMapping(SyncProcessDefinitionRequest.class, SyncProcessDefinitionRequestImpl.class);
 
         resolver.addMapping(CloudProcessDefinition.class, CloudProcessDefinitionImpl.class);
         resolver.addMapping(

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/conf/CloudProcessModelAutoConfiguration.java
@@ -50,7 +50,6 @@ import org.activiti.cloud.api.process.model.CloudStartMessageDeploymentDefinitio
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
 import org.activiti.cloud.api.process.model.impl.CloudApplicationImpl;
 import org.activiti.cloud.api.process.model.impl.CloudBPMNActivityImpl;
 import org.activiti.cloud.api.process.model.impl.CloudIntegrationContextImpl;
@@ -61,7 +60,8 @@ import org.activiti.cloud.api.process.model.impl.CloudStartMessageDeploymentDefi
 import org.activiti.cloud.api.process.model.impl.IntegrationErrorImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
 import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
-import org.activiti.cloud.api.process.model.impl.SyncProcessDefinitionRequestImpl;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.api.process.model.impl.events.CloudApplicationDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityCompletedEventImpl;
@@ -282,6 +282,20 @@ public class CloudProcessModelAutoConfiguration {
             )
         );
 
+        module.registerSubtypes(
+            new NamedType(
+                SyncCloudProcessDefinitionsPayload.class,
+                SyncCloudProcessDefinitionsPayload.class.getSimpleName()
+            )
+        );
+
+        module.registerSubtypes(
+            new NamedType(
+                SyncCloudProcessDefinitionsResult.class,
+                SyncCloudProcessDefinitionsResult.class.getSimpleName()
+            )
+        );
+
         SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver() {
             //this is a workaround for https://github.com/FasterXML/jackson-databind/issues/2019
             //once version 2.9.6 is related we can remove this @override method
@@ -294,7 +308,6 @@ public class CloudProcessModelAutoConfiguration {
         resolver.addMapping(IntegrationRequest.class, IntegrationRequestImpl.class);
         resolver.addMapping(IntegrationResult.class, IntegrationResultImpl.class);
         resolver.addMapping(IntegrationError.class, IntegrationErrorImpl.class);
-        resolver.addMapping(SyncProcessDefinitionRequest.class, SyncProcessDefinitionRequestImpl.class);
 
         resolver.addMapping(CloudProcessDefinition.class, CloudProcessDefinitionImpl.class);
         resolver.addMapping(

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/SyncProcessDefinitionRequest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/SyncProcessDefinitionRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.api.process.model;
+
+import java.util.List;
+import org.activiti.api.model.shared.Payload;
+
+public interface SyncProcessDefinitionRequest extends Payload {
+    List<String> getExcludedProcessDefinitionIds();
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-runtime-bundle-dependencies/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-runtime-bundle-dependencies/pom.xml
@@ -79,6 +79,11 @@
       </dependency>
       <dependency>
         <groupId>org.activiti.cloud</groupId>
+        <artifactId>activiti-cloud-services-runtime-gateway</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud</groupId>
         <artifactId>activiti-cloud-starter-runtime-bundle</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
@@ -147,7 +147,6 @@
     <dependency>
       <groupId>org.activiti</groupId>
       <artifactId>activiti-api-process-runtime-impl</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.activiti</groupId>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.api.runtime.event.impl.ProcessDeployedEventImpl;
+import org.activiti.api.runtime.event.impl.ProcessDeployedEvents;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.util.StreamUtils;
+
+public class ProcessDefinitionsSyncService {
+
+    private final RepositoryService repositoryService;
+    private final APIProcessDefinitionConverter converter;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public ProcessDefinitionsSyncService(
+        RepositoryService repositoryService,
+        APIProcessDefinitionConverter converter,
+        ApplicationEventPublisher applicationEventPublisher
+    ) {
+        this.repositoryService = repositoryService;
+        this.applicationEventPublisher = applicationEventPublisher;
+        this.converter = converter;
+    }
+
+    @Async
+    public void syncProcessDefinitions(List<String> excludedProcessDefinitionIds) {
+        toProcessDeployedEventList(excludedProcessDefinitionIds)
+            .map(ProcessDeployedEvents::new)
+            .forEach(applicationEventPublisher::publishEvent);
+    }
+
+    private Stream<List<ProcessDeployedEvent>> toProcessDeployedEventList(List<String> excludedProcessDefinitionIds) {
+        final AtomicInteger counter = new AtomicInteger();
+
+        return repositoryService
+            .createProcessDefinitionQuery()
+            .list()
+            .stream()
+            .filter(it -> !excludedProcessDefinitionIds.contains(it.getId()))
+            .collect(Collectors.groupingBy(it -> counter.getAndIncrement() / 10))
+            .values()
+            .stream()
+            .map(converter::from)
+            .map(processDefinitions -> processDefinitions.stream().map(this::toProcessDeployedEvent).toList());
+    }
+
+    private ProcessDeployedEvent toProcessDeployedEvent(ProcessDefinition processDefinition) {
+        try (InputStream inputStream = repositoryService.getProcessModel(processDefinition.getId())) {
+            String xmlModel = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            return new ProcessDeployedEventImpl(processDefinition, xmlModel);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
@@ -53,7 +53,8 @@ public class ProcessDefinitionsSyncService {
     public List<String> syncProcessDefinitions(SyncCloudProcessDefinitionsPayload payload) {
         List<String> excludedProcessDefinitionIds = payload.getExcludedProcessDefinitionIds();
 
-        return toProcessDeployedEventList(excludedProcessDefinitionIds)
+        return queryProcessDefinitionsStream(excludedProcessDefinitionIds)
+            .map(processDefinitions -> processDefinitions.stream().map(this::toProcessDeployedEvent).toList())
             .map(ProcessDeployedEvents::new)
             .peek(applicationEventPublisher::publishEvent)
             .flatMap(it -> it.getProcessDeployedEvents().stream())
@@ -61,7 +62,7 @@ public class ProcessDefinitionsSyncService {
             .toList();
     }
 
-    private Stream<List<ProcessDeployedEvent>> toProcessDeployedEventList(List<String> excludedProcessDefinitionIds) {
+    private Stream<List<ProcessDefinition>> queryProcessDefinitionsStream(List<String> excludedProcessDefinitionIds) {
         final AtomicInteger counter = new AtomicInteger();
 
         return repositoryService
@@ -74,8 +75,7 @@ public class ProcessDefinitionsSyncService {
             .collect(Collectors.groupingBy(it -> counter.getAndIncrement() / 10))
             .values()
             .stream()
-            .map(converter::from)
-            .map(processDefinitions -> processDefinitions.stream().map(this::toProcessDeployedEvent).toList());
+            .map(converter::from);
     }
 
     private ProcessDeployedEvent toProcessDeployedEvent(ProcessDefinition processDefinition) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDefinitionsSyncService.java
@@ -19,9 +19,12 @@ package org.activiti.cloud.services.core;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.activiti.api.process.model.ProcessDefinition;
@@ -52,8 +55,9 @@ public class ProcessDefinitionsSyncService {
 
     public List<String> syncProcessDefinitions(SyncCloudProcessDefinitionsPayload payload) {
         List<String> excludedProcessDefinitionIds = payload.getExcludedProcessDefinitionIds();
+        var processDefinitionKeys = payload.getProcessDefinitionKeys();
 
-        return queryProcessDefinitionsStream(excludedProcessDefinitionIds)
+        return queryProcessDefinitionsStream(processDefinitionKeys, excludedProcessDefinitionIds)
             .map(processDefinitions -> processDefinitions.stream().map(this::toProcessDeployedEvent).toList())
             .map(ProcessDeployedEvents::new)
             .peek(applicationEventPublisher::publishEvent)
@@ -62,11 +66,21 @@ public class ProcessDefinitionsSyncService {
             .toList();
     }
 
-    private Stream<List<ProcessDefinition>> queryProcessDefinitionsStream(List<String> excludedProcessDefinitionIds) {
+    private Stream<List<ProcessDefinition>> queryProcessDefinitionsStream(
+        List<String> processDefinitionKeys,
+        List<String> excludedProcessDefinitionIds
+    ) {
         final AtomicInteger counter = new AtomicInteger();
 
-        return repositoryService
-            .createProcessDefinitionQuery()
+        var query = repositoryService.createProcessDefinitionQuery();
+
+        Optional
+            .ofNullable(processDefinitionKeys)
+            .filter(Predicate.not(Collection::isEmpty))
+            .map(Set::copyOf)
+            .ifPresent(query::processDefinitionKeys);
+
+        return query
             .list()
             .stream()
             .filter(it ->

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutor.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core.commands;
+
+import org.activiti.api.model.shared.EmptyResult;
+import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
+
+public class SyncProcessDefinitionsCmdExecutor extends AbstractCommandExecutor<SyncProcessDefinitionRequest> {
+
+    private final ProcessDefinitionsSyncService processDefinitionsSyncService;
+
+    public SyncProcessDefinitionsCmdExecutor(ProcessDefinitionsSyncService processDefinitionsSyncService) {
+        this.processDefinitionsSyncService = processDefinitionsSyncService;
+    }
+
+    @Override
+    public EmptyResult execute(SyncProcessDefinitionRequest syncProcessDefinitionRequest) {
+        processDefinitionsSyncService.syncProcessDefinitions(
+            syncProcessDefinitionRequest.getExcludedProcessDefinitionIds()
+        );
+
+        return new EmptyResult();
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutor.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutor.java
@@ -15,11 +15,11 @@
  */
 package org.activiti.cloud.services.core.commands;
 
-import org.activiti.api.model.shared.EmptyResult;
-import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 
-public class SyncProcessDefinitionsCmdExecutor extends AbstractCommandExecutor<SyncProcessDefinitionRequest> {
+public class SyncProcessDefinitionsCmdExecutor extends AbstractCommandExecutor<SyncCloudProcessDefinitionsPayload> {
 
     private final ProcessDefinitionsSyncService processDefinitionsSyncService;
 
@@ -28,11 +28,9 @@ public class SyncProcessDefinitionsCmdExecutor extends AbstractCommandExecutor<S
     }
 
     @Override
-    public EmptyResult execute(SyncProcessDefinitionRequest syncProcessDefinitionRequest) {
-        processDefinitionsSyncService.syncProcessDefinitions(
-            syncProcessDefinitionRequest.getExcludedProcessDefinitionIds()
-        );
+    public SyncCloudProcessDefinitionsResult execute(SyncCloudProcessDefinitionsPayload payload) {
+        var result = processDefinitionsSyncService.syncProcessDefinitions(payload);
 
-        return new EmptyResult();
+        return new SyncCloudProcessDefinitionsResult(payload, result);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
 import org.activiti.cloud.services.core.ProcessDefinitionAdminService;
 import org.activiti.cloud.services.core.ProcessDefinitionService;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.ProcessVariableDateConverter;
 import org.activiti.cloud.services.core.ProcessVariableJsonNodeConverter;
@@ -50,6 +51,7 @@ import org.activiti.cloud.services.core.commands.SignalCmdExecutor;
 import org.activiti.cloud.services.core.commands.StartMessageCmdExecutor;
 import org.activiti.cloud.services.core.commands.StartProcessInstanceCmdExecutor;
 import org.activiti.cloud.services.core.commands.SuspendProcessInstanceCmdExecutor;
+import org.activiti.cloud.services.core.commands.SyncProcessDefinitionsCmdExecutor;
 import org.activiti.cloud.services.core.commands.UpdateTaskVariableCmdExecutor;
 import org.activiti.cloud.services.core.decorator.ProcessDefinitionDecorator;
 import org.activiti.cloud.services.core.decorator.ProcessDefinitionVariablesDecorator;
@@ -59,13 +61,16 @@ import org.activiti.cloud.services.core.pageable.sort.ProcessInstanceSortApplier
 import org.activiti.cloud.services.core.pageable.sort.TaskSortApplier;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.common.util.DateFormatterProvider;
+import org.activiti.engine.RepositoryService;
 import org.activiti.image.ProcessDiagramGenerator;
 import org.activiti.image.impl.DefaultProcessDiagramGenerator;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.spring.process.CachingProcessExtensionService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
@@ -167,6 +172,24 @@ public class ServicesCoreAutoConfiguration {
     @ConditionalOnMissingBean
     public DeleteProcessInstanceCmdExecutor deleteProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime) {
         return new DeleteProcessInstanceCmdExecutor(processAdminRuntime);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SyncProcessDefinitionsCmdExecutor syncProcessDefinitionsCmdExecutor(
+        ProcessDefinitionsSyncService processDefinitionsSyncService
+    ) {
+        return new SyncProcessDefinitionsCmdExecutor(processDefinitionsSyncService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionsSyncService processDefinitionsSyncService(
+        RepositoryService repositoryService,
+        APIProcessDefinitionConverter converter,
+        ApplicationEventPublisher applicationEventPublisher
+    ) {
+        return new ProcessDefinitionsSyncService(repositoryService, converter, applicationEventPublisher);
     }
 
     @Bean("commandEndpoint")

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.core.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
+import org.activiti.cloud.api.process.model.impl.SyncProcessDefinitionRequestImpl;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SyncProcessDefinitionsCmdExecutorTest {
+
+    @InjectMocks
+    private SyncProcessDefinitionsCmdExecutor subject;
+
+    @Mock
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
+
+    @Test
+    public void syncProcessDefinitionsCmdExecutorTest() {
+        SyncProcessDefinitionRequest payload = new SyncProcessDefinitionRequestImpl(List.of("1", "2", "3"));
+
+        assertThat(subject.getHandledType()).isEqualTo(SyncProcessDefinitionRequest.class.getName());
+
+        subject.execute(payload);
+
+        verify(processDefinitionsSyncService).syncProcessDefinitions(payload.getExcludedProcessDefinitionIds());
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
@@ -19,8 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
-import org.activiti.cloud.api.process.model.SyncProcessDefinitionRequest;
-import org.activiti.cloud.api.process.model.impl.SyncProcessDefinitionRequestImpl;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
 import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,12 +38,12 @@ public class SyncProcessDefinitionsCmdExecutorTest {
 
     @Test
     public void syncProcessDefinitionsCmdExecutorTest() {
-        SyncProcessDefinitionRequest payload = new SyncProcessDefinitionRequestImpl(List.of("1", "2", "3"));
+        SyncCloudProcessDefinitionsPayload payload = new SyncCloudProcessDefinitionsPayload(List.of("1", "2", "3"));
 
-        assertThat(subject.getHandledType()).isEqualTo(SyncProcessDefinitionRequest.class.getName());
+        assertThat(subject.getHandledType()).isEqualTo(SyncCloudProcessDefinitionsPayload.class.getName());
 
         subject.execute(payload);
 
-        verify(processDefinitionsSyncService).syncProcessDefinitions(payload.getExcludedProcessDefinitionIds());
+        verify(processDefinitionsSyncService).syncProcessDefinitions(payload);
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/commands/SyncProcessDefinitionsCmdExecutorTest.java
@@ -38,7 +38,11 @@ public class SyncProcessDefinitionsCmdExecutorTest {
 
     @Test
     public void syncProcessDefinitionsCmdExecutorTest() {
-        SyncCloudProcessDefinitionsPayload payload = new SyncCloudProcessDefinitionsPayload(List.of("1", "2", "3"));
+        SyncCloudProcessDefinitionsPayload payload = SyncCloudProcessDefinitionsPayload
+            .builder()
+            .processDefinitionKeys(List.of("key1", "key2"))
+            .excludedProcessDefinitionIds(List.of("1", "2", "3"))
+            .build();
 
         assertThat(subject.getHandledType()).isEqualTo(SyncCloudProcessDefinitionsPayload.class.getName());
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -36,6 +36,7 @@ import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
@@ -124,6 +125,9 @@ class ProcessDefinitionAdminControllerImplIT {
 
     @MockBean
     private ManagementService managementService;
+
+    @MockBean
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
@@ -48,6 +48,7 @@ import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.StartEvent;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -149,6 +150,9 @@ class ProcessDefinitionControllerImplIT {
 
     @MockBean
     private ManagementService managementService;
+
+    @MockBean
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
 
     private final ObjectMapper om = new ObjectMapper();
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -45,6 +45,7 @@ import org.activiti.api.runtime.shared.security.PrincipalIdentityProvider;
 import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
@@ -136,6 +137,9 @@ class ProcessInstanceAdminControllerImplIT {
 
     @MockBean
     private ManagementService managementService;
+
+    @MockBean
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -60,6 +60,7 @@ import org.activiti.api.runtime.shared.security.SecurityContextPrincipalProvider
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -147,6 +148,9 @@ class ProcessInstanceControllerImplIT {
 
     @MockBean
     private ManagementService managementService;
+
+    @MockBean
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
 
     @Test
     void getProcessInstances() throws Exception {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -54,6 +54,7 @@ import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.api.task.runtime.TaskRuntime;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.ProcessDefinitionsSyncService;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -150,6 +151,9 @@ class TaskControllerImplIT {
 
     @MockBean
     private ManagementService managementService;
+
+    @MockBean
+    private ProcessDefinitionsSyncService processDefinitionsSyncService;
 
     @BeforeEach
     void setUp() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.activiti.cloud</groupId>
+    <artifactId>activiti-cloud-services-runtime-bundle</artifactId>
+    <version>8.7.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>activiti-cloud-services-runtime-gateway</artifactId>
+  <name>Activiti Cloud Services :: Process Runtime Messaging Gateway</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-integration</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-service-messaging-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-api-process-model-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-api-task-model-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-test-binder</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/ProcessRuntimeGateway.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/ProcessRuntimeGateway.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.gateway;
+
+import org.activiti.api.model.shared.EmptyResult;
+import org.activiti.api.process.model.payloads.DeleteProcessPayload;
+import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
+import org.activiti.api.process.model.payloads.RemoveProcessVariablesPayload;
+import org.activiti.api.process.model.payloads.ResumeProcessPayload;
+import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
+import org.activiti.api.process.model.payloads.SignalPayload;
+import org.activiti.api.process.model.payloads.StartMessagePayload;
+import org.activiti.api.process.model.payloads.StartProcessPayload;
+import org.activiti.api.process.model.payloads.SuspendProcessPayload;
+import org.activiti.api.process.model.results.ProcessInstanceResult;
+import org.activiti.api.task.model.payloads.ClaimTaskPayload;
+import org.activiti.api.task.model.payloads.CompleteTaskPayload;
+import org.activiti.api.task.model.payloads.CreateTaskVariablePayload;
+import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
+import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
+import org.activiti.api.task.model.results.TaskResult;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
+
+public interface ProcessRuntimeGateway {
+    ProcessInstanceResult startProcess(StartProcessPayload startProcessPayload);
+
+    ProcessInstanceResult suspendProcess(SuspendProcessPayload payload);
+
+    ProcessInstanceResult resumeProcessInstance(ResumeProcessPayload payload);
+
+    EmptyResult setProcessVariables(SetProcessVariablesPayload setProcessVariablesPayload);
+
+    EmptyResult deleteProcess(DeleteProcessPayload payload);
+
+    EmptyResult removeProcessVariables(RemoveProcessVariablesPayload payload);
+
+    TaskResult completeTask(CompleteTaskPayload payload);
+
+    TaskResult claimTask(ClaimTaskPayload payload);
+
+    TaskResult releaseTask(ReleaseTaskPayload releaseTaskPayload);
+
+    EmptyResult createTaskVariable(CreateTaskVariablePayload payload);
+
+    EmptyResult updateTaskVariable(UpdateTaskVariablePayload payload);
+
+    ProcessInstanceResult startMessage(StartMessagePayload payload);
+
+    EmptyResult receiveMessage(ReceiveMessagePayload payload);
+
+    EmptyResult sendSignal(SignalPayload payload);
+
+    SyncCloudProcessDefinitionsResult syncProcessDefinitions(SyncCloudProcessDefinitionsPayload payload);
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/ProcessRuntimeGateway.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/ProcessRuntimeGateway.java
@@ -41,7 +41,7 @@ public interface ProcessRuntimeGateway {
 
     ProcessInstanceResult suspendProcess(SuspendProcessPayload payload);
 
-    ProcessInstanceResult resumeProcessInstance(ResumeProcessPayload payload);
+    ProcessInstanceResult resumeProcess(ResumeProcessPayload payload);
 
     EmptyResult setProcessVariables(SetProcessVariablesPayload setProcessVariablesPayload);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/channels/ProcessRuntimeGatewayChannels.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/channels/ProcessRuntimeGatewayChannels.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.gateway.channels;
+
+import org.activiti.cloud.common.messaging.functional.InputBinding;
+import org.activiti.cloud.common.messaging.functional.OutputBinding;
+import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.SubscribableChannel;
+
+public interface ProcessRuntimeGatewayChannels {
+    String PROCESS_RUNTIME_GATEWAY_PRODUCER = "ProcessRuntimeGatewayProducer";
+    String PROCESS_RUNTIME_GATEWAY_RESULTS = "ProcessRuntimeGatewayResults";
+
+    @OutputBinding(PROCESS_RUNTIME_GATEWAY_PRODUCER)
+    default MessageChannel processRuntimeGatewayProducer() {
+        return MessageChannels.direct(PROCESS_RUNTIME_GATEWAY_PRODUCER).getObject();
+    }
+
+    @InputBinding(PROCESS_RUNTIME_GATEWAY_RESULTS)
+    default SubscribableChannel processRuntimeGatewayResults() {
+        return MessageChannels.publishSubscribe(PROCESS_RUNTIME_GATEWAY_RESULTS).getObject();
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/channels/ProcessRuntimeGatewayChannelsConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/channels/ProcessRuntimeGatewayChannelsConfiguration.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.gateway.channels;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ProcessRuntimeGatewayChannelsConfiguration implements ProcessRuntimeGatewayChannels {}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/config/ProcessRuntimeGatewayAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/config/ProcessRuntimeGatewayAutoConfiguration.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.gateway.config;
+
+import static org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels.PROCESS_RUNTIME_GATEWAY_PRODUCER;
+import static org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels.PROCESS_RUNTIME_GATEWAY_RESULTS;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import org.activiti.api.model.shared.Result;
+import org.activiti.cloud.services.gateway.ProcessRuntimeGateway;
+import org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannelsConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import org.springframework.integration.config.IntegrationConverter;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
+import org.springframework.integration.support.channel.HeaderChannelRegistry;
+import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
+import org.springframework.messaging.Message;
+
+@AutoConfiguration
+@EnableConfigurationProperties(ProcessRuntimeGatewayProperties.class)
+@PropertySource("classpath:process-runtime-gateway.properties")
+@Import({ ProcessRuntimeGatewayChannelsConfiguration.class })
+public class ProcessRuntimeGatewayAutoConfiguration {
+
+    public static final String PROCESS_RUNTIME_GATEWAY_BEAN_NAME = "processRuntimeGateway";
+    public static final String PROCESS_RUNTIME_GATEWAY_RESULT_CHANNEL_NAME = "processRuntimeGatewayResultChannelName";
+
+    @Bean
+    IntegrationFlow processRuntimeGatewayProducerFlow(
+        ProcessRuntimeGatewayProperties properties,
+        StreamBridge streamBridge,
+        BindingServiceProperties bindingServiceProperties,
+        HeaderChannelRegistry headerChannelRegistry
+    ) {
+        return IntegrationFlow
+            .from(
+                ProcessRuntimeGateway.class,
+                gatewayProxySpec ->
+                    gatewayProxySpec
+                        .beanName(PROCESS_RUNTIME_GATEWAY_BEAN_NAME)
+                        .replyTimeout(properties.getReplyTimeout().toMillis())
+            )
+            .enrichHeaders(headerEnricherSpec ->
+                headerEnricherSpec
+                    .headerChannelsToString()
+                    .headerFunction(
+                        PROCESS_RUNTIME_GATEWAY_RESULT_CHANNEL_NAME,
+                        message -> headerChannelRegistry.channelToChannelName(message.getHeaders().getReplyChannel())
+                    )
+            )
+            .handle(
+                message ->
+                    streamBridge.send(
+                        bindingServiceProperties.getBindingDestination(PROCESS_RUNTIME_GATEWAY_PRODUCER),
+                        message
+                    ),
+                messageHandlerSpec -> messageHandlerSpec.advice(new RequestHandlerRetryAdvice())
+            )
+            .get();
+    }
+
+    @Bean
+    IntegrationFlow processRuntimeGatewayResultsFlow(HeaderChannelRegistry headerChannelRegistry) {
+        return IntegrationFlow
+            .from(PROCESS_RUNTIME_GATEWAY_RESULTS)
+            .filter(
+                Message.class,
+                message ->
+                    Optional
+                        .ofNullable(message.getHeaders().get(PROCESS_RUNTIME_GATEWAY_RESULT_CHANNEL_NAME, String.class))
+                        .map(headerChannelRegistry::channelNameToChannel)
+                        .isPresent()
+            )
+            .route(Message.class, message -> message.getHeaders().get(PROCESS_RUNTIME_GATEWAY_RESULT_CHANNEL_NAME))
+            .get();
+    }
+
+    @IntegrationConverter
+    @Bean
+    ConditionalGenericConverter processRuntimeGatewayResultConverter(ObjectMapper objectMapper) {
+        final var jackson2JsonObjectMapper = new Jackson2JsonObjectMapper(objectMapper);
+
+        return new ConditionalGenericConverter() {
+            @Override
+            public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+                return (
+                    Result.class.isAssignableFrom(targetType.getObjectType()) && sourceType.getType() == byte[].class
+                );
+            }
+
+            @Override
+            public Set<ConvertiblePair> getConvertibleTypes() {
+                return null;
+            }
+
+            @Override
+            public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+                try {
+                    return jackson2JsonObjectMapper.fromJson(source, targetType.getType());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/config/ProcessRuntimeGatewayProperties.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/java/org/activiti/cloud/services/gateway/config/ProcessRuntimeGatewayProperties.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.gateway.config;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("activiti.cloud.process-runtime-gateway")
+public class ProcessRuntimeGatewayProperties {
+
+    private boolean enabled;
+
+    @NotEmpty
+    private String group;
+
+    @NotNull
+    private Duration replyTimeout = Duration.ofSeconds(30);
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public @NotEmpty String getGroup() {
+        return group;
+    }
+
+    public void setGroup(@NotEmpty String group) {
+        this.group = group;
+    }
+
+    public @NotNull Duration getReplyTimeout() {
+        return replyTimeout;
+    }
+
+    public void setReplyTimeout(@NotNull Duration replyTimeout) {
+        this.replyTimeout = replyTimeout;
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.activiti.cloud.services.gateway.config.ProcessRuntimeGatewayAutoConfiguration

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/resources/process-runtime-gateway.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/main/resources/process-runtime-gateway.properties
@@ -1,0 +1,11 @@
+activiti.cloud.process-runtime-gateway.enabled=true
+activiti.cloud.process-runtime-gateway.group=${spring.application.name}
+
+# process runtime gateway command producer bindings
+spring.cloud.stream.bindings.ProcessRuntimeGatewayProducer.destination=commandConsumer
+spring.cloud.stream.bindings.ProcessRuntimeGatewayProducer.contentType=application/json
+
+# process runtime gateway command results bindings
+spring.cloud.stream.bindings.ProcessRuntimeGatewayResults.destination=commandResults
+spring.cloud.stream.bindings.ProcessRuntimeGatewayResults.group=${activiti.cloud.process-runtime-gateway.group}
+spring.cloud.stream.bindings.ProcessRuntimeGatewayResults.contentType=application/json

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/java/org/activiti/cloud/services/gateway/ProcessRuntimeGatewayTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/java/org/activiti/cloud/services/gateway/ProcessRuntimeGatewayTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.gateway;
+
+import static org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels.PROCESS_RUNTIME_GATEWAY_PRODUCER;
+import static org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels.PROCESS_RUNTIME_GATEWAY_RESULTS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
+import org.activiti.cloud.common.messaging.functional.FunctionBinding;
+import org.activiti.cloud.common.messaging.functional.InputBinding;
+import org.activiti.cloud.common.messaging.functional.OutputBinding;
+import org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels;
+import org.activiti.cloud.services.gateway.config.ProcessRuntimeGatewayProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.SubscribableChannel;
+
+@SpringBootTest(
+    properties = {
+        "spring.cloud.stream.bindings.commandConsumer.destination=commandConsumer",
+        "spring.cloud.stream.bindings.commandConsumer.contentType=application/json",
+        "spring.cloud.stream.bindings.commandConsumer.group=${spring.application.name}",
+        "spring.cloud.stream.bindings.commandResults.destination=commandResults",
+        "spring.cloud.stream.bindings.commandResults.contentType=application/json",
+    }
+)
+@EnableTestBinder
+public class ProcessRuntimeGatewayTest {
+
+    @SpringBootApplication
+    @EnableTestBinder
+    static class TestApplication {
+
+        final String COMMAND_CONSUMER = "commandConsumer";
+        final String COMMAND_RESULTS = "commandResults";
+
+        @InputBinding(COMMAND_CONSUMER)
+        MessageChannel commandConsumer() {
+            return MessageChannels.publishSubscribe(COMMAND_CONSUMER).getObject();
+        }
+
+        @OutputBinding(COMMAND_RESULTS)
+        SubscribableChannel commandResults() {
+            return MessageChannels.direct(COMMAND_RESULTS).getObject();
+        }
+
+        @FunctionBinding(input = COMMAND_CONSUMER, output = COMMAND_RESULTS)
+        @Bean
+        Function<SyncCloudProcessDefinitionsPayload, SyncCloudProcessDefinitionsResult> testCommandExecutor() {
+            return payload -> {
+                var processDefinitionsIds = payload.getExcludedProcessDefinitionIds();
+
+                return new SyncCloudProcessDefinitionsResult(payload, processDefinitionsIds);
+            };
+        }
+    }
+
+    @Autowired
+    private ProcessRuntimeGateway processRuntimeGateway;
+
+    @Autowired
+    private ProcessRuntimeGatewayChannels processRuntimeGatewayChannels;
+
+    @Autowired
+    private ProcessRuntimeGatewayProperties processRuntimeGatewayProperties;
+
+    @Autowired
+    private BindingServiceProperties bindingServiceProperties;
+
+    @Test
+    void contextLoads() {
+        assertThat(processRuntimeGatewayProperties.getReplyTimeout()).isEqualTo(Duration.ofSeconds(30));
+
+        assertThat(processRuntimeGatewayProperties.getGroup()).isEqualTo("query");
+        assertThat(bindingServiceProperties.getGroup(PROCESS_RUNTIME_GATEWAY_RESULTS)).isEqualTo("query");
+
+        assertThat(bindingServiceProperties.getBindingDestination(PROCESS_RUNTIME_GATEWAY_PRODUCER))
+            .isEqualTo("commandConsumer_my-app");
+        assertThat(bindingServiceProperties.getBindingDestination(PROCESS_RUNTIME_GATEWAY_RESULTS))
+            .isEqualTo("commandResults_my-app");
+    }
+
+    @Test
+    void processRuntimeGatewayTest() {
+        // given
+        var excludedProcessDefinitionIds = List.of("foo", "bar");
+
+        // when
+        var result = processRuntimeGateway.syncProcessDefinitions(
+            new SyncCloudProcessDefinitionsPayload(excludedProcessDefinitionIds)
+        );
+
+        // then
+        assertThat(result)
+            .isNotNull()
+            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
+            .isEqualTo(excludedProcessDefinitionIds);
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/java/org/activiti/cloud/services/gateway/ProcessRuntimeGatewayTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/java/org/activiti/cloud/services/gateway/ProcessRuntimeGatewayTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -30,6 +32,7 @@ import org.activiti.cloud.common.messaging.functional.InputBinding;
 import org.activiti.cloud.common.messaging.functional.OutputBinding;
 import org.activiti.cloud.services.gateway.channels.ProcessRuntimeGatewayChannels;
 import org.activiti.cloud.services.gateway.config.ProcessRuntimeGatewayProperties;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -74,9 +77,13 @@ public class ProcessRuntimeGatewayTest {
         @Bean
         Function<SyncCloudProcessDefinitionsPayload, SyncCloudProcessDefinitionsResult> testCommandExecutor() {
             return payload -> {
-                var processDefinitionsIds = payload.getExcludedProcessDefinitionIds();
+                var result = Stream
+                    .of("foo:1", "foo:2", "bar:1", "bar:2", "baz")
+                    .filter(it -> payload.getProcessDefinitionKeys().stream().anyMatch(it::startsWith))
+                    .filter(Predicate.not(payload.getExcludedProcessDefinitionIds()::contains))
+                    .toList();
 
-                return new SyncCloudProcessDefinitionsResult(payload, processDefinitionsIds);
+                return new SyncCloudProcessDefinitionsResult(payload, result);
             };
         }
     }
@@ -109,17 +116,23 @@ public class ProcessRuntimeGatewayTest {
     @Test
     void processRuntimeGatewayTest() {
         // given
-        var excludedProcessDefinitionIds = List.of("foo", "bar");
+        var processDefinitionKeys = List.of("foo", "bar", "baz");
+        var excludedProcessDefinitionIds = List.of("foo:1", "bar:1");
 
         // when
         var result = processRuntimeGateway.syncProcessDefinitions(
-            new SyncCloudProcessDefinitionsPayload(excludedProcessDefinitionIds)
+            SyncCloudProcessDefinitionsPayload
+                .builder()
+                .processDefinitionKeys(processDefinitionKeys)
+                .excludedProcessDefinitionIds(excludedProcessDefinitionIds)
+                .build()
         );
 
         // then
         assertThat(result)
             .isNotNull()
             .extracting(SyncCloudProcessDefinitionsResult::getEntity)
-            .isEqualTo(excludedProcessDefinitionIds);
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .containsOnly("foo:2", "bar:2", "baz");
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/resources/application.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-runtime-gateway/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.application.name=query
+
+activiti.cloud.application.name=my-app

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/pom.xml
@@ -23,5 +23,6 @@
     <module>activiti-cloud-services-job-executor</module>
     <module>messages-events</module>
     <module>activiti-cloud-runtime-bundle-rest-client</module>
+    <module>activiti-cloud-services-runtime-gateway</module>
   </modules>
 </project>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -207,6 +207,11 @@
       <artifactId>activiti-cloud-services-test-containers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-runtime-gateway</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.starter.tests.cmdendpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.activiti.api.model.shared.Result;
 import org.activiti.api.process.model.ProcessInstance;
@@ -32,6 +33,7 @@ import org.activiti.api.task.model.payloads.CompleteTaskPayload;
 import org.activiti.api.task.model.payloads.CreateTaskVariablePayload;
 import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
 import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -58,6 +60,7 @@ public class CommandEndPointITStreamHandler {
     private AtomicBoolean removeProcessVariablesAck = new AtomicBoolean(false);
     private AtomicBoolean createTaskVariableAck = new AtomicBoolean(false);
     private AtomicBoolean updateTaskVariableAck = new AtomicBoolean(false);
+    private AtomicReference<SyncCloudProcessDefinitionsResult> syncProcessDefinitionsAck = new AtomicReference<>();
 
     @TestConfiguration
     class CommandEndpointITStreamHandlerConfiguration {
@@ -93,6 +96,8 @@ public class CommandEndPointITStreamHandler {
                     setProcessVariablesAck.set(true);
                 } else if (result.getPayload() instanceof RemoveProcessVariablesPayload) {
                     removeProcessVariablesAck.set(true);
+                } else if (result instanceof SyncCloudProcessDefinitionsResult syncCloudProcessDefinitionsResult) {
+                    syncProcessDefinitionsAck.set(syncCloudProcessDefinitionsResult);
                 }
             };
         }
@@ -122,6 +127,10 @@ public class CommandEndPointITStreamHandler {
         claimedTaskAck.set(false);
     }
 
+    public void resetSyncProcessDefinitionsAck() {
+        syncProcessDefinitionsAck.set(null);
+    }
+
     public AtomicBoolean getReleasedTaskAck() {
         return releasedTaskAck;
     }
@@ -148,5 +157,9 @@ public class CommandEndPointITStreamHandler {
 
     public AtomicBoolean getRemoveProcessVariablesAck() {
         return removeProcessVariablesAck;
+    }
+
+    public AtomicReference<SyncCloudProcessDefinitionsResult> getSyncProcessDefinitionsAck() {
+        return syncProcessDefinitionsAck;
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -24,6 +24,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
@@ -216,6 +217,30 @@ public class CommandEndpointIT {
             .extracting(SyncCloudProcessDefinitionsResult::getEntity)
             .asInstanceOf(InstanceOfAssertFactories.LIST)
             .contains(processDefinitionIds.values().toArray());
+    }
+
+    @Test
+    public void syncCloudProcessDefinitionsExcludedTest() {
+        streamHandler.resetSyncProcessDefinitionsAck();
+
+        var payload = new SyncCloudProcessDefinitionsPayload(
+            List.of(processDefinitionIds.values().toArray(String[]::new))
+        );
+
+        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).setHeader("cmdId", "jobId").build());
+
+        await("process definitions result to be synced")
+            .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
+
+        var result = streamHandler.getSyncProcessDefinitionsAck().get();
+
+        assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
+
+        assertThat(result)
+            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .isNotEmpty()
+            .doesNotContain(processDefinitionIds.values().toArray());
     }
 
     private void completeTask(Task task) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -42,11 +42,14 @@ import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -192,6 +195,27 @@ public class CommandEndpointIT {
         assertThat(streamHandler.getClaimedTaskAck()).isTrue();
         assertThat(streamHandler.getReleasedTaskAck()).isTrue();
         assertThat(streamHandler.getCompletedTaskAck()).isTrue();
+    }
+
+    @Test
+    public void syncCloudProcessDefinitionsTest() {
+        streamHandler.resetSyncProcessDefinitionsAck();
+
+        var payload = new SyncCloudProcessDefinitionsPayload();
+
+        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).setHeader("cmdId", "jobId").build());
+
+        await("process definitions result to be synced")
+            .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
+
+        var result = streamHandler.getSyncProcessDefinitionsAck().get();
+
+        assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
+
+        assertThat(result)
+            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .contains(processDefinitionIds.values().toArray());
     }
 
     private void completeTask(Task task) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -49,7 +49,6 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.api.task.model.CloudTask;
-import org.activiti.cloud.services.gateway.ProcessRuntimeGateway;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
@@ -107,9 +106,6 @@ public class CommandEndpointIT {
 
     @Autowired
     private CommandEndPointITStreamHandler streamHandler;
-
-    @Autowired
-    private ProcessRuntimeGateway processRuntimeGateway;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();
 
@@ -223,15 +219,9 @@ public class CommandEndpointIT {
     public void syncCloudProcessDefinitionsTest() {
         streamHandler.resetSyncProcessDefinitionsAck();
         processDeployedEvents.clear();
-
         var payload = new SyncCloudProcessDefinitionsPayload();
 
-        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).setHeader("cmdId", "jobId").build());
-
-        await("process definitions result to be synced")
-            .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
-
-        var result = streamHandler.getSyncProcessDefinitionsAck().get();
+        var result = doSyncCloudProcessDefinitions(payload);
 
         assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
 
@@ -252,32 +242,15 @@ public class CommandEndpointIT {
             .contains(processDefinitionIds.values().toArray(String[]::new));
     }
 
-    @Test
-    public void syncCloudProcessDefinitionsRuntimeGatewayTest() {
-        streamHandler.resetSyncProcessDefinitionsAck();
-        processDeployedEvents.clear();
+    protected SyncCloudProcessDefinitionsResult doSyncCloudProcessDefinitions(
+        SyncCloudProcessDefinitionsPayload payload
+    ) {
+        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).setHeader("cmdId", "jobId").build());
 
-        var payload = new SyncCloudProcessDefinitionsPayload();
+        await("process definitions result to be synced")
+            .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
 
-        var result = processRuntimeGateway.syncProcessDefinitions(payload);
-
-        assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
-
-        assertThat(result)
-            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
-            .asInstanceOf(InstanceOfAssertFactories.LIST)
-            .contains(processDefinitionIds.values().toArray());
-
-        assertThat(processDeployedEvents).isNotEmpty();
-
-        assertThat(
-            processDeployedEvents
-                .stream()
-                .flatMap(it -> it.getProcessDeployedEvents().stream())
-                .map(ProcessDeployedEvent::getProcessDefinitionId)
-                .toList()
-        )
-            .contains(processDefinitionIds.values().toArray(String[]::new));
+        return streamHandler.getSyncProcessDefinitionsAck().get();
     }
 
     @Test
@@ -288,12 +261,7 @@ public class CommandEndpointIT {
             List.of(processDefinitionIds.values().toArray(String[]::new))
         );
 
-        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).setHeader("cmdId", "jobId").build());
-
-        await("process definitions result to be synced")
-            .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
-
-        var result = streamHandler.getSyncProcessDefinitionsAck().get();
+        var result = doSyncCloudProcessDefinitions(payload);
 
         assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
 
@@ -312,20 +280,32 @@ public class CommandEndpointIT {
             .withTaskId(task.getId())
             .withVariables(variables)
             .build();
+
+        doCompleteTask(completeTaskCmd);
+    }
+
+    protected void doCompleteTask(CompleteTaskPayload payload) {
         clientStream
             .myCmdProducer()
-            .send(MessageBuilder.withPayload(completeTaskCmd).setHeader("cmdId", completeTaskCmd.getId()).build());
+            .send(MessageBuilder.withPayload(payload).setHeader("cmdId", payload.getId()).build());
+
         await("task to be completed").untilTrue(streamHandler.getCompletedTaskAck());
     }
 
     private void releaseTask(Task task) {
         ReleaseTaskPayload releaseTaskCmd = TaskPayloadBuilder.release().withTaskId(task.getId()).build();
-        clientStream
-            .myCmdProducer()
-            .send(MessageBuilder.withPayload(releaseTaskCmd).setHeader("cmdId", releaseTaskCmd.getId()).build());
-        await("task to be released").untilTrue(streamHandler.getReleasedTaskAck());
+
+        doReleaseTask(releaseTaskCmd);
 
         assertThatTaskHasStatus(task.getId(), CREATED);
+    }
+
+    protected void doReleaseTask(ReleaseTaskPayload payload) {
+        clientStream
+            .myCmdProducer()
+            .send(MessageBuilder.withPayload(payload).setHeader("cmdId", payload.getId()).build());
+
+        await("task to be released").untilTrue(streamHandler.getReleasedTaskAck());
     }
 
     private void setProcessVariables(String proInstanceId) {
@@ -336,13 +316,7 @@ public class CommandEndpointIT {
             .withVariables(variables)
             .build();
 
-        clientStream
-            .myCmdProducer()
-            .send(
-                MessageBuilder.withPayload(setProcessVariables).setHeader("cmdId", setProcessVariables.getId()).build()
-            );
-
-        await("Variable to be set").untilTrue(streamHandler.getSetProcessVariablesAck());
+        doSetProcessVariables(setProcessVariables);
 
         ResponseEntity<CollectionModel<CloudVariableInstance>> retrievedVars = processInstanceRestTemplate.getVariables(
             proInstanceId
@@ -352,6 +326,14 @@ public class CommandEndpointIT {
             .contains(tuple("procVar", "v2"));
     }
 
+    protected void doSetProcessVariables(SetProcessVariablesPayload payload) {
+        clientStream
+            .myCmdProducer()
+            .send(MessageBuilder.withPayload(payload).setHeader("cmdId", payload.getId()).build());
+
+        await("Variable to be set").untilTrue(streamHandler.getSetProcessVariablesAck());
+    }
+
     private void claimTask(Task task) {
         streamHandler.resetClaimedTaskAck();
         ClaimTaskPayload claimTaskPayload = TaskPayloadBuilder
@@ -359,13 +341,18 @@ public class CommandEndpointIT {
             .withTaskId(task.getId())
             .withAssignee("hruser")
             .build();
+
+        doClaimTask(claimTaskPayload);
+
+        assertThatTaskHasStatus(task.getId(), ASSIGNED);
+    }
+
+    protected void doClaimTask(ClaimTaskPayload claimTaskPayload) {
         clientStream
             .myCmdProducer()
             .send(MessageBuilder.withPayload(claimTaskPayload).setHeader("cmdId", claimTaskPayload.getId()).build());
 
         await("task to be claimed").untilTrue(streamHandler.getClaimedTaskAck());
-
-        assertThatTaskHasStatus(task.getId(), ASSIGNED);
     }
 
     private void assertThatTaskHasStatus(String taskId, Task.TaskStatus status) {
@@ -377,11 +364,8 @@ public class CommandEndpointIT {
     private void resumeProcessInstance(String processDefinitionId, String processInstanceId) {
         //given
         ResumeProcessPayload resumeProcess = ProcessPayloadBuilder.resume(processInstanceId);
-        clientStream
-            .myCmdProducer()
-            .send(MessageBuilder.withPayload(resumeProcess).setHeader("cmdId", resumeProcess.getId()).build());
 
-        await("process to be resumed").untilTrue(streamHandler.getResumedProcessInstanceAck());
+        doResumeProcessInstance(resumeProcess);
 
         await()
             .untilAsserted(() -> {
@@ -397,12 +381,18 @@ public class CommandEndpointIT {
             });
     }
 
+    protected void doResumeProcessInstance(ResumeProcessPayload resumeProcess) {
+        clientStream
+            .myCmdProducer()
+            .send(MessageBuilder.withPayload(resumeProcess).setHeader("cmdId", resumeProcess.getId()).build());
+
+        await("process to be resumed").untilTrue(streamHandler.getResumedProcessInstanceAck());
+    }
+
     private void suspendProcessInstance(SuspendProcessPayload suspendProcessInstanceCmd) {
         //given
+        doSuspendProcessInstance(suspendProcessInstanceCmd);
 
-        clientStream.myCmdProducer().send(MessageBuilder.withPayload(suspendProcessInstanceCmd).build());
-
-        await("process to be suspended").untilTrue(streamHandler.getSuspendedProcessInstanceAck());
         //when
         ProcessInstance processInstance = executeGetProcessInstanceRequest(
             suspendProcessInstanceCmd.getProcessInstanceId()
@@ -414,12 +404,15 @@ public class CommandEndpointIT {
         assertThat(processInstance.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.SUSPENDED);
     }
 
+    protected void doSuspendProcessInstance(SuspendProcessPayload payload) {
+        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).build());
+
+        await("process to be suspended").untilTrue(streamHandler.getSuspendedProcessInstanceAck());
+    }
+
     private String startProcessInstance(StartProcessPayload startProcessPayload) {
         //given
-        clientStream.myCmdProducer().send(MessageBuilder.withPayload(startProcessPayload).build());
-
-        await("process to be started").untilTrue(streamHandler.getStartedProcessInstanceAck());
-        String processInstanceId = streamHandler.getProcessInstanceId();
+        var processInstanceId = doStartProcessInstance(startProcessPayload);
 
         //when
         ProcessInstance processInstance = executeGetProcessInstanceRequest(processInstanceId);
@@ -430,6 +423,14 @@ public class CommandEndpointIT {
         assertThat(processInstance.getStartDate()).isNotNull();
         assertThat(processInstance.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.RUNNING);
         return processInstance.getId();
+    }
+
+    protected String doStartProcessInstance(StartProcessPayload payload) {
+        clientStream.myCmdProducer().send(MessageBuilder.withPayload(payload).build());
+
+        await("process to be started").untilTrue(streamHandler.getStartedProcessInstanceAck());
+
+        return streamHandler.getProcessInstanceId();
     }
 
     private ProcessInstance executeGetProcessInstanceRequest(String processInstanceId) {
@@ -478,14 +479,19 @@ public class CommandEndpointIT {
         );
         SignalPayload sendSignal = ProcessPayloadBuilder.signal().withName("go").build();
 
+        doSendSignal(sendSignal);
+
+        ResponseEntity<PagedModel<CloudTask>> taskEntity = processInstanceRestTemplate.getTasks(startProcessEntity);
+        assertThat(taskEntity.getBody().getContent()).extracting(Task::getName).containsExactly("Boundary target");
+    }
+
+    protected void doSendSignal(SignalPayload sendSignal) {
         //when
         clientStream
             .myCmdProducer()
             .send(MessageBuilder.withPayload(sendSignal).setHeader("cmdId", sendSignal.getId()).build());
+
         //then
         await("signal to be sent").untilTrue(streamHandler.getSendSignalAck());
-
-        ResponseEntity<PagedModel<CloudTask>> taskEntity = processInstanceRestTemplate.getTasks(startProcessEntity);
-        assertThat(taskEntity.getBody().getContent()).extracting(Task::getName).containsExactly("Boundary target");
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -107,9 +107,11 @@ public class CommandEndpointIT {
     @Autowired
     private CommandEndPointITStreamHandler streamHandler;
 
-    private Map<String, String> processDefinitionIds = new HashMap<>();
+    private final Map<String, String> processDefinitionIds = new HashMap<>();
 
-    private static List<ProcessDeployedEvents> processDeployedEvents = new ArrayList<>();
+    private final Map<String, String> processDefinitionKeys = new HashMap<>();
+
+    private static final List<ProcessDeployedEvents> processDeployedEvents = new ArrayList<>();
 
     @TestComponent
     static class TestProcessDeployedEventsListener {
@@ -140,6 +142,7 @@ public class CommandEndpointIT {
 
         for (ProcessDefinition pd : processDefinitions.getBody().getContent()) {
             processDefinitionIds.put(pd.getName(), pd.getId());
+            processDefinitionKeys.put(pd.getKey(), pd.getId());
         }
     }
 
@@ -271,6 +274,28 @@ public class CommandEndpointIT {
             .asInstanceOf(InstanceOfAssertFactories.LIST)
             .isNotEmpty()
             .doesNotContain(processDefinitionIds.values().toArray());
+    }
+
+    @Test
+    public void syncCloudProcessDefinitionsKeysTest() {
+        final var testProcessDefinitionKey = "SimpleProcess";
+        streamHandler.resetSyncProcessDefinitionsAck();
+
+        var payload = SyncCloudProcessDefinitionsPayload
+            .builder()
+            .processDefinitionKeys(List.of(testProcessDefinitionKey))
+            .excludedProcessDefinitionIds(List.of("foo", "bar"))
+            .build();
+
+        var result = doSyncCloudProcessDefinitions(payload);
+
+        assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
+
+        assertThat(result)
+            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .isNotEmpty()
+            .containsOnly(processDefinitionKeys.get(testProcessDefinitionKey));
     }
 
     private void completeTask(Task task) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,11 +31,13 @@ import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
 import org.activiti.api.process.model.payloads.ResumeProcessPayload;
 import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.SuspendProcessPayload;
+import org.activiti.api.runtime.event.impl.ProcessDeployedEvents;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.model.payloads.ClaimTaskPayload;
@@ -56,9 +59,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
@@ -81,6 +86,7 @@ import org.springframework.test.context.TestPropertySource;
         TaskRestTemplate.class,
         MessageClientStreamConfiguration.class,
         TestChannelBinderConfiguration.class,
+        CommandEndpointIT.TestProcessDeployedEventsListener.class,
     }
 )
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
@@ -106,6 +112,17 @@ public class CommandEndpointIT {
     private ProcessRuntimeGateway processRuntimeGateway;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();
+
+    private static List<ProcessDeployedEvents> processDeployedEvents = new ArrayList<>();
+
+    @TestComponent
+    static class TestProcessDeployedEventsListener {
+
+        @EventListener
+        void on(ProcessDeployedEvents event) {
+            processDeployedEvents.add(event);
+        }
+    }
 
     private static final String PROCESS_DEFINITIONS_URL = "/v1/process-definitions";
     private static final String PROCESS_INSTANCES_RELATIVE_URL = "/v1/process-instances";
@@ -205,6 +222,7 @@ public class CommandEndpointIT {
     @Test
     public void syncCloudProcessDefinitionsTest() {
         streamHandler.resetSyncProcessDefinitionsAck();
+        processDeployedEvents.clear();
 
         var payload = new SyncCloudProcessDefinitionsPayload();
 
@@ -221,11 +239,23 @@ public class CommandEndpointIT {
             .extracting(SyncCloudProcessDefinitionsResult::getEntity)
             .asInstanceOf(InstanceOfAssertFactories.LIST)
             .contains(processDefinitionIds.values().toArray());
+
+        assertThat(processDeployedEvents).isNotEmpty();
+
+        assertThat(
+            processDeployedEvents
+                .stream()
+                .flatMap(it -> it.getProcessDeployedEvents().stream())
+                .map(ProcessDeployedEvent::getProcessDefinitionId)
+                .toList()
+        )
+            .contains(processDefinitionIds.values().toArray(String[]::new));
     }
 
     @Test
     public void syncCloudProcessDefinitionsRuntimeGatewayTest() {
         streamHandler.resetSyncProcessDefinitionsAck();
+        processDeployedEvents.clear();
 
         var payload = new SyncCloudProcessDefinitionsPayload();
 
@@ -237,6 +267,17 @@ public class CommandEndpointIT {
             .extracting(SyncCloudProcessDefinitionsResult::getEntity)
             .asInstanceOf(InstanceOfAssertFactories.LIST)
             .contains(processDefinitionIds.values().toArray());
+
+        assertThat(processDeployedEvents).isNotEmpty();
+
+        assertThat(
+            processDeployedEvents
+                .stream()
+                .flatMap(it -> it.getProcessDeployedEvents().stream())
+                .map(ProcessDeployedEvent::getProcessDefinitionId)
+                .toList()
+        )
+            .contains(processDefinitionIds.values().toArray(String[]::new));
     }
 
     @Test

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -46,6 +46,7 @@ import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
 import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
 import org.activiti.cloud.api.task.model.CloudTask;
+import org.activiti.cloud.services.gateway.ProcessRuntimeGateway;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
@@ -100,6 +101,9 @@ public class CommandEndpointIT {
 
     @Autowired
     private CommandEndPointITStreamHandler streamHandler;
+
+    @Autowired
+    private ProcessRuntimeGateway processRuntimeGateway;
 
     private Map<String, String> processDefinitionIds = new HashMap<>();
 
@@ -210,6 +214,22 @@ public class CommandEndpointIT {
             .untilAsserted(() -> assertThat(streamHandler.getSyncProcessDefinitionsAck()).isNotNull());
 
         var result = streamHandler.getSyncProcessDefinitionsAck().get();
+
+        assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
+
+        assertThat(result)
+            .extracting(SyncCloudProcessDefinitionsResult::getEntity)
+            .asInstanceOf(InstanceOfAssertFactories.LIST)
+            .contains(processDefinitionIds.values().toArray());
+    }
+
+    @Test
+    public void syncCloudProcessDefinitionsRuntimeGatewayTest() {
+        streamHandler.resetSyncProcessDefinitionsAck();
+
+        var payload = new SyncCloudProcessDefinitionsPayload();
+
+        var result = processRuntimeGateway.syncProcessDefinitions(payload);
 
         assertThat(result).extracting(SyncCloudProcessDefinitionsResult::getPayload).isEqualTo(payload);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -257,9 +257,10 @@ public class CommandEndpointIT {
     public void syncCloudProcessDefinitionsExcludedTest() {
         streamHandler.resetSyncProcessDefinitionsAck();
 
-        var payload = new SyncCloudProcessDefinitionsPayload(
-            List.of(processDefinitionIds.values().toArray(String[]::new))
-        );
+        var payload = SyncCloudProcessDefinitionsPayload
+            .builder()
+            .excludedProcessDefinitionIds(List.of(processDefinitionIds.values().toArray(String[]::new)))
+            .build();
 
         var result = doSyncCloudProcessDefinitions(payload);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/ProcessRuntimeGatewayIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/ProcessRuntimeGatewayIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starter.tests.cmdendpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.api.process.model.payloads.ResumeProcessPayload;
+import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
+import org.activiti.api.process.model.payloads.SignalPayload;
+import org.activiti.api.process.model.payloads.StartProcessPayload;
+import org.activiti.api.process.model.payloads.SuspendProcessPayload;
+import org.activiti.api.task.model.payloads.ClaimTaskPayload;
+import org.activiti.api.task.model.payloads.CompleteTaskPayload;
+import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsPayload;
+import org.activiti.cloud.api.process.model.impl.SyncCloudProcessDefinitionsResult;
+import org.activiti.cloud.services.gateway.ProcessRuntimeGateway;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ProcessRuntimeGatewayIT extends CommandEndpointIT {
+
+    @Autowired
+    private ProcessRuntimeGateway processRuntimeGateway;
+
+    @Override
+    protected SyncCloudProcessDefinitionsResult doSyncCloudProcessDefinitions(
+        SyncCloudProcessDefinitionsPayload payload
+    ) {
+        return processRuntimeGateway.syncProcessDefinitions(payload);
+    }
+
+    @Override
+    protected void doSendSignal(SignalPayload payload) {
+        var result = processRuntimeGateway.sendSignal(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected void doClaimTask(ClaimTaskPayload payload) {
+        var result = processRuntimeGateway.claimTask(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected void doCompleteTask(CompleteTaskPayload payload) {
+        var result = processRuntimeGateway.completeTask(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected void doResumeProcessInstance(ResumeProcessPayload payload) {
+        var result = processRuntimeGateway.resumeProcess(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected void doSuspendProcessInstance(SuspendProcessPayload payload) {
+        var result = processRuntimeGateway.suspendProcess(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected String doStartProcessInstance(StartProcessPayload payload) {
+        var result = processRuntimeGateway.startProcess(payload);
+
+        assertThat(result).isNotNull();
+
+        return result.getEntity().getId();
+    }
+
+    @Override
+    protected void doReleaseTask(ReleaseTaskPayload payload) {
+        var result = processRuntimeGateway.releaseTask(payload);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Override
+    protected void doSetProcessVariables(SetProcessVariablesPayload payload) {
+        var result = processRuntimeGateway.setProcessVariables(payload);
+
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
This is part 1 of the implementation to add a command executor in the Process Runtime Service core to be able to trigger process definitions sync via a command message sent by the Query service via a batch job. The Process Runtime will handle the synchronization request by sending the process definitions back to Query via existing process deployed audit messages and return execution result to the requestor via command results channel.

Part of https://hyland.atlassian.net/browse/AAE-26100