### PR TITLE
AAE-38295 Implement RabbitMq prefix in Activiti Cloud Messaging configuration

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>activiti-cloud-services-test-liquibase</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-binder</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/pom.xml
@@ -29,6 +29,11 @@
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-starter-audit-consumer</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-liquibase</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
@@ -61,6 +61,6 @@ public class QueryConsumerApplicationFunctionRouterIT extends QueryConsumerAppli
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().hasSize(1).containsOnlyKeys("consumer");
+        assertThat(binderFactoryListenerTestContext.getQueues()).isNotEmpty().hasSize(1).containsOnlyKeys("consumer");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
@@ -17,35 +17,12 @@ package org.activiti.cloud.query.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingProperties;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
-@Testcontainers
 public class QueryConsumerApplicationFunctionRouterIT extends QueryConsumerApplicationIT {
-
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
-
-    @Autowired
-    private BindingServiceProperties bindingServiceProperties;
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     void bindingServiceProperties() {
@@ -79,5 +56,11 @@ public class QueryConsumerApplicationFunctionRouterIT extends QueryConsumerAppli
                     .isNotEmpty()
             );
         assertThat(functionRouter.registrations("functionRouterAnonymousInput")).isEmpty();
+    }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().hasSize(1).containsOnlyKeys("consumer");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.query.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT extends QueryConsumerApplicationFunctionRouterIT {
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.consumer");
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
+}

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -40,12 +40,14 @@ public class QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT extends Quer
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.consumer");
+        assertThat(binderFactoryListenerTestContext.getQueues()).isNotEmpty().containsOnlyKeys("default-app.consumer");
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -23,6 +23,8 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -41,6 +43,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 @SpringBootTest(classes = { QueryConsumerApplication.class })
 @CleanupLiquibaseAfterTest
 @Import(QueryConsumerApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryConsumerApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -17,20 +17,79 @@ package org.activiti.cloud.query.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @SpringBootTest(classes = { QueryConsumerApplication.class })
+@Import(QueryConsumerApplicationIT.BinderFactoryListenerConfiguration.class)
 public class QueryConsumerApplicationIT {
 
-    @Autowired
-    private Environment environment;
+    @Container
+    @ServiceConnection
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
+    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+
+    @TestConfiguration
+    static class BinderFactoryListenerConfiguration {
+
+        @Bean
+        DeclarableCustomizer declarableCustomizer() {
+            return declarable -> {
+                if (declarable instanceof AnonymousQueue queue) {
+                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Queue queue) {
+                    queues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Exchange exchange) {
+                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+                }
+
+                return declarable;
+            };
+        }
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+        anonQueues.clear();
+    }
 
     @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
+    protected Environment environment;
+
+    @Autowired
+    protected ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    protected BindingServiceProperties bindingServiceProperties;
 
     @Test
     public void contextLoads() {}
@@ -47,5 +106,33 @@ public class QueryConsumerApplicationIT {
     void messagingPropertiesRabbitMqCompression() {
         assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
         assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
+    }
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isNullOrEmpty();
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().hasSize(2).containsOnlyKeys("engineEvents.query", "engineEvents.audit");
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues).isEmpty();
+    }
+
+    @Test
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -20,8 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -36,21 +39,18 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @SpringBootTest(classes = { QueryConsumerApplication.class })
+@CleanupLiquibaseAfterTest
 @Import(QueryConsumerApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryConsumerApplicationIT {
 
-    @Container
     @ServiceConnection
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
-    @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
     static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -23,8 +23,6 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
-import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -43,7 +41,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 @SpringBootTest(classes = { QueryConsumerApplication.class })
 @CleanupLiquibaseAfterTest
 @Import(QueryConsumerApplicationIT.BinderFactoryListenerConfiguration.class)
-@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryConsumerApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -17,32 +17,24 @@ package org.activiti.cloud.query.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
-import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
-import org.junit.jupiter.api.AfterAll;
+import org.activiti.cloud.services.test.liquibase.EnableCleanupLiquibaseAfterTest;
+import org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestContext;
+import org.activiti.cloud.starters.test.binder.EnableBinderFactoryListenerTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.ResourceLocks;
-import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.DeclarableCustomizer;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
 
 @SpringBootTest(classes = { QueryConsumerApplication.class })
-@CleanupLiquibaseAfterTest
-@Import(QueryConsumerApplicationIT.BinderFactoryListenerConfiguration.class)
+@EnableCleanupLiquibaseAfterTest
+@EnableBinderFactoryListenerTestContext
 @ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryConsumerApplicationIT {
 
@@ -52,35 +44,8 @@ public class QueryConsumerApplicationIT {
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
-    static final Map<String, Queue> queues = new LinkedHashMap<>();
-    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
-    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
-
-    @TestConfiguration
-    static class BinderFactoryListenerConfiguration {
-
-        @Bean
-        DeclarableCustomizer declarableCustomizer() {
-            return declarable -> {
-                if (declarable instanceof AnonymousQueue queue) {
-                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Queue queue) {
-                    queues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Exchange exchange) {
-                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
-                }
-
-                return declarable;
-            };
-        }
-    }
-
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        exchanges.clear();
-        anonQueues.clear();
-    }
+    @Autowired
+    protected BinderFactoryListenerTestContext binderFactoryListenerTestContext;
 
     @Autowired
     protected Environment environment;
@@ -123,16 +88,19 @@ public class QueryConsumerApplicationIT {
 
     @Test
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().hasSize(2).containsOnlyKeys("engineEvents.query", "engineEvents.audit");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .hasSize(2)
+            .containsOnlyKeys("engineEvents.query", "engineEvents.audit");
     }
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
     }
 
     @Test
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges()).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.query.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class QueryConsumerApplicationRabbitmqPrefixIT extends QueryConsumerApplicationIT {
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents.query", "default-app.engineEvents.audit");
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
+}

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
@@ -40,7 +40,7 @@ public class QueryConsumerApplicationRabbitmqPrefixIT extends QueryConsumerAppli
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .containsOnlyKeys("default-app.engineEvents.query", "default-app.engineEvents.audit");
     }
@@ -48,6 +48,8 @@ public class QueryConsumerApplicationRabbitmqPrefixIT extends QueryConsumerAppli
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
@@ -20,10 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
-@Testcontainers
 public class QueryRestApplicationFunctionRouterIT extends QueryRestApplicationIT {
 
     @Test

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
@@ -58,11 +58,12 @@ public class QueryRestApplicationFunctionRouterIT extends QueryRestApplicationIT
 
     @Test
     void rabbitQueues() {
-        assertThat(queues).satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("consumer.")));
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("consumer.")));
     }
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterIT.java
@@ -18,36 +18,13 @@ package org.activiti.cloud.query.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@TestPropertySource(
-    properties = { "activiti.cloud.messaging.function-router.enabled=true", "spring.sql.init.mode=always" }
-)
+@TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
 @Testcontainers
 public class QueryRestApplicationFunctionRouterIT extends QueryRestApplicationIT {
-
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
-
-    @Autowired
-    private BindingServiceProperties bindingServiceProperties;
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     void bindingServiceProperties() {
@@ -79,5 +56,15 @@ public class QueryRestApplicationFunctionRouterIT extends QueryRestApplicationIT
                     .containsOnly("engineEventsGraphQlSourceConsumer_registration")
                     .isNotEmpty()
             );
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues).satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("consumer.")));
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues).isEmpty();
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.query.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class QueryRestApplicationFunctionRouterRabbitmqPrefixIT extends QueryRestApplicationFunctionRouterIT {
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.consumer.")));
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
+}

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -40,13 +40,15 @@ public class QueryRestApplicationFunctionRouterRabbitmqPrefixIT extends QueryRes
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.consumer.")));
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -28,6 +28,7 @@ import com.introproventures.graphql.jpa.query.web.GraphQLController;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
@@ -35,11 +36,21 @@ import org.activiti.cloud.services.notifications.graphql.web.api.GraphQLQueryRes
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -53,14 +64,58 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(
     classes = { QueryRestApplication.class },
-    properties = "identity.test.token-interceptor.enabled=false",
+    properties = { "identity.test.token-interceptor.enabled=false", "spring.sql.init.mode=always" },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Testcontainers
+@Import(QueryRestApplicationIT.BinderFactoryListenerConfiguration.class)
 public class QueryRestApplicationIT {
+
+    @Container
+    @ServiceConnection
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
+    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+
+    @TestConfiguration
+    static class BinderFactoryListenerConfiguration {
+
+        @Bean
+        DeclarableCustomizer declarableCustomizer() {
+            return declarable -> {
+                if (declarable instanceof AnonymousQueue queue) {
+                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Queue queue) {
+                    queues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Exchange exchange) {
+                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+                }
+
+                return declarable;
+            };
+        }
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+        anonQueues.clear();
+    }
 
     @Autowired
     private WebApplicationContext context;
@@ -81,10 +136,13 @@ public class QueryRestApplicationIT {
     private GraphQLSchema graphQLSchema;
 
     @Autowired
-    private Environment environment;
+    protected Environment environment;
 
     @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
+    protected ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    protected BindingServiceProperties bindingServiceProperties;
 
     @Test
     public void contextLoads() {
@@ -245,6 +303,35 @@ public class QueryRestApplicationIT {
     void messagingPropertiesRabbitMqCompression() {
         assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
         assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
+    }
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isNullOrEmpty();
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues).isEmpty();
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues)
+            .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("engineEvents.anonymous.")));
+    }
+
+    @Test
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 
     private HttpEntity entityWithAuthorizationHeader(String user, String password) {

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -39,8 +39,6 @@ import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
-import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -78,7 +76,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @CleanupLiquibaseAfterTest
 @Import(QueryRestApplicationIT.BinderFactoryListenerConfiguration.class)
-@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryRestApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -35,9 +35,12 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.notifications.graphql.web.api.GraphQLQueryResult;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
+import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -66,8 +69,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(
     classes = { QueryRestApplication.class },
@@ -75,17 +76,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Testcontainers
+@CleanupLiquibaseAfterTest
 @Import(QueryRestApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryRestApplicationIT {
 
-    @Container
     @ServiceConnection
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
-    @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
     static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -28,32 +28,25 @@ import com.introproventures.graphql.jpa.query.web.GraphQLController;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.notifications.graphql.web.api.GraphQLQueryResult;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
-import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
+import org.activiti.cloud.services.test.liquibase.EnableCleanupLiquibaseAfterTest;
+import org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestContext;
+import org.activiti.cloud.starters.test.binder.EnableBinderFactoryListenerTestContext;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.ResourceLocks;
-import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.DeclarableCustomizer;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -76,8 +69,8 @@ import org.testcontainers.containers.RabbitMQContainer;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@CleanupLiquibaseAfterTest
-@Import(QueryRestApplicationIT.BinderFactoryListenerConfiguration.class)
+@EnableCleanupLiquibaseAfterTest
+@EnableBinderFactoryListenerTestContext
 @ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryRestApplicationIT {
 
@@ -87,35 +80,8 @@ public class QueryRestApplicationIT {
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
-    static final Map<String, Queue> queues = new LinkedHashMap<>();
-    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
-    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
-
-    @TestConfiguration
-    static class BinderFactoryListenerConfiguration {
-
-        @Bean
-        DeclarableCustomizer declarableCustomizer() {
-            return declarable -> {
-                if (declarable instanceof AnonymousQueue queue) {
-                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Queue queue) {
-                    queues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Exchange exchange) {
-                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
-                }
-
-                return declarable;
-            };
-        }
-    }
-
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        exchanges.clear();
-        anonQueues.clear();
-    }
+    @Autowired
+    protected BinderFactoryListenerTestContext binderFactoryListenerTestContext;
 
     @Autowired
     private WebApplicationContext context;
@@ -320,18 +286,18 @@ public class QueryRestApplicationIT {
 
     @Test
     void rabbitQueues() {
-        assertThat(queues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getQueues()).isEmpty();
     }
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues)
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("engineEvents.anonymous.")));
     }
 
     @Test
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges()).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 
     private HttpEntity entityWithAuthorizationHeader(String user, String password) {

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -39,6 +39,8 @@ import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -76,6 +78,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @CleanupLiquibaseAfterTest
 @Import(QueryRestApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryRestApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationRabbitmqPrefixIT.java
@@ -40,7 +40,7 @@ public class QueryRestApplicationRabbitmqPrefixIT extends QueryRestApplicationIT
     @Test
     @Override
     void anonymousRabbitQueues() {
-        assertThat(anonQueues)
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .satisfies(map ->
                 assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.engineEvents.anonymous."))
             );
@@ -49,6 +49,8 @@ public class QueryRestApplicationRabbitmqPrefixIT extends QueryRestApplicationIT
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationRabbitmqPrefixIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.query.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class QueryRestApplicationRabbitmqPrefixIT extends QueryRestApplicationIT {
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+
+    @Test
+    @Override
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues)
+            .satisfies(map ->
+                assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.engineEvents.anonymous."))
+            );
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
+}

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
@@ -83,4 +83,25 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
                     .isNotEmpty()
             );
     }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .hasSize(2)
+            .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("consumer")));
+    }
+
+    @Test
+    @Override
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues).isEmpty();
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
+    }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
@@ -87,7 +87,7 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .hasSize(2)
             .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("consumer")));
