### PR TITLE
AAE-34337 Add ability to republish discarded events in order to be consumed by another node instead of retrying on the same node

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.common.messaging.config;
 
 import static org.springframework.integration.handler.LoggingHandler.Level.DEBUG;
+import static org.springframework.integration.handler.LoggingHandler.Level.INFO;
 
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -25,6 +26,8 @@ import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
 import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -36,10 +39,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.integration.filter.ExpressionEvaluatingSelector;
 import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StringUtils;
 
@@ -49,9 +55,12 @@ import org.springframework.util.StringUtils;
 )
 public class ConnectorConfiguration extends AbstractFunctionalBindingConfiguration {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorConfiguration.class);
+
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_FLOW = "connectorBindingSelectorDiscardFlow";
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_CHANNEL = "connectorBindingSelectorDiscardChannel";
     public static final String NULL_CHANNEL = "nullChannel";
+    public static final String RETRY_COUNT = "x-retry-count";
 
     @Bean(name = CONNECTOR_BINDING_SELECTOR_DISCARD_FLOW)
     IntegrationFlow functionBindingSelectorDiscardFlow() {
@@ -137,10 +146,24 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 .log(LoggingHandler.Level.DEBUG, beanName + ".integrationRequest")
                                 .filter(
                                     selector,
-                                    filter ->
-                                        filter
-                                            .discardChannel(CONNECTOR_BINDING_SELECTOR_DISCARD_CHANNEL)
-                                            .throwExceptionOnRejection(false)
+                                    filter -> {
+                                        int retry = connectorBinding.retry();
+                                        if (retry > 0) {
+                                            LOGGER.info(
+                                                "Configure filter retry count to {} for bean {}",
+                                                retry,
+                                                beanName
+                                            );
+                                            filter
+                                                .discardFlow(flow -> handleRetryDiscardFlow(flow, retry))
+                                                .throwExceptionOnRejection(false);
+                                        } else {
+                                            LOGGER.debug("Configure default discard for bean {}", beanName);
+                                            filter
+                                                .discardChannel(CONNECTOR_BINDING_SELECTOR_DISCARD_CHANNEL)
+                                                .throwExceptionOnRejection(false);
+                                        }
+                                    }
                                 )
                                 .filter(
                                     connectorType,
@@ -167,5 +190,57 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                 return bean;
             }
         };
