### PR TITLE
AAE-37326 Added count APIs and tests for tasks and process instances

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -183,4 +183,11 @@ public class ProcessInstanceAdminController {
     ) {
         return processInstanceAdminService.findAllAppVersions(predicate);
     }
+
+    @Operation(summary = "Count process instances")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long searchProcessInstances(@RequestBody ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceAdminService.count(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -130,4 +130,9 @@ public class ProcessInstanceAdminService {
     public Page<ProcessInstanceEntity> search(ProcessInstanceSearchRequest searchRequest, Pageable pageable) {
         return processInstanceSearchService.searchUnrestricted(searchRequest, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Long count(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceSearchService.countUnrestricted(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
@@ -145,4 +145,11 @@ public class ProcessInstanceController {
             processInstanceRepresentationModelAssembler
         );
     }
+
+    @Operation(summary = "Count process instances")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countProcessInstances(@RequestBody ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceControllerHelper.countProcessInstances(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceSearchService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceSearchService.java
@@ -83,4 +83,21 @@ public class ProcessInstanceSearchService {
         );
         return processInstances;
     }
+
+    @Transactional(readOnly = true)
+    public Long countRestricted(ProcessInstanceSearchRequest searchRequest) {
+        ProcessInstanceSpecification restrictedSpecification = ProcessInstanceSpecification.restricted(
+            searchRequest,
+            securityManager.getAuthenticatedUserId()
+        );
+        return processInstanceRepository.count(restrictedSpecification);
+    }
+
+    @Transactional(readOnly = true)
+    public Long countUnrestricted(ProcessInstanceSearchRequest searchRequest) {
+        ProcessInstanceSpecification unrestrictedSpecification = ProcessInstanceSpecification.unrestricted(
+            searchRequest
+        );
+        return processInstanceRepository.count(unrestrictedSpecification);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -203,4 +203,9 @@ public class ProcessInstanceService {
 
         return taskRepository.exists(whereExpression);
     }
+
+    @Transactional(readOnly = true)
+    public Long count(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceSearchService.countRestricted(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -229,4 +229,11 @@ public class TaskAdminController extends TaskControllerAdvice {
                 .collect(Collectors.toList())
             : null;
     }
+
+    @Operation(summary = "Count tasks")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countTasks(@RequestBody TaskSearchRequest taskSearchRequest) {
+        return taskControllerHelper.countTasksUnrestricted(taskSearchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -244,4 +244,11 @@ public class TaskController extends TaskControllerAdvice {
                 .collect(Collectors.toList())
             : null;
     }
+
+    @Operation(summary = "Count tasks")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countTasks(@RequestBody TaskSearchRequest taskSearchRequest) {
+        return taskControllerHelper.countTasksRestricted(taskSearchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
@@ -246,7 +246,6 @@ public class TaskControllerHelper {
         tasks.forEach(task -> task.setTaskCandidateGroups(candidatesByTaskId.get(task.getId())));
     }
 
-    // TODO
     @Transactional(readOnly = true)
     public Long countTasksUnrestricted(TaskSearchRequest taskSearchRequest) {
         TaskSpecification unrestrictedTaskSpecification = TaskSpecification.unrestricted(taskSearchRequest);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
@@ -245,4 +245,22 @@ public class TaskControllerHelper {
             .collect(Collectors.groupingBy(TaskCandidateGroupEntity::getTaskId, Collectors.toSet()));
         tasks.forEach(task -> task.setTaskCandidateGroups(candidatesByTaskId.get(task.getId())));
     }
+
+    // TODO
+    @Transactional(readOnly = true)
+    public Long countTasksUnrestricted(TaskSearchRequest taskSearchRequest) {
+        TaskSpecification unrestrictedTaskSpecification = TaskSpecification.unrestricted(taskSearchRequest);
+        return taskRepository.count(unrestrictedTaskSpecification);
+    }
+
+    @Transactional(readOnly = true)
+    public Long countTasksRestricted(TaskSearchRequest taskSearchRequest) {
+        TaskSpecification restrictedTaskSpecification = TaskSpecification.restricted(
+            taskSearchRequest,
+            securityManager.getAuthenticatedUserId(),
+            securityManager.getAuthenticatedUserGroups()
+        );
+
+        return taskRepository.count(restrictedTaskSpecification);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/helper/ProcessInstanceControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/helper/ProcessInstanceControllerHelper.java
@@ -87,4 +87,8 @@ public class ProcessInstanceControllerHelper {
     ) {
         return processInstanceRepository.mapSubprocesses(processInstances, pageable);
     }
+
+    public Long countProcessInstances(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceService.count(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
@@ -88,6 +88,8 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
     protected abstract String getSearchEndpoint();
 
+    protected abstract String getCountEndpoint();
+
     @Test
     public void should_excludeProcessInstances_by_processDefinitionCategoryName() throws Exception {
         // given
@@ -128,6 +130,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body("_embedded.processInstances", hasSize(1))
             .body("_embedded.processInstances[0].id", equalTo(processInstanceToKeep.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -147,6 +158,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, contains("id0", "id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -172,6 +192,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, contains("id1", "id3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -201,6 +230,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -230,6 +268,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -265,6 +312,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem("id1"))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem("id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -288,6 +344,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -311,6 +376,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -334,6 +408,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -357,6 +440,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -380,6 +472,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -403,6 +504,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -426,6 +536,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -449,6 +568,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -486,6 +614,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 0)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -495,6 +632,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -510,6 +656,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 4)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -519,6 +674,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
     }
 
     @Test
@@ -543,6 +707,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables", empty());
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -577,6 +750,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables", hasSize(2))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables.name", hasItem(VAR_NAME))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables.name", hasItem("var3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -619,6 +801,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -660,6 +851,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -697,6 +897,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -735,6 +944,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -773,6 +991,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -811,6 +1038,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -849,6 +1085,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -887,6 +1132,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -926,6 +1180,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -964,6 +1227,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1003,6 +1275,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1057,6 +1338,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1086,6 +1376,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1124,6 +1423,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1162,6 +1470,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body("page.totalElements", equalTo(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1200,6 +1517,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1239,6 +1565,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1277,6 +1612,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1316,6 +1660,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1370,6 +1723,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1399,6 +1761,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1437,6 +1808,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1475,6 +1855,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1513,6 +1902,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1552,6 +1950,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1590,6 +1997,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1629,6 +2045,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1683,6 +2108,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1712,6 +2146,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1754,6 +2197,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1796,6 +2248,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1838,6 +2299,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1881,6 +2351,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1923,6 +2402,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1966,6 +2454,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2026,6 +2523,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2055,6 +2561,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2093,6 +2608,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2136,6 +2660,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance3.getId(), processInstance2.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("startDate", Sort.Direction.DESC, false, null, null));
@@ -2151,6 +2684,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2200,6 +2742,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2224,6 +2775,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2273,6 +2833,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2297,6 +2866,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance2.getId(), processInstance1.getId(), processInstance3.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2346,6 +2924,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2370,6 +2957,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2419,6 +3015,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2443,6 +3048,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2498,6 +3112,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance1.getId(), processInstance3.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2522,6 +3145,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2575,6 +3207,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 containsInRelativeOrder(processInstance2.getId(), processInstance3.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2603,6 +3244,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 containsInRelativeOrder(processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     /**
@@ -2670,6 +3320,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             )
             .body("page.totalElements", is(4));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
+
         requestBuilder.invertSort();
 
         given()
@@ -2687,6 +3346,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains("cool", "best", "amazing", null)
             )
             .body("page.totalElements", is(4));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
     }
 
     @Test
@@ -2702,6 +3370,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(400);
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort(VAR_NAME, Sort.Direction.ASC, true, PROCESS_DEFINITION_KEY, null));
@@ -2713,6 +3390,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .post(getSearchEndpoint())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -2758,6 +3444,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 4)
             .when()
@@ -2774,6 +3469,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 8)
             .when()
@@ -2786,6 +3490,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body("page.totalPages", is(3))
             .body("page.size", is(4))
             .body("page.number", is(2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -2831,5 +3544,14 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(10));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
@@ -71,6 +71,8 @@ public abstract class AbstractTaskControllerIT {
 
     protected abstract String getSearchEndpointHttpPost();
 
+    protected abstract String getCountEndpointHttpPost();
+
     @BeforeEach
     public void setUp() {
         webAppContextSetup(context);
@@ -86,15 +88,15 @@ public abstract class AbstractTaskControllerIT {
     void should_return400_whenInvalidSearchParameterIsProvided() {
         String missingSortField =
             """
-        {
-            "sort": {
-                "direction": "ASC",
-                "isProcessVariable": false,
-                "processDefinitionKey": null,
-                "type": "bigdecimal",
-                "processVariable": false
-            }
-        }""";
+                {
+                    "sort": {
+                        "direction": "ASC",
+                        "isProcessVariable": false,
+                        "processDefinitionKey": null,
+                        "type": "bigdecimal",
+                        "processVariable": false
+                    }
+                }""";
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -111,6 +113,15 @@ public abstract class AbstractTaskControllerIT {
                         )
                     )
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(missingSortField)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -174,6 +185,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 0)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -183,6 +203,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -198,6 +227,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 4)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -207,6 +245,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
     }
 
     @Test
@@ -240,6 +287,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables", hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables[0].name", is(VAR_NAME));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -259,6 +315,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains("id0", "id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -289,6 +354,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -338,6 +412,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -375,6 +458,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables", hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables[0].name", is(VAR_NAME));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -416,6 +508,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -457,6 +558,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -498,6 +608,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -541,6 +660,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -579,6 +707,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -614,6 +751,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -652,6 +798,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -688,6 +843,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -726,6 +890,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -767,6 +940,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -810,6 +992,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -844,6 +1035,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -887,6 +1087,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -922,6 +1131,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -966,6 +1184,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -985,6 +1212,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1021,6 +1257,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1040,6 +1285,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1084,6 +1338,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1103,6 +1366,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1133,6 +1405,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1152,6 +1433,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1197,6 +1487,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1223,6 +1522,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1260,6 +1568,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(null, VAR_NAME, VariableType.INTEGER, String.valueOf(42), FilterOperator.GREATER_THAN),
             new VariableFilter(
@@ -1280,6 +1597,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1325,6 +1651,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1361,6 +1696,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1406,6 +1750,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1444,6 +1797,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1488,6 +1850,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1507,6 +1878,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1543,6 +1923,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -1562,6 +1951,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1606,6 +2004,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1625,6 +2032,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1661,6 +2077,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -1680,6 +2105,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1726,6 +2160,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1752,6 +2195,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1796,6 +2248,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1822,6 +2283,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1865,6 +2335,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1900,6 +2379,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1943,6 +2431,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1979,6 +2476,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2025,6 +2531,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2044,6 +2559,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2081,6 +2605,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2100,6 +2633,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2146,6 +2688,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2165,6 +2716,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2202,6 +2762,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2221,6 +2790,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2268,6 +2846,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -2294,6 +2881,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2332,6 +2928,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(null, VAR_NAME, VariableType.DATE, "2024-08-02", FilterOperator.GREATER_THAN),
             new VariableFilter(null, VAR_NAME, VariableType.DATE, "2024-08-04", FilterOperator.LESS_THAN_OR_EQUAL)
@@ -2346,6 +2951,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2395,6 +3009,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2434,6 +3057,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2483,6 +3115,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2523,6 +3164,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2575,6 +3225,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2594,6 +3253,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2635,6 +3303,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2654,6 +3331,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2706,6 +3392,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2725,6 +3420,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2766,6 +3470,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2785,6 +3498,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2835,6 +3557,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -2861,6 +3592,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2909,6 +3649,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -2935,6 +3684,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2981,6 +3739,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         variableFilter =
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -3001,6 +3768,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3038,6 +3814,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         variableFilter =
             new VariableFilter(null, VAR_NAME, VariableType.BOOLEAN, String.valueOf(false), FilterOperator.EQUALS);
 
@@ -3052,6 +3837,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3071,6 +3865,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3089,6 +3892,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3108,6 +3920,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3128,6 +3949,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3148,6 +3978,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3167,6 +4006,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3187,6 +4035,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3207,6 +4064,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3237,6 +4103,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3257,6 +4132,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3277,6 +4161,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3297,6 +4190,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3317,6 +4219,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3337,6 +4248,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3357,6 +4277,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3377,6 +4306,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3397,6 +4335,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3417,6 +4364,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3437,6 +4393,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3467,6 +4432,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3497,6 +4471,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3519,6 +4502,15 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(400)
+            .body(equalTo(""));
     }
 
     @Test
@@ -3563,6 +4555,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("priority", Sort.Direction.DESC, false, null, null));
@@ -3576,6 +4577,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
@@ -3591,6 +4601,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("lastModified", Sort.Direction.DESC, false, null, null));
@@ -3604,6 +4623,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3653,6 +4681,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3674,6 +4711,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3723,6 +4769,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3744,6 +4799,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3793,6 +4857,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3814,6 +4887,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3863,6 +4945,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3884,6 +4975,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_3, TASK_ID_2, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3939,6 +5039,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_1, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3960,6 +5069,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_3, TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -4001,6 +5119,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -4022,14 +5149,23 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     /**
      * From Postgres documentation: <a href="https://www.postgresql.org/docs/current/queries-order.html">Postgres sorting</a>
-     *  By default, null values sort as if larger than any non-null value;
-     *  that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.
-     *  We are overriding this behavior in order to have null values always at the end
-     *  by setting property hibernate.order_by.default_null_ordering=last in CustomHibernateAutoConfiguration
+     * By default, null values sort as if larger than any non-null value;
+     * that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.
+     * We are overriding this behavior in order to have null values always at the end
+     * by setting property hibernate.order_by.default_null_ordering=last in CustomHibernateAutoConfiguration
      */
     @Test
     void should_returnTasks_sortedByProcessVariables_respectingDefaultNullBehaviour() {
@@ -4067,6 +5203,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(4))
             .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("1", "2", "3", "0"));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
+
         requestBuilder.invertSort();
 
         given()
@@ -4080,6 +5225,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(4))
             .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("3", "2", "1", "0"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
     }
 
     @Test
@@ -4095,6 +5249,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(400);
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort(VAR_NAME, Sort.Direction.ASC, true, PROCESS_DEFINITION_KEY, null));
@@ -4106,6 +5269,15 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -4153,6 +5325,15 @@ public abstract class AbstractTaskControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 4)
             .when()
@@ -4169,6 +5350,15 @@ public abstract class AbstractTaskControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 8)
             .when()
@@ -4181,6 +5371,15 @@ public abstract class AbstractTaskControllerIT {
             .body("page.totalPages", is(3))
             .body("page.size", is(4))
             .body("page.number", is(2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -4261,6 +5460,15 @@ public abstract class AbstractTaskControllerIT {
                 TASK_IDS_JSON_PATH,
                 contains(IntStream.range(0, 10).mapToObj(String::valueOf).toList().reversed().toArray())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -4347,6 +5555,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4357,6 +5574,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("1"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         requestBuilder.invertSort();
 
@@ -4375,6 +5601,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4385,6 +5620,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("2"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -4476,6 +5720,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4486,6 +5739,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("1"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         requestBuilder.invertSort();
 
@@ -4504,6 +5766,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4514,6 +5785,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("2"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -55,6 +56,11 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
         return "/admin/v1/process-instances/search";
     }
 
+    @Override
+    protected String getCountEndpoint() {
+        return "/admin/v1/process-instances/count";
+    }
+
     @Test
     void should_return_AllProcessInstances() {
         ProcessInstanceEntity processInstance1 = queryTestUtils
@@ -76,6 +82,15 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -103,5 +118,14 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchControllerIT.java
@@ -24,6 +24,7 @@ import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.util.ProcessInstanceSearchRequestBuilder;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -56,6 +57,11 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
         return "/v1/process-instances/search";
     }
 
+    @Override
+    protected String getCountEndpoint() {
+        return "/v1/process-instances/count";
+    }
+
     @Test
     void should_return_RestrictedProcessInstances() {
         ProcessInstanceEntity processInstance1 = queryTestUtils
@@ -73,6 +79,15 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body("_embedded.processInstances[0].id", equalTo(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("1"));
     }
 
     @Test
@@ -106,5 +121,14 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("2"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -59,8 +60,13 @@ class TaskAdminControllerIT extends AbstractTaskControllerIT {
         return "/admin/v1/tasks/search";
     }
 
+    @Override
+    protected String getCountEndpointHttpPost() {
+        return "/admin/v1/tasks/count";
+    }
+
     @Test
-    void should_returnTasks_unrestrictedTasks() {
+    void should_returnTasksAndCount_unrestrictedTasks() {
         String otherUser = "other-user";
 
         TaskEntity task1 = queryTestUtils.buildTask().withOwner(otherUser).buildAndSave();
@@ -78,5 +84,14 @@ class TaskAdminControllerIT extends AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(task1.getId(), task2.getId(), task3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post("/admin/v1/tasks/count")
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.activiti.cloud.services.query.rest.TaskControllerIT.CURRENT_USER;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.util.List;
@@ -25,6 +26,7 @@ import org.activiti.QueryRestTestApplication;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -67,8 +69,13 @@ class TaskControllerIT extends AbstractTaskControllerIT {
         return "/v1/tasks/search";
     }
 
+    @Override
+    protected String getCountEndpointHttpPost() {
+        return "/v1/tasks/count";
+    }
+
     @Test
-    void should_returnTasks_restrictedToCurrentUser() {
+    void should_returnTasksAndCount_restrictedToCurrentUser() {
         String otherUser = "other-user";
         String testgroup = "testgroup";
         Mockito.when(securityManager.getAuthenticatedUserGroups()).thenReturn(List.of(testgroup));
@@ -106,5 +113,14 @@ class TaskControllerIT extends AbstractTaskControllerIT {
                 TASK_IDS_JSON_PATH,
                 containsInAnyOrder(task1.getId(), task2.getId(), task4.getId(), task6.getId(), task7.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post("/v1/tasks/count")
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("5"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
@@ -15,13 +15,6 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.activiti.cloud.services.query.rest.TaskControllerIT.CURRENT_USER;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-
-import java.util.List;
 import org.activiti.QueryRestTestApplication;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -38,6 +31,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.activiti.cloud.services.query.rest.TaskControllerIT.CURRENT_USER;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 @SpringBootTest(
     classes = { QueryRestTestApplication.class, AlfrescoWebAutoConfiguration.class },

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
@@ -15,6 +15,12 @@
  */
 package org.activiti.cloud.services.query.rest;
 
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.activiti.cloud.services.query.rest.TaskControllerIT.CURRENT_USER;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+import java.util.List;
 import org.activiti.QueryRestTestApplication;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -31,13 +37,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-
-import java.util.List;
-
-import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.activiti.cloud.services.query.rest.TaskControllerIT.CURRENT_USER;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 @SpringBootTest(
     classes = { QueryRestTestApplication.class, AlfrescoWebAutoConfiguration.class },

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -66,8 +66,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -76,8 +76,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -97,6 +97,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudTask_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/v1/tasks/count": {
+      "post": {
+        "tags": [
+          "task-controller"
+        ],
+        "summary": "Count tasks",
+        "operationId": "countTasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -168,8 +244,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -178,8 +254,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -199,6 +275,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudProcessInstance_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/v1/process-instances/count": {
+      "post": {
+        "tags": [
+          "process-instance-controller"
+        ],
+        "summary": "Count process instances",
+        "operationId": "countProcessInstances",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -597,8 +749,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -607,8 +759,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -999,8 +1151,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1009,8 +1161,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -1348,8 +1500,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1358,8 +1510,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -1450,8 +1602,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1460,8 +1612,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -1481,6 +1633,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudTask_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/admin/v1/tasks/count": {
+      "post": {
+        "tags": [
+          "task-admin-controller"
+        ],
+        "summary": "Count tasks",
+        "operationId": "countTasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -1772,8 +2000,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1782,8 +2010,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -2087,8 +2315,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2097,8 +2325,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -2367,8 +2595,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2377,8 +2605,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -2469,8 +2697,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2479,8 +2707,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -2500,6 +2728,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudProcessInstance_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/admin/v1/process-instances/count": {
+      "post": {
+        "tags": [
+          "process-instance-admin-controller"
+        ],
+        "summary": "Count process instances",
+        "operationId": "searchProcessInstances",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -2898,8 +3202,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2908,8 +3212,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3013,8 +3317,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3023,8 +3327,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3087,8 +3391,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3097,8 +3401,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3161,8 +3465,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3171,8 +3475,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3241,8 +3545,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3251,8 +3555,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3569,8 +3873,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3579,8 +3883,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3643,8 +3947,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3653,8 +3957,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3772,8 +4076,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3782,8 +4086,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -3886,8 +4190,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3896,8 +4200,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4219,8 +4523,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4229,8 +4533,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4293,8 +4597,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4303,8 +4607,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4444,8 +4748,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4454,8 +4758,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4518,8 +4822,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4528,8 +4832,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4626,8 +4930,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4636,8 +4940,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4741,8 +5045,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4751,8 +5055,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4815,8 +5119,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4825,8 +5129,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4889,8 +5193,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4899,8 +5203,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -4969,8 +5273,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4979,8 +5283,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5099,8 +5403,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5109,8 +5413,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5173,8 +5477,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5183,8 +5487,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5247,8 +5551,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5257,8 +5561,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5321,8 +5625,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5331,8 +5635,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5450,8 +5754,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5460,8 +5764,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5550,8 +5854,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5560,8 +5864,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5682,8 +5986,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5692,8 +5996,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -5756,8 +6060,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5766,8 +6070,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -6033,8 +6337,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6043,8 +6347,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -6197,8 +6501,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6207,8 +6511,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -6271,8 +6575,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6281,8 +6585,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -6379,8 +6683,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6389,8 +6693,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/json": {
                 "schema": {
@@ -6701,10 +7005,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -6722,14 +7026,14 @@
           "type": {
             "type": "string"
           },
+          "taskVariable": {
+            "type": "boolean"
+          },
           "taskId": {
             "type": "string"
           },
           "processInstanceId": {
             "type": "string"
-          },
-          "taskVariable": {
-            "type": "boolean"
           }
         },
         "title": "CloudVariableInstance_ProcessVariables"
@@ -6807,6 +7111,12 @@
               ]
             }
           },
+          "processDefinitionName": {
+            "type": "string"
+          },
+          "rootProcessInstanceId": {
+            "type": "string"
+          },
           "processVariables": {
             "type": "array",
             "items": {
@@ -6814,22 +7124,16 @@
             },
             "uniqueItems": true
           },
-          "rootProcessInstanceId": {
-            "type": "string"
-          },
-          "processDefinitionName": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -6858,12 +7162,12 @@
           "standalone": {
             "type": "boolean"
           },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
           "description": {
             "type": "string"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
           },
           "status": {
             "type": "string",
@@ -6876,10 +7180,31 @@
               "DELETED"
             ]
           },
-          "processInstanceId": {
+          "formKey": {
             "type": "string"
           },
+          "createdDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "claimedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "completedBy": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "string"
+          },
+          "processInstanceId": {
             "type": "string"
           },
           "candidateUsers": {
@@ -6894,38 +7219,17 @@
               "type": "string"
             }
           },
+          "processDefinitionId": {
+            "type": "string"
+          },
           "completedDate": {
             "type": "string",
             "format": "date-time"
           },
-          "assignee": {
-            "type": "string"
-          },
           "parentTaskId": {
             "type": "string"
           },
-          "formKey": {
-            "type": "string"
-          },
           "taskDefinitionKey": {
-            "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "businessKey": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "claimedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "processDefinitionId": {
             "type": "string"
           }
         },
@@ -7096,10 +7400,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7114,6 +7418,22 @@
           "id": {
             "type": "string"
           },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "processDefinitionKey": {
+            "type": "string"
+          },
+          "processDefinitionName": {
+            "type": "string"
+          },
+          "rootProcessInstanceId": {
+            "type": "string"
+          },
+          "parentId": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -7124,38 +7444,22 @@
               "COMPLETED"
             ]
           },
-          "parentId": {
-            "type": "string"
-          },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "rootProcessInstanceId": {
-            "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "businessKey": {
-            "type": "string"
-          },
           "startDate": {
             "type": "string",
             "format": "date-time"
           },
-          "processDefinitionId": {
+          "businessKey": {
             "type": "string"
           },
           "initiator": {
             "type": "string"
           },
-          "processDefinitionKey": {
+          "processDefinitionId": {
             "type": "string"
           },
-          "processDefinitionName": {
-            "type": "string"
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "title": "QueryCloudProcessInstance_ProcessVariables"
@@ -7227,10 +7531,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7248,14 +7552,14 @@
           "type": {
             "type": "string"
           },
+          "taskVariable": {
+            "type": "boolean"
+          },
           "taskId": {
             "type": "string"
           },
           "processInstanceId": {
             "type": "string"
-          },
-          "taskVariable": {
-            "type": "boolean"
           }
         },
         "title": "CloudVariableInstance"
@@ -7327,10 +7631,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7348,14 +7652,14 @@
           "type": {
             "type": "string"
           },
+          "taskVariable": {
+            "type": "boolean"
+          },
           "taskId": {
             "type": "string"
           },
           "processInstanceId": {
             "type": "string"
-          },
-          "taskVariable": {
-            "type": "boolean"
           }
         },
         "title": "CloudVariableInstance_General"
@@ -7384,6 +7688,12 @@
               ]
             }
           },
+          "processDefinitionName": {
+            "type": "string"
+          },
+          "rootProcessInstanceId": {
+            "type": "string"
+          },
           "processVariables": {
             "type": "array",
             "items": {
@@ -7391,22 +7701,16 @@
             },
             "uniqueItems": true
           },
-          "rootProcessInstanceId": {
-            "type": "string"
-          },
-          "processDefinitionName": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7435,12 +7739,12 @@
           "standalone": {
             "type": "boolean"
           },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
           "description": {
             "type": "string"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
           },
           "status": {
             "type": "string",
@@ -7453,10 +7757,31 @@
               "DELETED"
             ]
           },
-          "processInstanceId": {
+          "formKey": {
             "type": "string"
           },
+          "createdDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "claimedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "completedBy": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "string"
+          },
+          "processInstanceId": {
             "type": "string"
           },
           "candidateUsers": {
@@ -7471,38 +7796,17 @@
               "type": "string"
             }
           },
+          "processDefinitionId": {
+            "type": "string"
+          },
           "completedDate": {
             "type": "string",
             "format": "date-time"
           },
-          "assignee": {
-            "type": "string"
-          },
           "parentTaskId": {
             "type": "string"
           },
-          "formKey": {
-            "type": "string"
-          },
           "taskDefinitionKey": {
-            "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "businessKey": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "claimedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "processDefinitionId": {
             "type": "string"
           }
         },
@@ -7533,10 +7837,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7551,6 +7855,22 @@
           "id": {
             "type": "string"
           },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "processDefinitionKey": {
+            "type": "string"
+          },
+          "processDefinitionName": {
+            "type": "string"
+          },
+          "rootProcessInstanceId": {
+            "type": "string"
+          },
+          "parentId": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -7561,38 +7881,22 @@
               "COMPLETED"
             ]
           },
-          "parentId": {
-            "type": "string"
-          },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "rootProcessInstanceId": {
-            "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "businessKey": {
-            "type": "string"
-          },
           "startDate": {
             "type": "string",
             "format": "date-time"
           },
-          "processDefinitionId": {
+          "businessKey": {
             "type": "string"
           },
           "initiator": {
             "type": "string"
           },
-          "processDefinitionKey": {
+          "processDefinitionId": {
             "type": "string"
           },
-          "processDefinitionName": {
-            "type": "string"
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "title": "QueryCloudProcessInstance_General"
@@ -7654,10 +7958,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7675,14 +7979,14 @@
           "type": {
             "type": "string"
           },
+          "taskVariable": {
+            "type": "boolean"
+          },
           "taskId": {
             "type": "string"
           },
           "processInstanceId": {
             "type": "string"
-          },
-          "taskVariable": {
-            "type": "boolean"
           }
         },
         "title": "QueryCloudVariableInstance"
@@ -7769,10 +8073,10 @@
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7893,6 +8197,13 @@
           "id": {
             "type": "string"
           },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "processDefinitionKey": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -7902,18 +8213,7 @@
               "ERROR"
             ]
           },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
           "businessKey": {
-            "type": "string"
-          },
-          "processDefinitionKey": {
             "type": "string"
           },
           "startedDate": {
@@ -7924,16 +8224,20 @@
             "type": "string",
             "format": "date-time"
           },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "appName": {
             "type": "string"
           },
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {
@@ -7945,19 +8249,19 @@
           "executionId": {
             "type": "string"
           },
+          "activityName": {
+            "type": "string"
+          },
           "activityType": {
             "type": "string"
           },
-          "activityName": {
+          "elementId": {
             "type": "string"
           },
           "processInstanceId": {
             "type": "string"
           },
           "processDefinitionId": {
-            "type": "string"
-          },
-          "elementId": {
             "type": "string"
           }
         },
@@ -8010,6 +8314,24 @@
               "INTEGRATION_ERROR_RECEIVED"
             ]
           },
+          "errorCode": {
+            "type": "string"
+          },
+          "requestDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resultDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "errorDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "errorClassName": {
+            "type": "string"
+          },
           "stackTraceElements": {
             "type": "array",
             "items": {
@@ -8043,59 +8365,47 @@
               }
             }
           },
-          "errorCode": {
-            "type": "string"
-          },
-          "requestDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "resultDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "errorDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "errorClassName": {
-            "type": "string"
-          },
           "id": {
             "type": "string"
           },
-          "processInstanceId": {
-            "type": "string"
-          },
-          "rootProcessInstanceId": {
+          "parentProcessInstanceId": {
             "type": "string"
           },
           "processDefinitionVersion": {
             "type": "integer",
             "format": "int32"
           },
-          "businessKey": {
-            "type": "string"
-          },
-          "processDefinitionId": {
-            "type": "string"
-          },
-          "appVersion": {
-            "type": "string"
-          },
           "processDefinitionKey": {
             "type": "string"
           },
-          "parentProcessInstanceId": {
+          "rootProcessInstanceId": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "clientName": {
             "type": "string"
           },
           "executionId": {
             "type": "string"
           },
-          "connectorType": {
+          "clientType": {
             "type": "string"
           },
-          "clientName": {
+          "appVersion": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "processInstanceId": {
+            "type": "string"
+          },
+          "processDefinitionId": {
+            "type": "string"
+          },
+          "connectorType": {
             "type": "string"
           },
           "inBoundVariables": {
@@ -8110,22 +8420,16 @@
               "type": "object"
             }
           },
-          "clientId": {
-            "type": "string"
-          },
-          "clientType": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
           "serviceName": {
             "type": "string"
           },
-          "serviceFullName": {
+          "serviceType": {
             "type": "string"
           },
-          "serviceType": {
+          "serviceFullName": {
             "type": "string"
           },
           "serviceVersion": {


### PR DESCRIPTION
Issue link: https://hyland.atlassian.net/browse/AAE-37326

Added four new APIs:
/v1/tasks/count
/v1/process-instances/count
/admin/v1/process-instances/count
/admin/v1/tasks/count

to increase performance in getting tasks and process-instances notification numbers.