@@ -96,12 +96,12 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
     @Test
     @Override
     void anonymousRabbitQueues() {
-        assertThat(anonQueues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges()).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
@@ -17,35 +17,12 @@ package org.activiti.cloud.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingProperties;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
-@Testcontainers
 public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
-
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
-
-    @Container
-    @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
-
-    @Autowired
-    private BindingServiceProperties bindingServiceProperties;
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     void bindingServiceProperties() {

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
@@ -29,7 +29,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@TestPropertySource(properties = "activiti.cloud.messaging.function-router.enabled=true")
+@TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
 @Testcontainers
 public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
 

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -36,4 +36,19 @@ public class QueryApplicationFunctionRouterRabbitmqPrefixIT extends QueryApplica
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
             .isEqualTo("default-app.");
     }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .hasSize(2)
+            .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.consumer")));
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -40,7 +40,7 @@ public class QueryApplicationFunctionRouterRabbitmqPrefixIT extends QueryApplica
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .hasSize(2)
             .satisfies(map -> assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.consumer")));
@@ -49,6 +49,8 @@ public class QueryApplicationFunctionRouterRabbitmqPrefixIT extends QueryApplica
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
-public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
+public class QueryApplicationFunctionRouterRabbitmqPrefixIT extends QueryApplicationFunctionRouterIT {
 
     @Test
     void messagingRabbitMqPrefixProperties() {

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -23,19 +23,28 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -60,6 +69,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 )
 @Testcontainers
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
+@Import(QueryApplicationIT.BinderFactoryListenerConfiguration.class)
 public class QueryApplicationIT {
 
     @ServiceConnection
@@ -69,6 +79,36 @@ public class QueryApplicationIT {
     @Container
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
+    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+
+    @TestConfiguration
+    static class BinderFactoryListenerConfiguration {
+
+        @Bean
+        DeclarableCustomizer declarableCustomizer() {
+            return declarable -> {
+                if (declarable instanceof AnonymousQueue queue) {
+                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Queue queue) {
+                    queues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Exchange exchange) {
+                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+                }
+
+                return declarable;
+            };
+        }
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+        anonQueues.clear();
+    }
 
     @Autowired
     private WebApplicationContext context;
@@ -174,5 +214,23 @@ public class QueryApplicationIT {
 
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
             .isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().hasSize(2).containsOnlyKeys("engineEvents.query", "engineEvents.audit");
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues)
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map -> assertThat(map.keySet()).anyMatch(key -> key.startsWith("engineEvents.anonymous.")));
+    }
+
+    @Test
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -33,6 +33,8 @@ import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -69,6 +71,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 @CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(QueryApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -23,31 +23,24 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
-import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
+import org.activiti.cloud.services.test.liquibase.EnableCleanupLiquibaseAfterTest;
+import org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestContext;
+import org.activiti.cloud.starters.test.binder.EnableBinderFactoryListenerTestContext;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.ResourceLocks;
-import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.DeclarableCustomizer;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -68,10 +61,10 @@ import org.testcontainers.containers.RabbitMQContainer;
     properties = "identity.test.token-interceptor.enabled=false",
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
-@CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(QueryApplicationIT.BinderFactoryListenerConfiguration.class)
 @ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
+@EnableCleanupLiquibaseAfterTest
+@EnableBinderFactoryListenerTestContext
 public class QueryApplicationIT {
 
     @ServiceConnection
@@ -80,35 +73,8 @@ public class QueryApplicationIT {
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
-    static final Map<String, Queue> queues = new LinkedHashMap<>();
-    static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();
-    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
-
-    @TestConfiguration
-    static class BinderFactoryListenerConfiguration {
-
-        @Bean
-        DeclarableCustomizer declarableCustomizer() {
-            return declarable -> {
-                if (declarable instanceof AnonymousQueue queue) {
-                    anonQueues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Queue queue) {
-                    queues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Exchange exchange) {
-                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
-                }
-
-                return declarable;
-            };
-        }
-    }
-
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        exchanges.clear();
-        anonQueues.clear();
-    }
+    @Autowired
+    protected BinderFactoryListenerTestContext binderFactoryListenerTestContext;
 
     @Autowired
     private WebApplicationContext context;
@@ -218,12 +184,15 @@ public class QueryApplicationIT {
 
     @Test
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().hasSize(2).containsOnlyKeys("engineEvents.query", "engineEvents.audit");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .hasSize(2)
+            .containsOnlyKeys("engineEvents.query", "engineEvents.audit");
     }
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues)
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .isNotEmpty()
             .hasSize(1)
             .satisfies(map -> assertThat(map.keySet()).anyMatch(key -> key.startsWith("engineEvents.anonymous.")));
@@ -231,6 +200,6 @@ public class QueryApplicationIT {
 
     @Test
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges()).isNotEmpty().containsOnlyKeys("engineEvents");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -29,9 +29,12 @@ import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
+import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -59,26 +62,23 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(
     classes = { QueryApplication.class },
     properties = "identity.test.token-interceptor.enabled=false",
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
-@Testcontainers
+@CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(QueryApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryApplicationIT {
 
     @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
-    @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
     static final Map<String, AnonymousQueue> anonQueues = new LinkedHashMap<>();

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -33,8 +33,6 @@ import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
-import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -71,7 +69,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 @CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(QueryApplicationIT.BinderFactoryListenerConfiguration.class)
-@ResourceLocks(value = { @ResourceLock("postgres"), @ResourceLock("rabbitmq") })
 public class QueryApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
@@ -46,14 +48,27 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(
     classes = { QueryApplication.class },
     properties = "identity.test.token-interceptor.enabled=false",
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
+@Testcontainers
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 public class QueryApplicationIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
 
     @Autowired
     private WebApplicationContext context;
@@ -68,10 +83,13 @@ public class QueryApplicationIT {
     private IdentityTokenProducer identityTokenProducer;
 
     @Autowired
-    private Environment environment;
+    protected Environment environment;
 
     @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
+    protected ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    protected BindingServiceProperties bindingServiceProperties;
 
     @Test
     public void contextLoads() {
@@ -142,5 +160,19 @@ public class QueryApplicationIT {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         return new HttpEntity(headers);
+    }
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isNullOrEmpty();
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isNullOrEmpty();
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+@Testcontainers
+public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
+    @Test
+    void messagingProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void environment() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+}

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Alfresco Software, Ltd.
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
@@ -36,4 +36,30 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
             .isEqualTo("default-app.");
     }
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .hasSize(2)
+            .containsOnlyKeys("default-app.engineEvents.query", "default-app.engineEvents.audit");
+    }
+
+    @Test
+    @Override
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues)
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.engineEvents.anonymous."))
+            );
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+    }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
@@ -40,7 +40,7 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .hasSize(2)
             .containsOnlyKeys("default-app.engineEvents.query", "default-app.engineEvents.audit");
@@ -49,7 +49,7 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
     @Test
     @Override
     void anonymousRabbitQueues() {
-        assertThat(anonQueues)
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .isNotEmpty()
             .hasSize(1)
             .satisfies(map ->
@@ -60,6 +60,8 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges).isNotEmpty().containsOnlyKeys("default-app.engineEvents");
+        assertThat(binderFactoryListenerTestContext.getExchanges())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.engineEvents");
     }
 }

--- a/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
+++ b/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>rabbitmq</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-binder</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
+++ b/activiti-cloud-examples/example-cloud-connector/starter/pom.xml
@@ -25,6 +25,21 @@
       <artifactId>spring-cloud-stream-test-binder</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>rabbitmq</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
@@ -17,11 +17,9 @@ package org.activiti.cloud.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
@@ -29,12 +27,6 @@ public class CloudConnectorAppFunctionRouterIT extends CloudConnectorAppIT {
 
     @Autowired
     private BindingServiceProperties bindingServiceProperties;
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
-
-    @Autowired
-    private Environment environment;
 
     @Test
     void contextLoads() {}

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
@@ -29,9 +29,6 @@ public class CloudConnectorAppFunctionRouterIT extends CloudConnectorAppIT {
     private BindingServiceProperties bindingServiceProperties;
 
     @Test
-    void contextLoads() {}
-
-    @Test
     void bindingServiceProperties() {
         assertThat(bindingServiceProperties.getBindings()).doesNotContainKeys("functionRouterInput").isNotEmpty();
     }

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
@@ -27,12 +27,14 @@ public class CloudConnectorAppFunctionRouterRabbitmqPrefixIT extends CloudConnec
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.processing-connector");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.processing-connector");
     }
 
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "default-app.restconnector.POST",

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
@@ -26,6 +26,28 @@ public class CloudConnectorAppFunctionRouterRabbitmqPrefixIT extends CloudConnec
 
     @Test
     @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.processing-connector");
+    }
+
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "default-app.restconnector.POST",
+                "default-app.restConnector.GET",
+                "default-app.test-bpmn-error-connector.throwError",
+                "default-app.test-error-connector.throwError",
+                "default-app.miCloudConnector",
+                "default-app.headers.GET",
+                "default-app.Movies.getMovieDesc",
+                "default-app.ExampleConnector"
+            );
+    }
+
+    @Test
+    @Override
     void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterRabbitmqPrefixIT.java
