### PR TITLE
AAE-30697 Fix Activiti Cloud Keycloak test container is timing out during integration tests

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 public class KeycloakContainerApplicationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
@@ -29,7 +28,6 @@ public class KeycloakContainerApplicationInitializer
         .withAdminUsername("admin")
         .withAdminPassword("admin")
         .withRealmImportFile("activiti-realm.json")
-        .waitingFor(Wait.defaultWaitStrategy())
         .withReuse(true);
 
     @Override


### PR DESCRIPTION
https://hyland.atlassian.net/browse/AAE-30697

The wait strategy override `Wait.defaultWaitStrategy()` is failing while checking internal ports inside a running container. 

Removed the default wait strategy override to be able to use the built-in wait strategy provided by the upstream:

```
        setWaitStrategy(Wait
            .forLogMessage(".*Running the server in development mode\\. DO NOT use this configuration in production.*\\n", 1)
            .withStartupTimeout(startupTimeout)
        );
```