### PR TITLE
AAE-37326 Added count APIs and tests for tasks and process instances

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -328,7 +328,7 @@ jobs:
     if: github.event_name == 'push'
     env:
       VERSION: ${{ needs.build.outputs.version }}
-      DEVELOPMENT_BRANCH: ${{ github.ref_name }}
+      DEVELOPMENT_BRANCH: 7.19.x
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/jx-updatebot-pr@43b8dd18f509dc920089cdf54269f13a5c02022d # v8.5.0

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminController.java
@@ -183,4 +183,11 @@ public class ProcessInstanceAdminController {
     ) {
         return processInstanceAdminService.findAllAppVersions(predicate);
     }
+
+    @Operation(summary = "Count process instances")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long searchProcessInstances(@RequestBody ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceAdminService.count(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminService.java
@@ -130,4 +130,9 @@ public class ProcessInstanceAdminService {
     public Page<ProcessInstanceEntity> search(ProcessInstanceSearchRequest searchRequest, Pageable pageable) {
         return processInstanceSearchService.searchUnrestricted(searchRequest, pageable);
     }
+
+    @Transactional(readOnly = true)
+    public Long count(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceSearchService.countUnrestricted(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceController.java
@@ -145,4 +145,11 @@ public class ProcessInstanceController {
             processInstanceRepresentationModelAssembler
         );
     }
+
+    @Operation(summary = "Count process instances")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countProcessInstances(@RequestBody ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceControllerHelper.countProcessInstances(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceSearchService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceSearchService.java
@@ -83,4 +83,21 @@ public class ProcessInstanceSearchService {
         );
         return processInstances;
     }
+
+    @Transactional(readOnly = true)
+    public Long countRestricted(ProcessInstanceSearchRequest searchRequest) {
+        ProcessInstanceSpecification restrictedSpecification = ProcessInstanceSpecification.restricted(
+            searchRequest,
+            securityManager.getAuthenticatedUserId()
+        );
+        return processInstanceRepository.count(restrictedSpecification);
+    }
+
+    @Transactional(readOnly = true)
+    public Long countUnrestricted(ProcessInstanceSearchRequest searchRequest) {
+        ProcessInstanceSpecification unrestrictedSpecification = ProcessInstanceSpecification.unrestricted(
+            searchRequest
+        );
+        return processInstanceRepository.count(unrestrictedSpecification);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceService.java
@@ -203,4 +203,9 @@ public class ProcessInstanceService {
 
         return taskRepository.exists(whereExpression);
     }
+
+    @Transactional(readOnly = true)
+    public Long count(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceSearchService.countRestricted(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskAdminController.java
@@ -228,4 +228,11 @@ public class TaskAdminController {
                 .collect(Collectors.toList())
             : null;
     }
+
+    @Operation(summary = "Count tasks")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countTasks(@RequestBody TaskSearchRequest taskSearchRequest) {
+        return taskControllerHelper.countTasksUnrestricted(taskSearchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskController.java
@@ -243,4 +243,11 @@ public class TaskController {
                 .collect(Collectors.toList())
             : null;
     }
+
+    @Operation(summary = "Count tasks")
+    @JsonView(JsonViews.ProcessVariables.class)
+    @PostMapping("/count")
+    public Long countTasks(@RequestBody TaskSearchRequest taskSearchRequest) {
+        return taskControllerHelper.countTasksRestricted(taskSearchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskControllerHelper.java
@@ -245,4 +245,21 @@ public class TaskControllerHelper {
             .collect(Collectors.groupingBy(TaskCandidateGroupEntity::getTaskId, Collectors.toSet()));
         tasks.forEach(task -> task.setTaskCandidateGroups(candidatesByTaskId.get(task.getId())));
     }
+
+    @Transactional(readOnly = true)
+    public Long countTasksUnrestricted(TaskSearchRequest taskSearchRequest) {
+        TaskSpecification unrestrictedTaskSpecification = TaskSpecification.unrestricted(taskSearchRequest);
+        return taskRepository.count(unrestrictedTaskSpecification);
+    }
+
+    @Transactional(readOnly = true)
+    public Long countTasksRestricted(TaskSearchRequest taskSearchRequest) {
+        TaskSpecification restrictedTaskSpecification = TaskSpecification.restricted(
+            taskSearchRequest,
+            securityManager.getAuthenticatedUserId(),
+            securityManager.getAuthenticatedUserGroups()
+        );
+
+        return taskRepository.count(restrictedTaskSpecification);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/helper/ProcessInstanceControllerHelper.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/helper/ProcessInstanceControllerHelper.java
@@ -87,4 +87,8 @@ public class ProcessInstanceControllerHelper {
     ) {
         return processInstanceRepository.mapSubprocesses(processInstances, pageable);
     }
+
+    public Long countProcessInstances(ProcessInstanceSearchRequest searchRequest) {
+        return processInstanceService.count(searchRequest);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
@@ -83,6 +83,59 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
     protected abstract String getSearchEndpoint();
 
+    protected abstract String getCountEndpoint();
+
+    @Test
+    public void should_excludeProcessInstances_by_processDefinitionCategoryName() throws Exception {
+        // given
+        ProcessDefinitionEntity processDefinitionToExclude = new ProcessDefinitionEntity();
+        processDefinitionToExclude.setId("proc-def-id-to-exclude");
+        processDefinitionToExclude.setKey("proc-def-key-to-exclude");
+        processDefinitionToExclude.setCategory("CategoryToExclude");
+        processDefinitionRepository.save(processDefinitionToExclude);
+
+        queryTestUtils
+            .buildProcessInstance()
+            .withProcessDefinitionKey(processDefinitionToExclude.getKey())
+            .withInitiator(USER)
+            .buildAndSave();
+
+        ProcessDefinitionEntity processDefinitionToKeep = new ProcessDefinitionEntity();
+        processDefinitionToKeep.setId("proc-def-id-to-keep");
+        processDefinitionToKeep.setKey("proc-def-key-to-keep");
+        processDefinitionToKeep.setCategory("CategoryToKeep");
+        processDefinitionRepository.save(processDefinitionToKeep);
+
+        ProcessInstanceEntity processInstanceToKeep = queryTestUtils
+            .buildProcessInstance()
+            .withProcessDefinitionKey(processDefinitionToKeep.getKey())
+            .withInitiator(USER)
+            .buildAndSave();
+
+        ProcessInstanceSearchRequestBuilder requestBuilder = new ProcessInstanceSearchRequestBuilder()
+            .withExcludeByProcessCategoryName("CategoryToExclude");
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getSearchEndpoint())
+            // then
+            .then()
+            .statusCode(200)
+            .body("_embedded.processInstances", hasSize(1))
+            .body("_embedded.processInstances[0].id", equalTo(processInstanceToKeep.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+    }
+
     @Test
     void should_returnProcessInstances_filteredById() {
         IntStream
@@ -100,6 +153,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, contains("id0", "id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -125,6 +187,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, contains("id1", "id3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -154,6 +225,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -183,6 +263,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -218,6 +307,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem("id1"))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem("id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -241,6 +339,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -264,6 +371,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -287,6 +403,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -310,6 +435,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -333,6 +467,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -356,6 +499,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -379,6 +531,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -402,6 +563,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -439,6 +609,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 0)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -448,6 +627,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -463,6 +651,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 4)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -472,6 +669,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
     }
 
     @Test
@@ -496,6 +702,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables", empty());
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -530,6 +745,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables", hasSize(2))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables.name", hasItem(VAR_NAME))
             .body(PROCESS_INSTANCES_JSON_PATH + "[0].variables.name", hasItem("var3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -572,6 +796,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -613,6 +846,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -650,6 +892,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -688,6 +939,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -726,6 +986,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -764,6 +1033,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -802,6 +1080,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -840,6 +1127,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -879,6 +1175,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -917,6 +1222,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -956,6 +1270,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1010,6 +1333,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1039,6 +1371,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1077,6 +1418,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1115,6 +1465,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body("page.totalElements", equalTo(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1153,6 +1512,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1192,6 +1560,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1230,6 +1607,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1269,6 +1655,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1323,6 +1718,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1352,6 +1756,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1390,6 +1803,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1428,6 +1850,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1466,6 +1897,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1505,6 +1945,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1543,6 +1992,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1582,6 +2040,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1636,6 +2103,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1665,6 +2141,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -1707,6 +2192,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1749,6 +2243,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1791,6 +2294,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1834,6 +2346,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1876,6 +2397,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1919,6 +2449,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1979,6 +2518,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGtEq = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2008,6 +2556,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2046,6 +2603,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2089,6 +2655,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance3.getId(), processInstance2.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("startDate", Sort.Direction.DESC, false, null, null));
@@ -2104,6 +2679,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2153,6 +2737,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2177,6 +2770,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2226,6 +2828,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2250,6 +2861,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance2.getId(), processInstance1.getId(), processInstance3.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2299,6 +2919,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2323,6 +2952,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2372,6 +3010,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance3.getId(), processInstance1.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2396,6 +3043,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance1.getId(), processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2451,6 +3107,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 contains(processInstance2.getId(), processInstance1.getId(), processInstance3.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2475,6 +3140,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 contains(processInstance3.getId(), processInstance1.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -2528,6 +3202,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 containsInRelativeOrder(processInstance2.getId(), processInstance3.getId())
             );
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(
@@ -2556,6 +3239,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 PROCESS_INSTANCE_IDS_JSON_PATH,
                 containsInRelativeOrder(processInstance3.getId(), processInstance2.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     /**
@@ -2636,6 +3328,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             )
             .body("page.totalElements", is(4));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
+
         requestBuilder.invertSort();
 
         given()
@@ -2658,6 +3359,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
                 )
             )
             .body("page.totalElements", is(4));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
     }
 
     @Test
@@ -2673,6 +3383,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(400);
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
+
         requestBuilder =
             new ProcessInstanceSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort(VAR_NAME, Sort.Direction.ASC, true, PROCESS_DEFINITION_KEY, null));
@@ -2684,6 +3403,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .post(getSearchEndpoint())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -2729,6 +3457,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 4)
             .when()
@@ -2745,6 +3482,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 8)
             .when()
@@ -2757,6 +3503,15 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .body("page.totalPages", is(3))
             .body("page.size", is(4))
             .body("page.number", is(2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -2802,5 +3557,14 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .then()
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(10));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
@@ -35,7 +35,6 @@ import org.activiti.QueryRestTestApplication;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
-import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessVariableKey;
 import org.activiti.cloud.services.query.rest.filter.FilterOperator;
@@ -89,56 +88,6 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
     protected abstract String getSearchEndpoint();
 
     protected abstract String getCountEndpoint();
-
-    @Test
-    public void should_excludeProcessInstances_by_processDefinitionCategoryName() {
-        // given
-        ProcessDefinitionEntity processDefinitionToExclude = new ProcessDefinitionEntity();
-        processDefinitionToExclude.setId("proc-def-id-to-exclude");
-        processDefinitionToExclude.setKey("proc-def-key-to-exclude");
-        processDefinitionToExclude.setCategory("CategoryToExclude");
-        processDefinitionRepository.save(processDefinitionToExclude);
-
-        queryTestUtils
-            .buildProcessInstance()
-            .withProcessDefinitionKey(processDefinitionToExclude.getKey())
-            .withInitiator(USER)
-            .buildAndSave();
-
-        ProcessDefinitionEntity processDefinitionToKeep = new ProcessDefinitionEntity();
-        processDefinitionToKeep.setId("proc-def-id-to-keep");
-        processDefinitionToKeep.setKey("proc-def-key-to-keep");
-        processDefinitionToKeep.setCategory("CategoryToKeep");
-        processDefinitionRepository.save(processDefinitionToKeep);
-
-        ProcessInstanceEntity processInstanceToKeep = queryTestUtils
-            .buildProcessInstance()
-            .withProcessDefinitionKey(processDefinitionToKeep.getKey())
-            .withInitiator(USER)
-            .buildAndSave();
-
-        ProcessInstanceSearchRequestBuilder requestBuilder = new ProcessInstanceSearchRequestBuilder();
-
-        given()
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(requestBuilder.buildJson())
-            .when()
-            .post(getSearchEndpoint())
-            // then
-            .then()
-            .statusCode(200)
-            .body("_embedded.processInstances", hasSize(1))
-            .body("_embedded.processInstances[0].id", equalTo(processInstanceToKeep.getId()));
-
-        given()
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(requestBuilder.buildJson())
-            .when()
-            .post(getCountEndpoint())
-            .then()
-            .statusCode(200)
-            .body(equalTo("1"));
-    }
 
     @Test
     void should_returnProcessInstances_filteredById() {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractProcessInstanceEntitySearchControllerIT.java
@@ -34,6 +34,8 @@ import java.util.stream.IntStream;
 import org.activiti.QueryRestTestApplication;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
+import org.activiti.cloud.services.query.model.ProcessDefinitionEntity;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessVariableKey;
 import org.activiti.cloud.services.query.rest.filter.FilterOperator;
@@ -67,6 +69,9 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
     @Autowired
     protected QueryTestUtils queryTestUtils;
 
+    @Autowired
+    private ProcessDefinitionRepository processDefinitionRepository;
+
     protected static final String PROCESS_INSTANCES_JSON_PATH = "_embedded.processInstances";
     protected static final String PROCESS_INSTANCE_IDS_JSON_PATH = "_embedded.processInstances.id";
 
@@ -86,7 +91,7 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
     protected abstract String getCountEndpoint();
 
     @Test
-    public void should_excludeProcessInstances_by_processDefinitionCategoryName() throws Exception {
+    public void should_excludeProcessInstances_by_processDefinitionCategoryName() {
         // given
         ProcessDefinitionEntity processDefinitionToExclude = new ProcessDefinitionEntity();
         processDefinitionToExclude.setId("proc-def-id-to-exclude");
@@ -112,8 +117,7 @@ abstract class AbstractProcessInstanceEntitySearchControllerIT {
             .withInitiator(USER)
             .buildAndSave();
 
-        ProcessInstanceSearchRequestBuilder requestBuilder = new ProcessInstanceSearchRequestBuilder()
-            .withExcludeByProcessCategoryName("CategoryToExclude");
+        ProcessInstanceSearchRequestBuilder requestBuilder = new ProcessInstanceSearchRequestBuilder();
 
         given()
             .contentType(MediaType.APPLICATION_JSON)

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
@@ -70,6 +70,8 @@ public abstract class AbstractTaskControllerIT {
 
     protected abstract String getSearchEndpointHttpPost();
 
+    protected abstract String getCountEndpointHttpPost();
+
     @BeforeEach
     public void setUp() {
         webAppContextSetup(context);
@@ -79,6 +81,46 @@ public abstract class AbstractTaskControllerIT {
     @AfterEach
     public void cleanUp() {
         queryTestUtils.cleanUp();
+    }
+
+    @Test
+    void should_return400_whenInvalidSearchParameterIsProvided() {
+        String missingSortField =
+            """
+                {
+                    "sort": {
+                        "direction": "ASC",
+                        "isProcessVariable": false,
+                        "processDefinitionKey": null,
+                        "type": "bigdecimal",
+                        "processVariable": false
+                    }
+                }""";
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(missingSortField)
+            .when()
+            .post(getSearchEndpointHttpPost())
+            .then()
+            .statusCode(400)
+            .expect(
+                content()
+                    .string(
+                        is(
+                            "Invalid search parameter: Could not resolve attribute 'null' of 'org.activiti.cloud.services.query.model.TaskEntity'"
+                        )
+                    )
+            );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(missingSortField)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -142,6 +184,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 0)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -151,6 +202,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -166,6 +226,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("skipCount", 4)
             .param("maxItems", 2)
             .body(requestBuilder.buildJson())
@@ -175,6 +244,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body("page.totalElements", equalTo(5));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("5"));
     }
 
     @Test
@@ -208,6 +286,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables", hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables[0].name", is(VAR_NAME));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -227,6 +314,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains("id0", "id2"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -257,6 +353,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -306,6 +411,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -343,6 +457,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables", hasSize(1))
             .body(TASKS_JSON_PATH + "[0].processVariables[0].name", is(VAR_NAME));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -384,6 +507,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -425,6 +557,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -466,6 +607,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -509,6 +659,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(200)
             .body("page.totalElements", equalTo(0));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -547,6 +706,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -582,6 +750,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -620,6 +797,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -656,6 +842,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -694,6 +889,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -735,6 +939,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -778,6 +991,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -812,6 +1034,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -855,6 +1086,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -890,6 +1130,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -934,6 +1183,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -953,6 +1211,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -989,6 +1256,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1008,6 +1284,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1052,6 +1337,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1071,6 +1365,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1101,6 +1404,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1120,6 +1432,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1165,6 +1486,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1191,6 +1521,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1228,6 +1567,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(null, VAR_NAME, VariableType.INTEGER, String.valueOf(42), FilterOperator.GREATER_THAN),
             new VariableFilter(
@@ -1248,6 +1596,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1293,6 +1650,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1329,6 +1695,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1374,6 +1749,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1412,6 +1796,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1456,6 +1849,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1475,6 +1877,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1511,6 +1922,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -1530,6 +1950,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1574,6 +2003,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -1593,6 +2031,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1629,6 +2076,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -1648,6 +2104,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -1694,6 +2159,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -1720,6 +2194,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1764,6 +2247,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -1790,6 +2282,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1833,6 +2334,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1868,6 +2378,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1911,6 +2430,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1947,6 +2475,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -1993,6 +2530,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2012,6 +2558,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2049,6 +2604,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2068,6 +2632,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2114,6 +2687,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2133,6 +2715,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2170,6 +2761,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2189,6 +2789,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2236,6 +2845,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -2262,6 +2880,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2300,6 +2927,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(null, VAR_NAME, VariableType.DATE, "2024-08-02", FilterOperator.GREATER_THAN),
             new VariableFilter(null, VAR_NAME, VariableType.DATE, "2024-08-04", FilterOperator.LESS_THAN_OR_EQUAL)
@@ -2314,6 +2950,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2363,6 +3008,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2402,6 +3056,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2451,6 +3114,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2491,6 +3163,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2543,6 +3224,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2562,6 +3252,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2603,6 +3302,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterGte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2622,6 +3330,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2674,6 +3391,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             PROCESS_DEFINITION_KEY,
             VAR_NAME,
@@ -2693,6 +3419,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2734,6 +3469,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         VariableFilter filterLte = new VariableFilter(
             null,
             VAR_NAME,
@@ -2753,6 +3497,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -2803,6 +3556,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withProcessVariableFilters(
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -2829,6 +3591,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2877,6 +3648,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         taskSearchRequestBuilder.withTaskVariableFilters(
             new VariableFilter(
                 null,
@@ -2903,6 +3683,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -2949,6 +3738,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         variableFilter =
             new VariableFilter(
                 PROCESS_DEFINITION_KEY,
@@ -2969,6 +3767,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3006,6 +3813,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
+
         variableFilter =
             new VariableFilter(null, VAR_NAME, VariableType.BOOLEAN, String.valueOf(false), FilterOperator.EQUALS);
 
@@ -3020,6 +3836,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3039,6 +3864,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3057,6 +3891,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("1"));
     }
 
     @Test
@@ -3076,6 +3919,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3096,6 +3948,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3116,6 +3977,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3135,6 +4005,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3155,6 +4034,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3175,6 +4063,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3205,6 +4102,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3225,6 +4131,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3245,6 +4160,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3265,6 +4189,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3285,6 +4218,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3305,6 +4247,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3325,6 +4276,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3345,6 +4305,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3365,6 +4334,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3385,6 +4363,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3405,6 +4392,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3435,6 +4431,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3465,6 +4470,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -3487,6 +4501,15 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(400)
+            .body(equalTo(""));
     }
 
     @Test
@@ -3531,6 +4554,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("priority", Sort.Direction.DESC, false, null, null));
@@ -3544,6 +4576,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
@@ -3559,6 +4600,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         taskSearchRequestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort("lastModified", Sort.Direction.DESC, false, null, null));
@@ -3572,6 +4622,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3621,6 +4680,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3642,6 +4710,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3691,6 +4768,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3712,6 +4798,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3761,6 +4856,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_3, TASK_ID_2));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3782,6 +4886,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_3, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3831,6 +4944,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3852,6 +4974,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_3, TASK_ID_2, TASK_ID_1));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3907,6 +5038,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_1, TASK_ID_3));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3928,6 +5068,15 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_3, TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -3969,6 +5118,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_2, TASK_ID_1));
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(
@@ -3990,12 +5148,21 @@ public abstract class AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(2))
             .body(TASK_IDS_JSON_PATH, contains(TASK_ID_1, TASK_ID_2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     /**
      * From Postgres documentation: https://www.postgresql.org/docs/current/queries-order.html
-     *  By default, null values sort as if larger than any non-null value;
-     *  that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.
+     * By default, null values sort as if larger than any non-null value;
+     * that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.
      */
     @Test
     void should_returnTasks_sortedByProcessVariables_respectingDefaultNullBehaviour() {
@@ -4040,8 +5207,40 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(200)
-            .body(TASKS_JSON_PATH, hasSize(8))
-            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("0", "1", "2", "3"));
+            .body(TASKS_JSON_PATH, hasSize(4))
+            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("1", "2", "3", "0"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
+
+        requestBuilder.invertSort();
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("maxItems", 8)
+            .param("skipCount", 0)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getSearchEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(TASKS_JSON_PATH, hasSize(4))
+            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("3", "2", "1", "0"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("4"));
     }
 
     @Test
@@ -4057,6 +5256,15 @@ public abstract class AbstractTaskControllerIT {
             .then()
             .statusCode(400);
 
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
+
         requestBuilder =
             new TaskSearchRequestBuilder()
                 .withSort(new CloudRuntimeEntitySort(VAR_NAME, Sort.Direction.ASC, true, PROCESS_DEFINITION_KEY, null));
@@ -4068,6 +5276,15 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(400);
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("0"));
     }
 
     @Test
@@ -4115,6 +5332,15 @@ public abstract class AbstractTaskControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 4)
             .when()
@@ -4131,6 +5357,15 @@ public abstract class AbstractTaskControllerIT {
         given()
             .contentType(MediaType.APPLICATION_JSON)
             .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
             .param("maxItems", 4)
             .param("skipCount", 8)
             .when()
@@ -4143,6 +5378,15 @@ public abstract class AbstractTaskControllerIT {
             .body("page.totalPages", is(3))
             .body("page.size", is(4))
             .body("page.number", is(2));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(taskSearchRequestBuilder.buildJson())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -4223,6 +5467,15 @@ public abstract class AbstractTaskControllerIT {
                 TASK_IDS_JSON_PATH,
                 contains(IntStream.range(0, 10).mapToObj(String::valueOf).toList().reversed().toArray())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(request)
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("10"));
     }
 
     @Test
@@ -4309,6 +5562,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4319,6 +5581,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("1"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         requestBuilder.invertSort();
 
@@ -4337,6 +5608,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4347,6 +5627,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("2"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test
@@ -4438,6 +5727,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4448,6 +5746,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("1"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
 
         requestBuilder.invertSort();
 
@@ -4466,6 +5773,15 @@ public abstract class AbstractTaskControllerIT {
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
             .param("maxItems", 2)
             .param("skipCount", 2)
             .body(requestBuilder.build())
@@ -4476,6 +5792,15 @@ public abstract class AbstractTaskControllerIT {
             .body(TASKS_JSON_PATH, hasSize(1))
             .body(TASK_IDS_JSON_PATH, contains("2"))
             .body("page.totalElements", is(3));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.build())
+            .when()
+            .post(getCountEndpointHttpPost())
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -96,22 +97,6 @@ public abstract class AbstractTaskControllerIT {
                         "processVariable": false
                     }
                 }""";
-
-        given()
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(missingSortField)
-            .when()
-            .post(getSearchEndpointHttpPost())
-            .then()
-            .statusCode(400)
-            .expect(
-                content()
-                    .string(
-                        is(
-                            "Invalid search parameter: Could not resolve attribute 'null' of 'org.activiti.cloud.services.query.model.TaskEntity'"
-                        )
-                    )
-            );
 
         given()
             .contentType(MediaType.APPLICATION_JSON)

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/AbstractTaskControllerIT.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -5192,8 +5191,8 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(200)
-            .body(TASKS_JSON_PATH, hasSize(4))
-            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("1", "2", "3", "0"));
+            .body(TASKS_JSON_PATH, hasSize(8))
+            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("0", "1", "2", "3"));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -5202,7 +5201,7 @@ public abstract class AbstractTaskControllerIT {
             .post(getCountEndpointHttpPost())
             .then()
             .statusCode(200)
-            .body(equalTo("4"));
+            .body(equalTo("10"));
 
         requestBuilder.invertSort();
 
@@ -5215,8 +5214,7 @@ public abstract class AbstractTaskControllerIT {
             .post(getSearchEndpointHttpPost())
             .then()
             .statusCode(200)
-            .body(TASKS_JSON_PATH, hasSize(4))
-            .body(TASK_IDS_JSON_PATH + "[0,1,2,3]", contains("3", "2", "1", "0"));
+            .body(TASKS_JSON_PATH, hasSize(8));
 
         given()
             .contentType(MediaType.APPLICATION_JSON)
@@ -5225,7 +5223,7 @@ public abstract class AbstractTaskControllerIT {
             .post(getCountEndpointHttpPost())
             .then()
             .statusCode(200)
-            .body(equalTo("4"));
+            .body(equalTo("10"));
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -55,6 +56,11 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
         return "/admin/v1/process-instances/search";
     }
 
+    @Override
+    protected String getCountEndpoint() {
+        return "/admin/v1/process-instances/count";
+    }
+
     @Test
     void should_return_AllProcessInstances() {
         ProcessInstanceEntity processInstance1 = queryTestUtils
@@ -76,6 +82,15 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 
     @Test
@@ -103,5 +118,14 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(equalTo("2"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchControllerIT.java
@@ -24,6 +24,7 @@ import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.util.ProcessInstanceSearchRequestBuilder;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -56,6 +57,11 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
         return "/v1/process-instances/search";
     }
 
+    @Override
+    protected String getCountEndpoint() {
+        return "/v1/process-instances/count";
+    }
+
     @Test
     void should_return_RestrictedProcessInstances() {
         ProcessInstanceEntity processInstance1 = queryTestUtils
@@ -73,6 +79,15 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
             .statusCode(200)
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(1))
             .body("_embedded.processInstances[0].id", equalTo(processInstance1.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("1"));
     }
 
     @Test
@@ -106,5 +121,14 @@ class ProcessInstanceEntitySearchControllerIT extends AbstractProcessInstanceEnt
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance1.getId()))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(processInstance2.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getCountEndpoint())
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("2"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.rest;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -59,8 +60,13 @@ class TaskAdminControllerIT extends AbstractTaskControllerIT {
         return "/admin/v1/tasks/search";
     }
 
+    @Override
+    protected String getCountEndpointHttpPost() {
+        return "/admin/v1/tasks/count";
+    }
+
     @Test
-    void should_returnTasks_unrestrictedTasks() {
+    void should_returnTasksAndCount_unrestrictedTasks() {
         String otherUser = "other-user";
 
         TaskEntity task1 = queryTestUtils.buildTask().withOwner(otherUser).buildAndSave();
@@ -78,5 +84,14 @@ class TaskAdminControllerIT extends AbstractTaskControllerIT {
             .statusCode(200)
             .body(TASKS_JSON_PATH, hasSize(3))
             .body(TASK_IDS_JSON_PATH, containsInAnyOrder(task1.getId(), task2.getId(), task3.getId()));
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post("/admin/v1/tasks/count")
+            .then()
+            .statusCode(200)
+            .body(equalTo("3"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerIT.java
@@ -25,6 +25,7 @@ import org.activiti.QueryRestTestApplication;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.TaskEntity;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -67,8 +68,13 @@ class TaskControllerIT extends AbstractTaskControllerIT {
         return "/v1/tasks/search";
     }
 
+    @Override
+    protected String getCountEndpointHttpPost() {
+        return "/v1/tasks/count";
+    }
+
     @Test
-    void should_returnTasks_restrictedToCurrentUser() {
+    void should_returnTasksAndCount_restrictedToCurrentUser() {
         String otherUser = "other-user";
         String testgroup = "testgroup";
         Mockito.when(securityManager.getAuthenticatedUserGroups()).thenReturn(List.of(testgroup));
@@ -106,5 +112,14 @@ class TaskControllerIT extends AbstractTaskControllerIT {
                 TASK_IDS_JSON_PATH,
                 containsInAnyOrder(task1.getId(), task2.getId(), task4.getId(), task6.getId(), task7.getId())
             );
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post("/v1/tasks/count")
+            .then()
+            .statusCode(200)
+            .body(IsEqual.equalTo("5"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -115,6 +115,82 @@
         ]
       }
     },
+    "/v1/tasks/count": {
+      "post": {
+        "tags": [
+          "task-controller"
+        ],
+        "summary": "Count tasks",
+        "operationId": "countTasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
     "/v1/process-instances/search": {
       "post": {
         "tags": [
@@ -205,6 +281,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudProcessInstance_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/v1/process-instances/count": {
+      "post": {
+        "tags": [
+          "process-instance-controller"
+        ],
+        "summary": "Count process instances",
+        "operationId": "countProcessInstances",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -1490,6 +1642,82 @@
         ]
       }
     },
+    "/admin/v1/tasks/count": {
+      "post": {
+        "tags": [
+          "task-admin-controller"
+        ],
+        "summary": "Count tasks",
+        "operationId": "countTasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
     "/admin/v1/process-instances": {
       "get": {
         "tags": [
@@ -2482,6 +2710,82 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResponseContentQueryCloudProcessInstance_ProcessVariables"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "oauth": []
+          }
+        ]
+      }
+    },
+    "/admin/v1/process-instances/count": {
+      "post": {
+        "tags": [
+          "process-instance-admin-controller"
+        ],
+        "summary": "Count process instances",
+        "operationId": "searchProcessInstances",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessInstanceSearchRequest_ProcessVariables"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryResponseContentActivitiErrorMessage"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
                 }
               }
             }
@@ -6677,12 +6981,6 @@
         "title": "CloudVariableInstance_ProcessVariables",
         "type": "object",
         "properties": {
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -6690,6 +6988,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -6704,13 +7008,13 @@
           "type": {
             "type": "string"
           },
-          "processInstanceId": {
-            "type": "string"
-          },
           "taskVariable": {
             "type": "boolean"
           },
           "taskId": {
+            "type": "string"
+          },
+          "processInstanceId": {
             "type": "string"
           }
         }
@@ -6799,12 +7103,6 @@
           "processDefinitionName": {
             "type": "string"
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -6812,6 +7110,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -6837,14 +7141,48 @@
           "standalone": {
             "type": "boolean"
           },
-          "completedDate": {
+          "createdDate": {
             "type": "string",
             "format": "date-time"
           },
-          "processDefinitionId": {
+          "claimedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "CREATED",
+              "ASSIGNED",
+              "SUSPENDED",
+              "COMPLETED",
+              "CANCELLED",
+              "DELETED"
+            ]
+          },
+          "completedBy": {
             "type": "string"
           },
-          "processInstanceId": {
+          "assignee": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "formKey": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "taskDefinitionKey": {
+            "type": "string"
+          },
+          "processDefinitionId": {
             "type": "string"
           },
           "candidateUsers": {
@@ -6859,48 +7197,14 @@
               "type": "string"
             }
           },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "parentTaskId": {
             "type": "string"
           },
-          "taskDefinitionKey": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "claimedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "completedBy": {
-            "type": "string"
-          },
-          "businessKey": {
-            "type": "string"
-          },
-          "assignee": {
-            "type": "string"
-          },
-          "formKey": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "CREATED",
-              "ASSIGNED",
-              "SUSPENDED",
-              "COMPLETED",
-              "CANCELLED",
-              "DELETED"
-            ]
-          },
-          "description": {
+          "processInstanceId": {
             "type": "string"
           },
           "processDefinitionVersion": {
@@ -7064,12 +7368,6 @@
               "$ref": "#/components/schemas/QueryCloudSubprocessInstance_ProcessVariables"
             }
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7077,6 +7375,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7088,22 +7392,12 @@
           "id": {
             "type": "string"
           },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "processDefinitionId": {
-            "type": "string"
-          },
-          "initiator": {
-            "type": "string"
-          },
-          "businessKey": {
-            "type": "string"
-          },
           "startDate": {
             "type": "string",
             "format": "date-time"
+          },
+          "initiator": {
+            "type": "string"
           },
           "status": {
             "type": "string",
@@ -7118,15 +7412,25 @@
           "parentId": {
             "type": "string"
           },
+          "businessKey": {
+            "type": "string"
+          },
+          "processDefinitionId": {
+            "type": "string"
+          },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
           "processDefinitionName": {
             "type": "string"
           },
           "processDefinitionKey": {
             "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
           }
         }
       },
@@ -7192,12 +7496,6 @@
         "title": "CloudVariableInstance",
         "type": "object",
         "properties": {
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7205,6 +7503,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7219,13 +7523,13 @@
           "type": {
             "type": "string"
           },
-          "processInstanceId": {
-            "type": "string"
-          },
           "taskVariable": {
             "type": "boolean"
           },
           "taskId": {
+            "type": "string"
+          },
+          "processInstanceId": {
             "type": "string"
           }
         }
@@ -7292,12 +7596,6 @@
         "title": "CloudVariableInstance_General",
         "type": "object",
         "properties": {
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7305,6 +7603,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7319,13 +7623,13 @@
           "type": {
             "type": "string"
           },
-          "processInstanceId": {
-            "type": "string"
-          },
           "taskVariable": {
             "type": "boolean"
           },
           "taskId": {
+            "type": "string"
+          },
+          "processInstanceId": {
             "type": "string"
           }
         }
@@ -7365,12 +7669,6 @@
           "processDefinitionName": {
             "type": "string"
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7378,6 +7676,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7403,14 +7707,48 @@
           "standalone": {
             "type": "boolean"
           },
-          "completedDate": {
+          "createdDate": {
             "type": "string",
             "format": "date-time"
           },
-          "processDefinitionId": {
+          "claimedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "CREATED",
+              "ASSIGNED",
+              "SUSPENDED",
+              "COMPLETED",
+              "CANCELLED",
+              "DELETED"
+            ]
+          },
+          "completedBy": {
             "type": "string"
           },
-          "processInstanceId": {
+          "assignee": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "formKey": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "taskDefinitionKey": {
+            "type": "string"
+          },
+          "processDefinitionId": {
             "type": "string"
           },
           "candidateUsers": {
@@ -7425,48 +7763,14 @@
               "type": "string"
             }
           },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
           "parentTaskId": {
             "type": "string"
           },
-          "taskDefinitionKey": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "dueDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "claimedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "completedBy": {
-            "type": "string"
-          },
-          "businessKey": {
-            "type": "string"
-          },
-          "assignee": {
-            "type": "string"
-          },
-          "formKey": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "CREATED",
-              "ASSIGNED",
-              "SUSPENDED",
-              "COMPLETED",
-              "CANCELLED",
-              "DELETED"
-            ]
-          },
-          "description": {
+          "processInstanceId": {
             "type": "string"
           },
           "processDefinitionVersion": {
@@ -7495,12 +7799,6 @@
               "$ref": "#/components/schemas/QueryCloudSubprocessInstance_General"
             }
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7508,6 +7806,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7519,22 +7823,12 @@
           "id": {
             "type": "string"
           },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "processDefinitionId": {
-            "type": "string"
-          },
-          "initiator": {
-            "type": "string"
-          },
-          "businessKey": {
-            "type": "string"
-          },
           "startDate": {
             "type": "string",
             "format": "date-time"
+          },
+          "initiator": {
+            "type": "string"
           },
           "status": {
             "type": "string",
@@ -7549,15 +7843,25 @@
           "parentId": {
             "type": "string"
           },
+          "businessKey": {
+            "type": "string"
+          },
+          "processDefinitionId": {
+            "type": "string"
+          },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
           "processDefinitionName": {
             "type": "string"
           },
           "processDefinitionKey": {
             "type": "string"
-          },
-          "processDefinitionVersion": {
-            "type": "integer",
-            "format": "int32"
           }
         }
       },
@@ -7626,12 +7930,6 @@
         "title": "CloudProcessDefinition",
         "type": "object",
         "properties": {
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
-            "type": "string"
-          },
           "appName": {
             "type": "string"
           },
@@ -7639,6 +7937,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           },
           "appVersion": {
@@ -7657,13 +7961,13 @@
             "type": "integer",
             "format": "int32"
           },
+          "description": {
+            "type": "string"
+          },
           "formKey": {
             "type": "string"
           },
           "category": {
-            "type": "string"
-          },
-          "description": {
             "type": "string"
           }
         }
@@ -7756,20 +8060,9 @@
           "id": {
             "type": "string"
           },
-          "completedDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "cancelledDate": {
-            "type": "string",
-            "format": "date-time"
-          },
           "startedDate": {
             "type": "string",
             "format": "date-time"
-          },
-          "businessKey": {
-            "type": "string"
           },
           "status": {
             "type": "string",
@@ -7780,17 +8073,22 @@
               "ERROR"
             ]
           },
-          "processDefinitionKey": {
+          "businessKey": {
             "type": "string"
+          },
+          "completedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cancelledDate": {
+            "type": "string",
+            "format": "date-time"
           },
           "processDefinitionVersion": {
             "type": "integer",
             "format": "int32"
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
+          "processDefinitionKey": {
             "type": "string"
           },
           "appName": {
@@ -7802,25 +8100,31 @@
           "serviceType": {
             "type": "string"
           },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
+            "type": "string"
+          },
           "appVersion": {
             "type": "string"
           },
-          "activityName": {
+          "executionId": {
             "type": "string"
           },
           "activityType": {
             "type": "string"
           },
-          "executionId": {
+          "activityName": {
+            "type": "string"
+          },
+          "elementId": {
             "type": "string"
           },
           "processDefinitionId": {
             "type": "string"
           },
           "processInstanceId": {
-            "type": "string"
-          },
-          "elementId": {
             "type": "string"
           }
         }
@@ -7865,7 +8169,27 @@
           "errorMessage": {
             "type": "string"
           },
-          "errorClassName": {
+          "requestDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resultDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "errorDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "INTEGRATION_REQUESTED",
+              "INTEGRATION_RESULT_RECEIVED",
+              "INTEGRATION_ERROR_RECEIVED"
+            ]
+          },
+          "errorCode": {
             "type": "string"
           },
           "stackTraceElements": {
@@ -7901,30 +8225,28 @@
               }
             }
           },
-          "requestDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "resultDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "errorDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "INTEGRATION_REQUESTED",
-              "INTEGRATION_RESULT_RECEIVED",
-              "INTEGRATION_ERROR_RECEIVED"
-            ]
-          },
-          "errorCode": {
+          "errorClassName": {
             "type": "string"
           },
           "id": {
+            "type": "string"
+          },
+          "clientName": {
+            "type": "string"
+          },
+          "appVersion": {
+            "type": "string"
+          },
+          "businessKey": {
+            "type": "string"
+          },
+          "executionId": {
+            "type": "string"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "clientType": {
             "type": "string"
           },
           "processDefinitionId": {
@@ -7948,41 +8270,17 @@
               "type": "object"
             }
           },
-          "clientType": {
-            "type": "string"
-          },
-          "executionId": {
-            "type": "string"
-          },
-          "businessKey": {
-            "type": "string"
-          },
-          "appVersion": {
-            "type": "string"
-          },
-          "clientId": {
-            "type": "string"
-          },
-          "clientName": {
-            "type": "string"
-          },
-          "processDefinitionKey": {
-            "type": "string"
-          },
-          "parentProcessInstanceId": {
-            "type": "string"
-          },
           "processDefinitionVersion": {
             "type": "integer",
             "format": "int32"
           },
+          "processDefinitionKey": {
+            "type": "string"
+          },
           "rootProcessInstanceId": {
             "type": "string"
           },
-          "serviceFullName": {
-            "type": "string"
-          },
-          "serviceVersion": {
+          "parentProcessInstanceId": {
             "type": "string"
           },
           "appName": {
@@ -7992,6 +8290,12 @@
             "type": "string"
           },
           "serviceType": {
+            "type": "string"
+          },
+          "serviceFullName": {
+            "type": "string"
+          },
+          "serviceVersion": {
             "type": "string"
           }
         }


### PR DESCRIPTION
Porting the changes done in https://github.com/Activiti/activiti-cloud/pull/1891 to `8.7.x`.
Issue link: https://hyland.atlassian.net/browse/AAE-37326

Added four new APIs:
/v1/tasks/count
/v1/process-instances/count
/admin/v1/process-instances/count
/admin/v1/tasks/count

to increase performance in getting tasks and process-instances notification numbers.