### PR TITLE
AAE-35733 - Extend TaskControllerAdvice in order to use it when the module is imported

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestControllersAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestControllersAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.activiti.cloud.services.query.rest.TaskController;
 import org.activiti.cloud.services.query.rest.TaskDeleteController;
 import org.activiti.cloud.services.query.rest.TaskVariableAdminController;
 import org.activiti.cloud.services.query.rest.TaskVariableController;
+import org.activiti.cloud.services.query.rest.advice.TaskControllerAdvice;
 import org.activiti.image.ProcessDiagramGenerator;
 import org.activiti.image.impl.DefaultProcessDiagramGenerator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -70,6 +71,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
         ProcessModelController.class,
         TaskAdminController.class,
         TaskController.class,
+        TaskControllerAdvice.class,
         TaskDeleteController.class,
         TaskVariableAdminController.class,
         TaskVariableController.class,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestControllersAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/conf/QueryRestControllersAutoConfiguration.java
@@ -71,7 +71,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
         ProcessModelController.class,
         TaskAdminController.class,
         TaskController.class,
-        TaskControllerAdvice.class,
         TaskDeleteController.class,
         TaskVariableAdminController.class,
         TaskVariableController.class,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -37,6 +37,7 @@ import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.TaskCandidateGroupEntity;
 import org.activiti.cloud.services.query.model.TaskCandidateUserEntity;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.activiti.cloud.services.query.rest.advice.TaskControllerAdvice;
 import org.activiti.cloud.services.query.rest.assembler.TaskRepresentationModelAssembler;
 import org.activiti.cloud.services.query.rest.payload.TaskSearchRequest;
 import org.activiti.cloud.services.query.rest.payload.TasksQueryBody;
@@ -60,7 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/admin/v1/tasks", produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
-public class TaskAdminController {
+public class TaskAdminController extends TaskControllerAdvice {
 
     private final TaskRepository taskRepository;
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.query.model.QTaskEntity;
 import org.activiti.cloud.services.query.model.TaskCandidateGroupEntity;
 import org.activiti.cloud.services.query.model.TaskCandidateUserEntity;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.activiti.cloud.services.query.rest.advice.TaskControllerAdvice;
 import org.activiti.cloud.services.query.rest.assembler.TaskRepresentationModelAssembler;
 import org.activiti.cloud.services.query.rest.payload.TaskSearchRequest;
 import org.activiti.cloud.services.query.rest.predicate.RootTasksFilter;
@@ -63,7 +64,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/v1/tasks", produces = { MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE })
-public class TaskController {
+public class TaskController extends TaskControllerAdvice {
 
     private final TaskRepository taskRepository;
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
@@ -23,9 +23,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = { TaskController.class, TaskAdminController.class })
 public class TaskControllerAdvice {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskControllerAdvice.class);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
@@ -15,8 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest.advice;
 
-import org.activiti.cloud.services.query.rest.TaskAdminController;
-import org.activiti.cloud.services.query.rest.TaskController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.InvalidDataAccessApiUsageException;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/advice/TaskControllerAdvice.java
@@ -22,10 +22,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice(assignableTypes = { TaskController.class, TaskAdminController.class })
+@RestControllerAdvice(assignableTypes = { TaskController.class, TaskAdminController.class })
 public class TaskControllerAdvice {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskControllerAdvice.class);


### PR DESCRIPTION
Controller Advice works fine in activiti-cloud but if not imported it will not work in projects that have activiti-cloud as dependency