+    }
+
+    private void handleRetryDiscardFlow(IntegrationFlowDefinition<?> flow, int maxRetry) {
+        flow.handle((payload, headers) -> {
+            Message<?> newMessage = handleMessagingExceptionIfPossible(payload, headers)
+                .orElse(buildNewMessage(headers, payload));
+            Object destination = headers.get("spring.cloud.function.destination");
+            if (destination != null) {
+                int retryCount = getRetryCount(headers);
+                if (retryCount < maxRetry - 1) {
+                    getStreamBridge().send((String) destination, newMessage);
+                } else {
+                    LOGGER.error("Cannot retry message because retry limited exceeded: {}", maxRetry);
+                }
+            } else {
+                LOGGER.error("Cannot retry message because destination from headers is null: {}", headers);
+            }
+            return null;
+        });
+    }
+
+    private Optional<Message<?>> handleMessagingExceptionIfPossible(Object payload, MessageHeaders headers) {
+        if (payload instanceof MessagingException messagingException) {
+            Object failedMessage = messagingException.getFailedMessage();
+            if (failedMessage instanceof Message<?> originalMessage) {
+                LOGGER.debug("Handling failed message for {}", payload);
+                return Optional.of(buildNewMessage(headers, originalMessage.getPayload()));
+            }
+        }
+        LOGGER.debug("Handled message exception for {}", payload);
+        return Optional.empty();
+    }
+
+    private Message<?> buildNewMessage(MessageHeaders headers, Object payload) {
+        int retryCount = handleRetryCount(headers);
+        Message<Object> message = MessageBuilder
+            .withPayload(payload)
+            .copyHeaders(headers)
+            .setHeader(RETRY_COUNT, retryCount)
+            .build();
+        LOGGER.info("New message for retry #{}: {}", retryCount, message);
+        return message;
+    }
+
+    private int handleRetryCount(MessageHeaders headers) {
+        int retryCount = getRetryCount(headers);
+        retryCount++;
+        return retryCount;
+    }
+
+    private static int getRetryCount(MessageHeaders headers) {
+        return headers.getOrDefault(RETRY_COUNT, 0) instanceof Integer count ? count : 0;
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
@@ -35,4 +35,6 @@ public @interface ConnectorBinding {
     String outputHeader() default "resultDestination";
 
     String connectorType() default "";
+
+    int retry() default 0;
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -22,11 +22,14 @@ import static org.activiti.cloud.common.messaging.config.test.TestBindingsChanne
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -39,6 +42,8 @@ import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanExpressionContext;
@@ -51,6 +56,7 @@ import org.springframework.cloud.stream.binder.test.OutputDestination;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -60,6 +66,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
@@ -77,7 +84,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
         "spring.cloud.stream.bindings.auditConsumer.destination=engineEvents",
         "spring.cloud.stream.bindings.queryConsumer.destination=engineEvents",
         "spring.cloud.stream.bindings.commandResults.destination=commandResults",
-        "spring.cloud.stream.bindings.integrationRequests.destination=rest-connector.GET,rest-connector.POST",
+        "spring.cloud.stream.bindings.integrationRequests.destination=rest-connector.GET,rest-connector.POST,script.EXECUTE",
         "spring.cloud.stream.bindings.integrationResults.destination=integrationResults",
         "spring.cloud.stream.default.error-handler-definition=myErrorHandler",
     }
@@ -89,6 +96,7 @@ public class ConnectorConfigurationIT {
     private static final String FUNCTION_NAME_B = "auditConsumerHandlerB";
     private static final String FUNCTION_NAME_C = "auditProcessorHandler";
     private static final String FUNCTION_NAME_ERROR = "connectorTestMyErrorHandler";
+    private static final String FUNCTION_NAME_RETRY = "connectorWithRetry";
 
     private static final String FUNCTION_NAME_D = "auditProcessorVersionHandler";
     public static final String MY_ERROR_HANDLER = "myErrorHandler";
@@ -119,6 +127,9 @@ public class ConnectorConfigurationIT {
 
     @MockitoSpyBean
     private MyErrorHandler myErrorHandler;
+
+    @MockitoSpyBean
+    private StreamBridge streamBridge;
 
     @Value("${application.min.version}")
     private String minVersion;
@@ -210,6 +221,20 @@ public class ConnectorConfigurationIT {
             return payload -> {
                 assertThat(payload).isNotNull().isEqualTo("PostRequest");
                 return "PostResult";
+            };
+        }
+
+        @Bean(FUNCTION_NAME_RETRY)
+        @ConnectorBinding(
+            input = INTEGRATION_REQUESTS,
+            output = INTEGRATION_RESULTS,
+            connectorType = "script.EXECUTE",
+            retry = 3,
+            condition = "headers['type']=='TestRetry'"
+        )
+        public ConsumerConnector<?> auditConsumerRetry() {
+            return payload -> {
+                assertThat(payload).isNotNull().isEqualTo("TestRetry");
             };
         }
     }
@@ -356,6 +381,7 @@ public class ConnectorConfigurationIT {
         // then
         Message<byte[]> reply = output.receive(2000, bindingResolver.getBindingDestination(COMMAND_RESULTS));
         assertThat(reply).isNull();
+        verify(streamBridge, never()).send(eq("script.EXECUTE"), any()); //never re-publish discarded message
     }
 
     @Test
@@ -451,6 +477,32 @@ public class ConnectorConfigurationIT {
 
         assertThat(output.receive(1, bindingResolver.getBindingDestination(INTEGRATION_RESULTS))).isNull();
     }
+
+    @Test
+    public void testShouldDiscardMessageWithInValidAppVersionWithRetryWithRepublishEvent() {
+        // given
+        byte[] payload = "Test retry".getBytes();
+        Message<?> message = MessageBuilder
+            .withPayload(payload)
+            .setHeader("appVersion", "20")
+            .setHeader("resultDestination", "commandResults")
+            .setHeader("spring.cloud.function.destination", "script.EXECUTE")
+            .build();
+        // when
+        input.send(message, "script.EXECUTE");
+
+        // then
+        verify(streamBridge, times(2)).send(eq("script.EXECUTE"), retryMessageCaptor.capture());
+        List<GenericMessage> retryMessages = retryMessageCaptor.getAllValues();
+        Assertions.assertThat(retryMessages).extracting("payload").containsExactly(payload, payload);
+        Assertions.assertThat(retryMessages).extracting("headers").extracting("x-retry-count").containsExactly(1, 2);
+
+        Message<byte[]> reply = output.receive(2000, bindingResolver.getBindingDestination(COMMAND_RESULTS));
+        assertThat(reply).isNull();
+    }
+
+    @Captor
+    private ArgumentCaptor<GenericMessage> retryMessageCaptor;
 
     private String resolveExpression(String value) {
         BeanExpressionResolver resolver = this.applicationContext.getBeanFactory().getBeanExpressionResolver();


### PR DESCRIPTION
When we are doing the upgrade of an application and we have a pod started with a new version and a pod started with an older version it could happen that the new pod produces an event with then new event version that it is consumed by a pod still running with the old version.
This will discard the event leaving the service task in a started status that will never be completed.

In order to solve this issue we added the retry parameter to the ConnectorBinding annotation. This new attribute will be used where requrired, for instance when running a ScriptTask.
Thanks to this new attribute we will republish the event multiple time in order to try to consume from a different node.