### PR TITLE
AAE-37542 Add entity_id index on audit tables

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/16-alter.oracle.schema.8.8.1.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/16-alter.oracle.schema.8.8.1.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS audit_event_entity_id_idx ON audit_event USING btree (entity_id)

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/16-alter.pg.schema.8.8.1.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/16-alter.pg.schema.8.8.1.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS audit_event_entity_id_idx ON audit_event USING btree (entity_id)

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
@@ -54,3 +54,5 @@ create table audit_event
 );
 
 CREATE INDEX audit_event_event_id_idx ON audit_event(event_id);
+
+CREATE INDEX IF NOT EXISTS audit_event_entity_id_idx ON audit_event USING btree (entity_id)

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
@@ -276,4 +276,22 @@
              splitStatements="false"
              stripComments="true"/>
   </changeSet>
+  <changeSet author="activiti-audit" runInTransaction="false"
+             id="alter16-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+             encoding="utf8"
+             path="changelog/16-alter.pg.schema.8.8.1.sql"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+  <changeSet author="activiti-audit" runInTransaction="false"
+             id="alter16-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+             encoding="utf8"
+             path="changelog/16-alter.oracle.schema.8.8.1.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"
+             stripComments="true"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Added index on entity_id to improve performance of queries filtering by this column.
Issue Link: https://hyland.atlassian.net/browse/AAE-37542