### PR TITLE
AAE-36969 Removing-Jakarta-for-querydsl-v7.0

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -113,12 +113,12 @@
       <dependency>
         <groupId>jakarta.inject</groupId>
         <artifactId>jakarta.inject-api</artifactId>
-        <version>2.0.1</version>
+        <version>${jakarta.inject-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mysema.commons</groupId>
         <artifactId>mysema-commons-lang</artifactId>
-        <version>0.2.4</version>
+        <version>${mysema-commons-lang.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Audit Dependencies BOM (Bill Of Materials)</name>
   <properties>
-    <openfeign.querydsl.version>5.6.1</openfeign.querydsl.version>
+    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -107,7 +107,6 @@
         <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${openfeign.querydsl.version}</version>
-        <classifier>jakarta</classifier>
       </dependency>
       <dependency>
         <groupId>io.github.classgraph</groupId>

--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -10,9 +10,6 @@
   <artifactId>activiti-cloud-audit-dependencies</artifactId>
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Audit Dependencies BOM (Bill Of Materials)</name>
-  <properties>
-    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-audit-dependencies/pom.xml
@@ -113,6 +113,17 @@
         <artifactId>classgraph</artifactId>
         <version>${classgraph.version}</version>
       </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mysema.commons</groupId>
+        <artifactId>mysema-commons-lang</artifactId>
+        <version>0.2.4</version>
+        <scope>runtime</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>7.0</version>
+      <version>${openfeign.querydsl.version}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>5.6.1</version>
+      <version>7.0</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -100,12 +100,12 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
+      <version>${jakarta.inject-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>
-      <version>0.2.4</version>
+      <version>${mysema-commons-lang.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -95,7 +95,6 @@
       <artifactId>querydsl-apt</artifactId>
       <version>${openfeign.querydsl.version}</version>
       <scope>provided</scope>
-      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-api/pom.xml
@@ -97,6 +97,17 @@
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.commons</groupId>
+      <artifactId>mysema-commons-lang</artifactId>
+      <version>0.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>7.0</version>
+      <version>${openfeign.querydsl.version}</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -88,12 +88,12 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
+      <version>${jakarta.inject-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>
-      <version>0.2.4</version>
+      <version>${mysema-commons-lang.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
-      <version>5.6.1</version>
+      <version>7.0</version>
       <scope>provided</scope>
       <classifier>jakarta</classifier>
     </dependency>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -86,6 +86,17 @@
       <classifier>jakarta</classifier>
     </dependency>
     <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.commons</groupId>
+      <artifactId>mysema-commons-lang</artifactId>
+      <version>0.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/pom.xml
@@ -83,7 +83,6 @@
       <artifactId>querydsl-apt</artifactId>
       <version>${openfeign.querydsl.version}</version>
       <scope>provided</scope>
-      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -87,6 +87,17 @@
         <artifactId>classgraph</artifactId>
         <version>${classgraph.version}</version>
       </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mysema.commons</groupId>
+        <artifactId>mysema-commons-lang</artifactId>
+        <version>0.2.4</version>
+        <scope>runtime</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -87,12 +87,12 @@
       <dependency>
         <groupId>jakarta.inject</groupId>
         <artifactId>jakarta.inject-api</artifactId>
-        <version>2.0.1</version>
+        <version>${jakarta.inject-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mysema.commons</groupId>
         <artifactId>mysema-commons-lang</artifactId>
-        <version>0.2.4</version>
+        <version>${mysema-commons-lang.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -10,9 +10,6 @@
   <name>Activiti Cloud Notifications :: GraphQL Dependencies (Bill Of Materials)</name>
   <artifactId>activiti-cloud-notifications-graphql-dependencies</artifactId>
   <packaging>pom</packaging>
-  <properties>
-    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -81,7 +81,6 @@
         <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${openfeign.querydsl.version}</version>
-        <classifier>jakarta</classifier>
       </dependency>
       <dependency>
         <groupId>io.github.classgraph</groupId>

--- a/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
+++ b/activiti-cloud-notifications-graphql-service/dependencies/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>activiti-cloud-notifications-graphql-dependencies</artifactId>
   <packaging>pom</packaging>
   <properties>
-    <openfeign.querydsl.version>5.6.1</openfeign.querydsl.version>
+    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -116,6 +116,17 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>jakarta.inject</groupId>
+        <artifactId>jakarta.inject-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mysema.commons</groupId>
+        <artifactId>mysema-commons-lang</artifactId>
+        <version>0.2.4</version>
+        <scope>runtime</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -118,12 +118,12 @@
       <dependency>
         <groupId>jakarta.inject</groupId>
         <artifactId>jakarta.inject-api</artifactId>
-        <version>2.0.1</version>
+        <version>${jakarta.inject-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mysema.commons</groupId>
         <artifactId>mysema-commons-lang</artifactId>
-        <version>0.2.4</version>
+        <version>${mysema-commons-lang.version}</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -11,7 +11,6 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Query Dependencies BOM (Bill Of Materials)</name>
   <properties>
-    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
     <graphql-jpa-query.version>1.2.15</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -103,7 +103,6 @@
         <groupId>io.github.openfeign.querydsl</groupId>
         <artifactId>querydsl-jpa</artifactId>
         <version>${openfeign.querydsl.version}</version>
-        <classifier>jakarta</classifier>
       </dependency>
       <dependency>
         <groupId>io.github.classgraph</groupId>

--- a/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-query-dependencies/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Query Dependencies BOM (Bill Of Materials)</name>
   <properties>
-    <openfeign.querydsl.version>5.6.1</openfeign.querydsl.version>
+    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
     <graphql-jpa-query.version>1.2.15</graphql-jpa-query.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
-      <classifier>jakarta</classifier>
       <version>${openfeign.querydsl.version}</version>
     </dependency>
     <dependency>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
@@ -127,6 +127,17 @@
           <artifactId>json-unit-assertj</artifactId>
           <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.commons</groupId>
+      <artifactId>mysema-commons-lang</artifactId>
+      <version>0.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/pom.xml
@@ -130,12 +130,12 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
+      <version>${jakarta.inject-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>
-      <version>0.2.4</version>
+      <version>${mysema-commons-lang.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
+      <version>${jakarta.inject-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>
-      <version>0.2.4</version>
+      <version>${mysema-commons-lang.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
@@ -47,5 +47,16 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.commons</groupId>
+      <artifactId>mysema-commons-lang</artifactId>
+      <version>0.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
-      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
@@ -130,7 +130,6 @@
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
-      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
@@ -259,6 +259,17 @@
           <artifactId>json-unit-assertj</artifactId>
           <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysema.commons</groupId>
+      <artifactId>mysema-commons-lang</artifactId>
+      <version>0.2.4</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/pom.xml
@@ -262,12 +262,12 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>2.0.1</version>
+      <version>${jakarta.inject-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.mysema.commons</groupId>
       <artifactId>mysema-commons-lang</artifactId>
-      <version>0.2.4</version>
+      <version>${mysema-commons-lang.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,8 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <json-unit.version>4.1.1</json-unit.version>
     <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
+    <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+    <mysema-commons-lang.version>0.2.4</mysema-commons-lang.version>
 
     <!-- dependencies versions -->
     <hibernate.version>6.5.3.Final</hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <json-unit.version>4.1.1</json-unit.version>
+    <openfeign.querydsl.version>7.0</openfeign.querydsl.version>
 
     <!-- dependencies versions -->
     <hibernate.version>6.5.3.Final</hibernate.version>


### PR DESCRIPTION
Version 7.0 of querydsl-jpa does not need Jakarta as classifier any more. Similar changes from hxp-studio-services
https://hyland.atlassian.net/browse/AAE-36969
https://github.com/Alfresco/hxp-studio-services/pull/4589