@@ -13,36 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.cloud.runtime;
+
+package org.activiti.cloud.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
 
-@TestPropertySource(
-    properties = {
-        "activiti.cloud.application.name=default-app",
-        "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}.",
-    }
-)
-public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
-
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
-
-    @Autowired
-    private Environment environment;
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class CloudConnectorAppFunctionRouterRabbitmqPrefixIT extends CloudConnectorAppFunctionRouterIT {
 
     @Test
     @Override

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -32,6 +32,7 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
@@ -65,6 +66,7 @@ public class CloudConnectorAppIT {
     private static final String CONNECTOR_SUFFIX = "Connector";
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, Queue> anonQueues = new LinkedHashMap<>();
     static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
 
     @TestConfiguration
@@ -73,7 +75,9 @@ public class CloudConnectorAppIT {
         @Bean
         DeclarableCustomizer declarableCustomizer() {
             return declarable -> {
-                if (declarable instanceof Queue queue) {
+                if (declarable instanceof AnonymousQueue anonymousQueue) {
+                    anonQueues.computeIfAbsent(anonymousQueue.getName(), key -> anonymousQueue);
+                } else if (declarable instanceof Queue queue) {
                     queues.computeIfAbsent(queue.getName(), key -> queue);
                 } else if (declarable instanceof Exchange exchange) {
                     exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
@@ -82,6 +86,13 @@ public class CloudConnectorAppIT {
                 return declarable;
             };
         }
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+        anonQueues.clear();
     }
 
     @Autowired
@@ -102,12 +113,6 @@ public class CloudConnectorAppIT {
     @Autowired
     protected ActivitiCloudMessagingProperties messagingProperties;
 
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        exchanges.clear();
-    }
-
     @Test
     void contextLoads() {
         //then
@@ -120,6 +125,11 @@ public class CloudConnectorAppIT {
     @Test
     void rabbitQueues() {
         assertThat(queues).isNotEmpty().containsOnlyKeys("processing-connector");
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues).isEmpty();
     }
 
     @Test

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -26,16 +26,25 @@ import static org.springframework.cloud.function.context.FunctionRegistration.RE
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.*;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.RabbitMQContainer;
@@ -46,6 +55,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @AutoConfigureMockMvc
 @Testcontainers
 @TestPropertySource(locations = "classpath:test.properties")
+@Import(CloudConnectorAppIT.BinderFactoryListenerConfiguration.class)
 public class CloudConnectorAppIT {
 
     @ServiceConnection
@@ -53,6 +63,26 @@ public class CloudConnectorAppIT {
     static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
 
     private static final String CONNECTOR_SUFFIX = "Connector";
+
+    static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+
+    @TestConfiguration
+    static class BinderFactoryListenerConfiguration {
+
+        @Bean
+        DeclarableCustomizer declarableCustomizer() {
+            return declarable -> {
+                if (declarable instanceof Queue queue) {
+                    queues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Exchange exchange) {
+                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+                }
+
+                return declarable;
+            };
+        }
+    }
 
     @Autowired
     private ApplicationContext context;
@@ -72,13 +102,40 @@ public class CloudConnectorAppIT {
     @Autowired
     protected ActivitiCloudMessagingProperties messagingProperties;
 
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+    }
+
     @Test
-    public void contextShouldLoad() throws Exception {
+    void contextLoads() {
         //then
         assertThat(context).isNotNull();
         assertThat(appName).isNotEmpty();
 
         assertThat(functionCatalog).isNotNull();
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("processing-connector");
+    }
+
+    @Test
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "restconnector.POST",
+                "restConnector.GET",
+                "test-bpmn-error-connector.throwError",
+                "test-error-connector.throwError",
+                "miCloudConnector",
+                "headers.GET",
+                "Movies.getMovieDesc",
+                "ExampleConnector"
+            );
     }
 
     @Test

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -29,9 +29,10 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
-import org.activiti.cloud.examples.connectors.*;
+import org.activiti.cloud.examples.connectors.CustomPojo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -49,19 +50,16 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = { CloudConnectorApp.class })
 @AutoConfigureMockMvc
-@Testcontainers
 @TestPropertySource(locations = "classpath:test.properties")
 @Import(CloudConnectorAppIT.BinderFactoryListenerConfiguration.class)
+@ResourceLock("rabbitmq")
 public class CloudConnectorAppIT {
 
     @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
     private static final String CONNECTOR_SUFFIX = "Connector";
 

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -33,15 +33,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = { CloudConnectorApp.class })
 @AutoConfigureMockMvc
+@Testcontainers
 @TestPropertySource(locations = "classpath:test.properties")
 public class CloudConnectorAppIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
 
     private static final String CONNECTOR_SUFFIX = "Connector";
 
@@ -58,10 +67,10 @@ public class CloudConnectorAppIT {
     private FunctionCatalog functionCatalog;
 
     @Autowired
-    private Environment environment;
+    protected Environment environment;
 
     @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
+    protected ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     public void contextShouldLoad() throws Exception {
@@ -105,6 +114,20 @@ public class CloudConnectorAppIT {
     void messagingPropertiesRabbitMqCompression() {
         assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
         assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
+    }
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isNullOrEmpty();
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isNullOrEmpty();
     }
 
     private static String getRegisteredConnectorName(String functionName) {

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -26,27 +26,19 @@ import static org.springframework.cloud.function.context.FunctionRegistration.RE
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.CustomPojo;
-import org.junit.jupiter.api.AfterAll;
+import org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestContext;
+import org.activiti.cloud.starters.test.binder.EnableBinderFactoryListenerTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
-import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.DeclarableCustomizer;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.RabbitMQContainer;
@@ -54,44 +46,14 @@ import org.testcontainers.containers.RabbitMQContainer;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = { CloudConnectorApp.class })
 @AutoConfigureMockMvc
 @TestPropertySource(locations = "classpath:test.properties")
-@Import(CloudConnectorAppIT.BinderFactoryListenerConfiguration.class)
 @ResourceLock("rabbitmq")
+@EnableBinderFactoryListenerTestContext
 public class CloudConnectorAppIT {
 
     @ServiceConnection
     static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
     private static final String CONNECTOR_SUFFIX = "Connector";
-
-    static final Map<String, Queue> queues = new LinkedHashMap<>();
-    static final Map<String, Queue> anonQueues = new LinkedHashMap<>();
-    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
-
-    @TestConfiguration
-    static class BinderFactoryListenerConfiguration {
-
-        @Bean
-        DeclarableCustomizer declarableCustomizer() {
-            return declarable -> {
-                if (declarable instanceof AnonymousQueue anonymousQueue) {
-                    anonQueues.computeIfAbsent(anonymousQueue.getName(), key -> anonymousQueue);
-                } else if (declarable instanceof Queue queue) {
-                    queues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Exchange exchange) {
-                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
-                }
-
-                return declarable;
-            };
-        }
-    }
-
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        exchanges.clear();
-        anonQueues.clear();
-    }
 
     @Autowired
     private ApplicationContext context;
@@ -111,6 +73,9 @@ public class CloudConnectorAppIT {
     @Autowired
     protected ActivitiCloudMessagingProperties messagingProperties;
 
+    @Autowired
+    protected BinderFactoryListenerTestContext binderFactoryListenerTestContext;
+
     @Test
     void contextLoads() {
         //then
@@ -122,17 +87,17 @@ public class CloudConnectorAppIT {
 
     @Test
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("processing-connector");
+        assertThat(binderFactoryListenerTestContext.getQueues()).isNotEmpty().containsOnlyKeys("processing-connector");
     }
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
     }
 
     @Test
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "restconnector.POST",

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -32,6 +32,7 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.CustomPojo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -54,6 +55,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 @AutoConfigureMockMvc
 @TestPropertySource(locations = "classpath:test.properties")
 @Import(CloudConnectorAppIT.BinderFactoryListenerConfiguration.class)
+@ResourceLock("rabbitmq")
 public class CloudConnectorAppIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -32,7 +32,6 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.CustomPojo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -55,7 +54,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 @AutoConfigureMockMvc
 @TestPropertySource(locations = "classpath:test.properties")
 @Import(CloudConnectorAppIT.BinderFactoryListenerConfiguration.class)
-@ResourceLock("rabbitmq")
 public class CloudConnectorAppIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
@@ -26,6 +26,29 @@ public class CloudConnectorAppRabbitmqPrefixIT extends CloudConnectorAppIT {
 
     @Test
     @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.processing-connector");
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "default-app.restconnector.POST",
+                "default-app.restConnector.GET",
+                "default-app.test-bpmn-error-connector.throwError",
+                "default-app.test-error-connector.throwError",
+                "default-app.miCloudConnector",
+                "default-app.headers.GET",
+                "default-app.Movies.getMovieDesc",
+                "default-app.ExampleConnector"
+            );
+    }
+
+    @Test
+    @Override
     void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Alfresco Software, Ltd.
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.activiti.cloud.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
@@ -27,13 +27,15 @@ public class CloudConnectorAppRabbitmqPrefixIT extends CloudConnectorAppIT {
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.processing-connector");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.processing-connector");
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "default-app.restconnector.POST",

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.examples;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class CloudConnectorAppRabbitmqPrefixIT extends CloudConnectorAppIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    void contextLoads() {}
+
+    @Test
+    void messagingProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void environment() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+}

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppRabbitmqPrefixIT.java
@@ -18,40 +18,21 @@ package org.activiti.cloud.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
 public class CloudConnectorAppRabbitmqPrefixIT extends CloudConnectorAppIT {
 
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
-
-    @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
-
-    @Autowired
-    private Environment environment;
-
     @Test
-    void contextLoads() {}
-
-    @Test
-    void messagingProperties() {
+    @Override
+    void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }
 
     @Test
-    void environment() {
+    @Override
+    void rabbitBinderDefaultPrefix() {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
             .isEqualTo("default-app.");
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
@@ -45,5 +45,10 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-liquibase</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/pom.xml
@@ -50,5 +50,10 @@
       <artifactId>activiti-cloud-services-test-liquibase</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-binder</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -24,8 +24,6 @@ import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationI
 import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
-import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -53,7 +51,6 @@ import org.testcontainers.containers.RabbitMQContainer;
 @CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(RuntimeBundleApplicationIT.BinderFactoryListenerConfiguration.class)
-@ResourceLocks(value = { @ResourceLock("rabbitmq"), @ResourceLock("postgres") })
 public class RuntimeBundleApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -76,4 +76,18 @@ public class RuntimeBundleApplicationIT {
         assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
         assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
     }
+
+    @Test
+    void messagingRabbitMqPrefixProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isNullOrEmpty();
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isNullOrEmpty();
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isNullOrEmpty();
+    }
 }

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -17,26 +17,18 @@ package org.activiti.cloud.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
-import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
-import org.junit.jupiter.api.AfterAll;
+import org.activiti.cloud.services.test.liquibase.EnableCleanupLiquibaseAfterTest;
+import org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestContext;
+import org.activiti.cloud.starters.test.binder.EnableBinderFactoryListenerTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.ResourceLocks;
-import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.DeclarableCustomizer;
-import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -50,9 +42,9 @@ import org.testcontainers.containers.RabbitMQContainer;
         "activiti.cloud.messaging.rabbitmq.compression-level=9",
     }
 )
-@CleanupLiquibaseAfterTest
+@EnableCleanupLiquibaseAfterTest
+@EnableBinderFactoryListenerTestContext
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Import(RuntimeBundleApplicationIT.BinderFactoryListenerConfiguration.class)
 @ResourceLocks(value = { @ResourceLock("rabbitmq"), @ResourceLock("postgres") })
 public class RuntimeBundleApplicationIT {
 
@@ -62,35 +54,8 @@ public class RuntimeBundleApplicationIT {
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
-    static final Map<String, Queue> queues = new LinkedHashMap<>();
-    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
-    static final Map<String, Queue> anonQueues = new LinkedHashMap<>();
-
-    @TestConfiguration
-    static class BinderFactoryListenerConfiguration {
-
-        @Bean
-        DeclarableCustomizer declarableCustomizer() {
-            return declarable -> {
-                if (declarable instanceof AnonymousQueue anonymousQueue) {
-                    anonQueues.computeIfAbsent(anonymousQueue.getName(), key -> anonymousQueue);
-                } else if (declarable instanceof Queue queue) {
-                    queues.computeIfAbsent(queue.getName(), key -> queue);
-                } else if (declarable instanceof Exchange exchange) {
-                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
-                }
-
-                return declarable;
-            };
-        }
-    }
-
-    @AfterAll
-    static void cleanUp() {
-        queues.clear();
-        anonQueues.clear();
-        exchanges.clear();
-    }
+    @Autowired
+    protected BinderFactoryListenerTestContext binderFactoryListenerTestContext;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -108,7 +73,7 @@ public class RuntimeBundleApplicationIT {
 
     @Test
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .containsOnlyKeys(
                 "engineEvents.query",
@@ -124,12 +89,12 @@ public class RuntimeBundleApplicationIT {
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(anonQueues).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
     }
 
     @Test
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "commandResults_default-app",

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -23,6 +23,7 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
@@ -63,6 +64,7 @@ public class RuntimeBundleApplicationIT {
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
     static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+    static final Map<String, Queue> anonQueues = new LinkedHashMap<>();
 
     @TestConfiguration
     static class BinderFactoryListenerConfiguration {
@@ -70,7 +72,9 @@ public class RuntimeBundleApplicationIT {
         @Bean
         DeclarableCustomizer declarableCustomizer() {
             return declarable -> {
-                if (declarable instanceof Queue queue) {
+                if (declarable instanceof AnonymousQueue anonymousQueue) {
+                    anonQueues.computeIfAbsent(anonymousQueue.getName(), key -> anonymousQueue);
+                } else if (declarable instanceof Queue queue) {
                     queues.computeIfAbsent(queue.getName(), key -> queue);
                 } else if (declarable instanceof Exchange exchange) {
                     exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
@@ -84,6 +88,7 @@ public class RuntimeBundleApplicationIT {
     @AfterAll
     static void cleanUp() {
         queues.clear();
+        anonQueues.clear();
         exchanges.clear();
     }
 
@@ -115,6 +120,11 @@ public class RuntimeBundleApplicationIT {
                 "integrationResult_my-runtime-bundle.my-runtime-bundle",
                 "integrationError_my-runtime-bundle.my-runtime-bundle"
             );
+    }
+
+    @Test
+    void anonymousRabbitQueues() {
+        assertThat(anonQueues).isEmpty();
     }
 
     @Test

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -17,13 +17,22 @@ package org.activiti.cloud.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -34,11 +43,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @SpringBootTest(
     classes = RuntimeBundleApplication.class,
     properties = {
-        "activiti.cloud.messaging.rabbitmq.compress=true", "activiti.cloud.messaging.rabbitmq.compression-level=9",
+        "activiti.cloud.application.name=default-app",
+        "activiti.cloud.messaging.rabbitmq.compress=true",
+        "activiti.cloud.messaging.rabbitmq.compression-level=9",
     }
 )
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Testcontainers
+@Import(RuntimeBundleApplicationIT.BinderFactoryListenerConfiguration.class)
 public class RuntimeBundleApplicationIT {
 
     @ServiceConnection
@@ -48,6 +60,32 @@ public class RuntimeBundleApplicationIT {
     @Container
     @ServiceConnection
     static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static final Map<String, Queue> queues = new LinkedHashMap<>();
+    static final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+
+    @TestConfiguration
+    static class BinderFactoryListenerConfiguration {
+
+        @Bean
+        DeclarableCustomizer declarableCustomizer() {
+            return declarable -> {
+                if (declarable instanceof Queue queue) {
+                    queues.computeIfAbsent(queue.getName(), key -> queue);
+                } else if (declarable instanceof Exchange exchange) {
+                    exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+                }
+
+                return declarable;
+            };
+        }
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        queues.clear();
+        exchanges.clear();
+    }
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -61,6 +99,38 @@ public class RuntimeBundleApplicationIT {
     @Test
     public void contextLoads() {
         assertThat(applicationContext).isNotNull();
+    }
+
+    @Test
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "engineEvents.query",
+                "engineEvents.audit",
+                "messageEvents_default-app.messages",
+                "signalEvent.my-runtime-bundle",
+                "commandConsumer_default-app.my-runtime-bundle",
+                "asyncExecutorJobs_default-app.my-runtime-bundle",
+                "integrationResult_my-runtime-bundle.my-runtime-bundle",
+                "integrationError_my-runtime-bundle.my-runtime-bundle"
+            );
+    }
+
+    @Test
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "commandResults_default-app",
+                "engineEvents",
+                "asyncExecutorJobs_default-app",
+                "commandConsumer_default-app",
+                "messageEvents_default-app",
+                "signalEvent",
+                "integrationResult_my-runtime-bundle",
+                "integrationError_my-runtime-bundle"
+            );
     }
 
     @Test

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -21,8 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
+import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -38,8 +41,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(
     classes = RuntimeBundleApplication.class,
@@ -49,18 +50,17 @@ import org.testcontainers.junit.jupiter.Testcontainers;
         "activiti.cloud.messaging.rabbitmq.compression-level=9",
     }
 )
+@CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
-@Testcontainers
 @Import(RuntimeBundleApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("rabbitmq"), @ResourceLock("postgres") })
 public class RuntimeBundleApplicationIT {
 
     @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine").withReuse(true);
 
-    @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine").withReuse(true);
 
     static final Map<String, Queue> queues = new LinkedHashMap<>();
     static final Map<String, Exchange> exchanges = new LinkedHashMap<>();

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -39,6 +40,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Testcontainers
 public class RuntimeBundleApplicationIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
 
     @Container
     @ServiceConnection

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -24,6 +24,8 @@ import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationI
 import org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.ResourceLocks;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.DeclarableCustomizer;
 import org.springframework.amqp.core.Exchange;
@@ -51,6 +53,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 @CleanupLiquibaseAfterTest
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Import(RuntimeBundleApplicationIT.BinderFactoryListenerConfiguration.class)
+@ResourceLocks(value = { @ResourceLock("rabbitmq"), @ResourceLock("postgres") })
 public class RuntimeBundleApplicationIT {
 
     @ServiceConnection

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
@@ -40,13 +40,15 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("consumer", "my-runtime-bundle");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .containsOnlyKeys("consumer", "my-runtime-bundle");
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "commandResults_default-app",

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
@@ -20,24 +20,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
-import org.testcontainers.containers.RabbitMQContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @TestPropertySource(
     properties = { "activiti.cloud.messaging.function-router.enabled=true", "activiti.cloud.application.name=myapp" }
 )
-@Testcontainers
 public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicationIT {
-
-    @ServiceConnection
-    @Container
-    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
 
     @Autowired
     protected BindingServiceProperties bindingServiceProperties;

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
@@ -40,13 +40,13 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
     static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
 
     @Autowired
-    private BindingServiceProperties bindingServiceProperties;
+    protected BindingServiceProperties bindingServiceProperties;
 
     @Autowired
-    private ActivitiCloudMessagingProperties messagingProperties;
+    protected ActivitiCloudMessagingProperties messagingProperties;
 
     @Autowired
-    private Environment environment;
+    protected Environment environment;
 
     @Test
     void bindingServiceProperties() {

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
@@ -25,9 +25,7 @@ import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(
-    properties = { "activiti.cloud.messaging.function-router.enabled=true", "activiti.cloud.application.name=myapp" }
-)
+@TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
 public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicationIT {
 
     @Autowired
@@ -38,6 +36,29 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
 
     @Autowired
     protected Environment environment;
+
+    @Test
+    @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("consumer", "my-runtime-bundle");
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "commandResults_default-app",
+                "engineEvents",
+                "asyncExecutorJobs_default-app",
+                "commandConsumer_default-app",
+                "messageEvents_default-app",
+                "signalEvent",
+                "integrationResult_my-runtime-bundle",
+                "integrationError_my-runtime-bundle"
+            );
+    }
 
     @Test
     void bindingServiceProperties() {
@@ -107,9 +128,9 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
 
         assertThat(functionRouter.registrations())
             .containsOnlyKeys(
-                "commandConsumer_myapp",
-                "asyncExecutorJobs_myapp",
-                "messageEvents_myapp",
+                "commandConsumer_default-app",
+                "asyncExecutorJobs_default-app",
+                "messageEvents_default-app",
                 "integrationResult_my-runtime-bundle",
                 "integrationError_my-runtime-bundle",
                 "signalEvent"

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -24,11 +24,13 @@ import org.springframework.test.context.TestPropertySource;
 public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFunctionRouterEnabledIT {
 
     @Test
+    @Override
     void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp.");
     }
 
     @Test
+    @Override
     void rabbitBinderDefaultPrefix() {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
             .isEqualTo("myapp.");

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFunctionRouterEnabledIT {
 
     @Test
-    void messagingProperties() {
+    void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp.");
     }
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}." })
+public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFunctionRouterEnabledIT {
+
+    @Test
+    void messagingProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp.");
+    }
+
+    @Test
+    void rabbitBinderDefaultPrefix() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("myapp.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("myapp.");
+    }
+
+    @Test
+    @Override
+    void bindingServicePropertiesRequiredProducerGroups() {
+        assertThat(bindingServiceProperties.getProducerProperties("signalProducer").getRequiredGroups()).isEmpty();
+        assertThat(bindingServiceProperties.getProducerProperties("messageEventsOutput").getRequiredGroups()).isEmpty();
+        assertThat(bindingServiceProperties.getProducerProperties("auditProducer").getRequiredGroups())
+            .containsOnly("myapp.consumer");
+    }
+}

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -25,18 +25,41 @@ public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFu
 
     @Test
     @Override
+    void rabbitQueues() {
+        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.consumer", "default-app.my-runtime-bundle");
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "default-app.commandResults_default-app",
+                "default-app.engineEvents",
+                "default-app.asyncExecutorJobs_default-app",
+                "default-app.commandConsumer_default-app",
+                "default-app.messageEvents_default-app",
+                "default-app.signalEvent",
+                "default-app.integrationResult_my-runtime-bundle",
+                "default-app.integrationError_my-runtime-bundle"
+            );
+    }
+
+    @Test
+    @Override
     void messagingRabbitMqPrefixProperties() {
-        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp.");
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }
 
     @Test
     @Override
     void rabbitBinderDefaultPrefix() {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
-            .isEqualTo("myapp.");
+            .isEqualTo("default-app.");
 
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
-            .isEqualTo("myapp.");
+            .isEqualTo("default-app.");
     }
 
     @Test
@@ -45,6 +68,6 @@ public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFu
         assertThat(bindingServiceProperties.getProducerProperties("signalProducer").getRequiredGroups()).isEmpty();
         assertThat(bindingServiceProperties.getProducerProperties("messageEventsOutput").getRequiredGroups()).isEmpty();
         assertThat(bindingServiceProperties.getProducerProperties("auditProducer").getRequiredGroups())
-            .containsOnly("myapp.consumer");
+            .containsOnly("default-app.consumer");
     }
 }

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -26,13 +26,15 @@ public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFu
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues).isNotEmpty().containsOnlyKeys("default-app.consumer", "default-app.my-runtime-bundle");
+        assertThat(binderFactoryListenerTestContext.getQueues())
+            .isNotEmpty()
+            .containsOnlyKeys("default-app.consumer", "default-app.my-runtime-bundle");
     }
 
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "default-app.commandResults_default-app",

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -52,7 +52,7 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
     }
 
     @Test
-    void environment() {
+    void rabbitBinderDefaultPrefix() {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
             .isEqualTo("default-app.");
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Alfresco Software, Ltd.
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@TestPropertySource(
+    properties = {
+        "activiti.cloud.application.name=default-app",
+        "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}.",
+    }
+)
+@Testcontainers
+public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
+
+    @ServiceConnection
+    @Container
+    static final RabbitMQContainer rabbitMq = new RabbitMQContainer("rabbitmq:3.8.6-management-alpine");
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    void messagingProperties() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
+    }
+
+    @Test
+    void environment() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("default-app.");
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("default-app.");
+    }
+}

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -46,6 +46,40 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
 
     @Test
     @Override
+    void rabbitQueues() {
+        assertThat(queues)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "default-app.engineEvents.query",
+                "default-app.engineEvents.audit",
+                "default-app.messageEvents_default-app.messages",
+                "default-app.signalEvent.my-runtime-bundle",
+                "default-app.commandConsumer_default-app.my-runtime-bundle",
+                "default-app.asyncExecutorJobs_default-app.my-runtime-bundle",
+                "default-app.integrationResult_my-runtime-bundle.my-runtime-bundle",
+                "default-app.integrationError_my-runtime-bundle.my-runtime-bundle"
+            );
+    }
+
+    @Test
+    @Override
+    void rabbitExchanges() {
+        assertThat(exchanges)
+            .isNotEmpty()
+            .containsOnlyKeys(
+                "default-app.commandResults_default-app",
+                "default-app.engineEvents",
+                "default-app.asyncExecutorJobs_default-app",
+                "default-app.commandConsumer_default-app",
+                "default-app.messageEvents_default-app",
+                "default-app.signalEvent",
+                "default-app.integrationResult_my-runtime-bundle",
+                "default-app.integrationError_my-runtime-bundle"
+            );
+    }
+
+    @Test
+    @Override
     void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -47,7 +47,7 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
     @Test
     @Override
     void rabbitQueues() {
-        assertThat(queues)
+        assertThat(binderFactoryListenerTestContext.getQueues())
             .isNotEmpty()
             .containsOnlyKeys(
                 "default-app.engineEvents.query",
@@ -64,7 +64,7 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
     @Test
     @Override
     void rabbitExchanges() {
-        assertThat(exchanges)
+        assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
             .containsOnlyKeys(
                 "default-app.commandResults_default-app",

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -25,7 +25,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @TestPropertySource(
     properties = {
@@ -33,7 +32,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
         "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}.",
     }
 )
-@Testcontainers
 public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
 
     @ServiceConnection
@@ -47,7 +45,7 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
     private Environment environment;
 
     @Test
-    void messagingProperties() {
+    void messagingRabbitMqPrefixProperties() {
         assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("default-app.");
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
@@ -75,6 +75,11 @@
       </dependency>
       <dependency>
         <groupId>org.activiti.cloud</groupId>
+        <artifactId>activiti-cloud-services-test-liquibase</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud</groupId>
         <artifactId>activiti-cloud-services-monitoring</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-common-dependencies/pom.xml
@@ -80,6 +80,11 @@
       </dependency>
       <dependency>
         <groupId>org.activiti.cloud</groupId>
+        <artifactId>activiti-cloud-services-test-binder</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud</groupId>
         <artifactId>activiti-cloud-services-monitoring</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -135,6 +135,8 @@ public class ActivitiCloudMessagingProperties {
 
         private Integer compressionLevel = 1;
 
+        private String prefix;
+
         public Boolean getMissingAnonymousQueuesFatal() {
             return missingAnonymousQueuesFatal;
         }
@@ -165,6 +167,14 @@ public class ActivitiCloudMessagingProperties {
 
         public void setCompressionLevel(Integer compressionLevel) {
             this.compressionLevel = compressionLevel;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(String prefix) {
+            this.prefix = prefix;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsBeanPostProcessor.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsBeanPostProcessor.java
@@ -149,7 +149,16 @@ public class ActivitiMessagingDestinationsBeanPostProcessor implements BeanPostP
                                 var overrideGroups = functionRouter
                                     .getRoutes()
                                     .get(bindingName)
-                                    .getOverrideRequiredProducerGroups();
+                                    .getOverrideRequiredProducerGroups()
+                                    .stream()
+                                    .map(it ->
+                                        Optional
+                                            .ofNullable(messagingProperties.getRabbitmq().getPrefix())
+                                            .map(prefix -> prefix.concat(it))
+                                            .orElse(it)
+                                    )
+                                    .toList();
+
                                 producer.setRequiredGroups(overrideGroups.toArray(new String[] {}));
 
                                 log.warn(

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -95,12 +95,16 @@ public class FunctionRouterConfiguration {
     @Bean
     DeclarableCustomizer functionRouterAnonymousQueueCustomizer(ActivitiCloudMessagingProperties messagingProperties) {
         final var groupPrefix = messagingProperties.getFunctionRouter().groupPrefix();
+        final var queuePrefix = Optional
+            .ofNullable(messagingProperties.getRabbitmq().getPrefix())
+            .map(prefix -> prefix.concat(groupPrefix))
+            .orElse(groupPrefix);
 
         return declarable -> {
             if (declarable instanceof Queue queue) {
                 Optional
                     .ofNullable(queue.getName())
-                    .filter(it -> it.startsWith(groupPrefix))
+                    .filter(it -> it.startsWith(queuePrefix))
                     .ifPresent(name -> queue.setLeaderLocator("client-local"));
             }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -26,6 +26,8 @@ activiti.cloud.messaging.destinations.integrationError.scope=${spring.applicatio
 # Default RabbitMq listener container properties
 activiti.cloud.messaging.rabbitmq.missing-anonymous-queues-fatal=true
 activiti.cloud.messaging.rabbitmq.missing-durable-queues-fatal=true
+spring.cloud.stream.rabbit.default.producer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
+spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
 
 # Function Router Rabbit binder properties
 spring.cloud.stream.rabbit.bindings.functionRouterInput.consumer.queue-name-group-only=true

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -26,8 +26,6 @@ activiti.cloud.messaging.destinations.integrationError.scope=${spring.applicatio
 # Default RabbitMq listener container properties
 activiti.cloud.messaging.rabbitmq.missing-anonymous-queues-fatal=true
 activiti.cloud.messaging.rabbitmq.missing-durable-queues-fatal=true
-spring.cloud.stream.rabbit.default.producer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
-spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
 
 # Function Router Rabbit binder properties
 spring.cloud.stream.rabbit.bindings.functionRouterInput.consumer.queue-name-group-only=true
@@ -40,3 +38,7 @@ spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.exclus
 # Default RabbitMq binder compression properties
 spring.cloud.stream.rabbit.default.producer.compress=${activiti.cloud.messaging.rabbitmq.compress:false}
 spring.cloud.stream.rabbit.binder.compression-level=${activiti.cloud.messaging.rabbitmq.compression-level:1}
+
+# Default RabbitMq prefix properties
+spring.cloud.stream.rabbit.default.producer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
+spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -32,7 +32,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
         "activiti.cloud.application.name=myapp",
         "activiti.cloud.messaging.rabbitmq.compress=true",
         "activiti.cloud.messaging.rabbitmq.compression-level=9",
-        "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}",
+        "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}.",
     }
 )
 @SpringBootApplication
@@ -73,10 +73,10 @@ public class ActivitiCloudMessagingAutoConfigurationTests {
 
     @Test
     public void rabbitMqPrefixConfiguration() {
-        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp");
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp.");
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
-            .isEqualTo("myapp");
+            .isEqualTo("myapp.");
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
-            .isEqualTo("myapp");
+            .isEqualTo("myapp.");
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -29,7 +29,10 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
 
 @SpringBootTest(
     properties = {
-        "activiti.cloud.messaging.rabbitmq.compress=true", "activiti.cloud.messaging.rabbitmq.compression-level=9",
+        "activiti.cloud.application.name=myapp",
+        "activiti.cloud.messaging.rabbitmq.compress=true",
+        "activiti.cloud.messaging.rabbitmq.compression-level=9",
+        "activiti.cloud.messaging.rabbitmq.prefix=${activiti.cloud.application.name}",
     }
 )
 @SpringBootApplication
@@ -66,5 +69,14 @@ public class ActivitiCloudMessagingAutoConfigurationTests {
             .isEqualTo(9);
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
             .isTrue();
+    }
+
+    @Test
+    public void rabbitMqPrefixConfiguration() {
+        assertThat(messagingProperties.getRabbitmq().getPrefix()).isEqualTo("myapp");
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
+            .isEqualTo("myapp");
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.consumer.prefix", String.class))
+            .isEqualTo("myapp");
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-binder/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-binder/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.activiti.cloud</groupId>
+    <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+    <version>8.8.0-SNAPSHOT</version>
+    <relativePath>../activiti-cloud-service-common-dependencies</relativePath>
+  </parent>
+
+  <artifactId>activiti-cloud-services-test-binder</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-amqp</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/BinderFactoryListenerTestContext.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/BinderFactoryListenerTestContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starters.test.binder;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.DeclarableCustomizer;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class BinderFactoryListenerTestContext {
+
+    public Map<String, Queue> getQueues() {
+        return queues;
+    }
+
+    public Map<String, Queue> getAnonymousQueues() {
+        return anonymousQueues;
+    }
+
+    public Map<String, Exchange> getExchanges() {
+        return exchanges;
+    }
+
+    public Map<String, Binding> getBindings() {
+        return bindings;
+    }
+
+    private final Map<String, Queue> queues = new LinkedHashMap<>();
+    private final Map<String, Queue> anonymousQueues = new LinkedHashMap<>();
+    private final Map<String, Exchange> exchanges = new LinkedHashMap<>();
+    private final Map<String, Binding> bindings = new LinkedHashMap<>();
+
+    public void afterTestClass() {
+        queues.clear();
+        exchanges.clear();
+        anonymousQueues.clear();
+        bindings.clear();
+    }
+
+    @Bean
+    DeclarableCustomizer binderFactoryListenerDeclarableCustomizer() {
+        return declarable -> {
+            if (declarable instanceof AnonymousQueue anonymousQueue) {
+                anonymousQueues.computeIfAbsent(anonymousQueue.getName(), key -> anonymousQueue);
+            } else if (declarable instanceof Queue queue) {
+                queues.computeIfAbsent(queue.getName(), key -> queue);
+            } else if (declarable instanceof Exchange exchange) {
+                exchanges.computeIfAbsent(exchange.getName(), key -> exchange);
+            } else if (declarable instanceof Binding binding) {
+                bindings.computeIfAbsent(binding.toString(), key -> binding);
+            }
+
+            return declarable;
+        };
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/BinderFactoryListenerTestExecutionListener.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/BinderFactoryListenerTestExecutionListener.java
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-package org.activiti.cloud.services.test.liquibase;
+package org.activiti.cloud.starters.test.binder;
 
 import java.util.Map;
 import java.util.Optional;
-import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.integration.spring.SpringLiquibase;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
-public class CleanupLiquibaseAfterTestExecutionListener extends AbstractTestExecutionListener {
+public class BinderFactoryListenerTestExecutionListener extends AbstractTestExecutionListener {
 
     @Override
     public int getOrder() {
@@ -38,20 +36,14 @@ public class CleanupLiquibaseAfterTestExecutionListener extends AbstractTestExec
             .of(testContext.getTestClass())
             .filter(testClass ->
                 Optional
-                    .ofNullable(AnnotationUtils.findAnnotation(testClass, EnableCleanupLiquibaseAfterTest.class))
+                    .ofNullable(AnnotationUtils.findAnnotation(testClass, EnableBinderFactoryListenerTestContext.class))
                     .isPresent()
             )
-            .map(testClass -> testContext.getApplicationContext().getBeansOfType(SpringLiquibase.class))
+            .map(testClass -> testContext.getApplicationContext().getBeansOfType(BinderFactoryListenerTestContext.class)
+            )
             .map(Map::values)
-            .ifPresent(values -> {
-                values.forEach(springLiquibase -> {
-                    try {
-                        springLiquibase.setDropFirst(true);
-                        springLiquibase.afterPropertiesSet();
-                    } catch (Exception e) {
-                        throw new UnexpectedLiquibaseException(e);
-                    }
-                });
-            });
+            .ifPresent(binderFactoryListenerTestConfigurations ->
+                binderFactoryListenerTestConfigurations.forEach(BinderFactoryListenerTestContext::afterTestClass)
+            );
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/EnableBinderFactoryListenerTestContext.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/java/org/activiti/cloud/starters/test/binder/EnableBinderFactoryListenerTestContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starters.test.binder;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(BinderFactoryListenerTestContext.class)
+public @interface EnableBinderFactoryListenerTestContext {
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-binder/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.TestExecutionListener = \
+  org.activiti.cloud.starters.test.binder.BinderFactoryListenerTestExecutionListener

--- a/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.activiti.cloud</groupId>
+    <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+    <version>8.8.0-SNAPSHOT</version>
+    <relativePath>../activiti-cloud-service-common-dependencies</relativePath>
+  </parent>
+
+  <artifactId>activiti-cloud-services-test-liquibase</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/CleanupLiquibaseAfterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/CleanupLiquibaseAfterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.test.liquibase;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.TestExecutionListeners;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@TestExecutionListeners(
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+    listeners = { CleanupLiquibaseAfterTestExecutionListener.class }
+)
+public @interface CleanupLiquibaseAfterTest {
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/CleanupLiquibaseAfterTestExecutionListener.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/CleanupLiquibaseAfterTestExecutionListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.test.liquibase;
+
+import java.util.Map;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.integration.spring.SpringLiquibase;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+public class CleanupLiquibaseAfterTestExecutionListener extends AbstractTestExecutionListener {
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) {
+        Map<String, SpringLiquibase> springLiquibaseMap = testContext
+            .getApplicationContext()
+            .getBeansOfType(SpringLiquibase.class);
+        springLiquibaseMap
+            .values()
+            .stream()
+            .forEach(springLiquibase -> {
+                try {
+                    springLiquibase.setDropFirst(true);
+                    springLiquibase.afterPropertiesSet();
+                } catch (Exception e) {
+                    throw new UnexpectedLiquibaseException(e);
+                }
+            });
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/EnableCleanupLiquibaseAfterTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/java/org/activiti/cloud/services/test/liquibase/EnableCleanupLiquibaseAfterTest.java
@@ -21,14 +21,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.test.context.TestExecutionListeners;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@TestExecutionListeners(
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
-    listeners = { CleanupLiquibaseAfterTestExecutionListener.class }
-)
-public @interface CleanupLiquibaseAfterTest {
+public @interface EnableCleanupLiquibaseAfterTest {
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-liquibase/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.TestExecutionListener = \
+    org.activiti.cloud.services.test.liquibase.CleanupLiquibaseAfterTestExecutionListener

--- a/activiti-cloud-service-common/activiti-cloud-services-test/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/pom.xml
@@ -130,6 +130,10 @@
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-test-liquibase</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-binder</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-service-common/activiti-cloud-services-test/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/pom.xml
@@ -122,10 +122,14 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
-      <dependency>
-          <groupId>net.javacrumbs.json-unit</groupId>
-          <artifactId>json-unit-assertj</artifactId>
-      </dependency>
+    <dependency>
+       <groupId>net.javacrumbs.json-unit</groupId>
+       <artifactId>json-unit-assertj</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-test-liquibase</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -33,6 +33,7 @@
     <module>activiti-cloud-service-messaging-config</module>
     <module>activiti-cloud-service-messaging-starter</module>
     <module>activiti-cloud-services-test-liquibase</module>
+    <module>activiti-cloud-services-test-binder</module>
   </modules>
   <properties>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -32,6 +32,7 @@
     <module>activiti-cloud-service-common-liquibase</module>
     <module>activiti-cloud-service-messaging-config</module>
     <module>activiti-cloud-service-messaging-starter</module>
+    <module>activiti-cloud-services-test-liquibase</module>
   </modules>
   <properties>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>


### PR DESCRIPTION
This PR adds support for configuration of the RabbitMq prefix in the Activiti Cloud Messaging configuration module. The prefix will be used by the RabbitMq binder to provision consumer and producer bindings to prepend all exchanges and queues names within a vhost, i.e. 

```
activiti.cloud.messaging.rabbitmq.prefix=foobar.
```

The `foobar.` prefix will be appended to all queues, i.e. `foobar.consumer`, `foobar.rb` and exchanges, i.e. `foobar.engineEvents`.

Fixes https://hyland.atlassian.net/browse/AAE-38295