### PR TITLE
AAE-29930 Fix HQL injection by replacing the querydsl package with a patched version of a fork from OpenFeign

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -92,19 +92,19 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-apt</artifactId>
         <version>${querydsl.version}</version>
         <scope>provided</scope>
         <classifier>jakarta</classifier>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-core</artifactId>
         <version>${querydsl.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${querydsl.version}</version>
         <classifier>jakarta</classifier>

--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Audit Dependencies BOM (Bill Of Materials)</name>
   <properties>
-    <querydsl.version>5.1.0</querydsl.version>
+    <querydsl.version>5.6.1</querydsl.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -91,9 +91,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>5.1.0</version>
+      <version>5.6.1</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -79,9 +79,9 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>5.1.0</version>
+      <version>5.6.1</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/pom.xml
@@ -59,7 +59,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit-rest/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit-rest/pom.xml
@@ -95,7 +95,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit/pom.xml
@@ -97,7 +97,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -66,19 +66,19 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-apt</artifactId>
         <version>${querydsl.version}</version>
         <scope>provided</scope>
         <classifier>jakarta</classifier>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-core</artifactId>
         <version>${querydsl.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${querydsl.version}</version>
         <classifier>jakarta</classifier>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>activiti-cloud-notifications-graphql-dependencies</artifactId>
   <packaging>pom</packaging>
   <properties>
-    <querydsl.version>5.1.0</querydsl.version>
+    <querydsl.version>5.6.1</querydsl.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Query Dependencies BOM (Bill Of Materials)</name>
   <properties>
-    <querydsl.version>5.1.0</querydsl.version>
+    <querydsl.version>5.6.1</querydsl.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -87,19 +87,19 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-apt</artifactId>
         <version>${querydsl.version}</version>
         <scope>provided</scope>
         <classifier>jakarta</classifier>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-core</artifactId>
         <version>${querydsl.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.querydsl</groupId>
+        <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${querydsl.version}</version>
         <classifier>jakarta</classifier>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
@@ -68,18 +68,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <version>${querydsl.version}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
       <classifier>jakarta</classifier>
       <version>${querydsl.version}</version>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
@@ -23,18 +23,18 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <version>${querydsl.version}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
@@ -117,18 +117,18 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <version>${querydsl.version}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.querydsl</groupId>
+      <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
       <classifier>jakarta</classifier>
     </dependency>


### PR DESCRIPTION
Ticket link: https://hyland.atlassian.net/browse/AAE-29930