### PR TITLE
AAE-33179 add 'sub' claim to user security context to fix tests

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/WithActivitiMockUserSecurityContextFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/services/common/security/test/support/WithActivitiMockUserSecurityContextFactory.java
@@ -100,6 +100,8 @@ public class WithActivitiMockUserSecurityContextFactory implements WithSecurityC
         groupsArray.addAll(groups);
         claims.put("groups", groupsArray);
 
+        claims.put("sub", username);
+
         return claims;
     }
 }


### PR DESCRIPTION
Add the sub claim to the security context to fix tests context.