### PR TITLE
AAE-34591 Migrate to Teams workflow webhook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,6 +447,6 @@ jobs:
     if: always() && failure() && github.event_name == 'push'
     steps:
       - name: Teams Notification
-        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@c1236aee36bb9b35c5972819fcf8a4d07572e6cd # v8.16.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@95f68dc050fba62b3331d9b47bc659526cdfb343 # v8.21.1
         with:
-          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WEBHOOK }}
+          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WORKFLOW_WEBHOOK }}


### PR DESCRIPTION
Migrating to the new Teams workflow webhook as the legacy ones are going to reach EoL by end of year.

Tested here: https://teams.microsoft.com/l/message/19:f44b2a4762214bb8a119ec512392fbd5@thread.tacv2/1747217246259?tenantId=8ca5db88-a5ab-48f7-a5e0-4ce50935f807&groupId=0212f351-7697-4df3-9330-a91abb1f34fa&parentMessageId=1747217246259&teamName=Automate&channelName=%F0%9F%A4%96%20Automate%20Activiti%20Github%20Notifications&createdTime=1747217246259