### PR TITLE
Trigram Search idea

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/33-alter.pg.schema.8.8.0.sql
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-liquibase/src/main/resources/config/query/liquibase/changelog/33-alter.pg.schema.8.8.0.sql
@@ -1,0 +1,2 @@
+
+CREATE INDEX task_variable_value_trgm_idx ON task_variable USING GIN ((value -> 'value') gin_trgm_ops) WHERE type = 'string';

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/TaskSearchRequest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/TaskSearchRequest.java
@@ -35,6 +35,7 @@ public record TaskSearchRequest (
     Set<Task.TaskStatus> status,
     Set<String> completedBy,
     Set<String> assignee,
+    Set<String> type,
     Date createdFrom,
     Date createdTo,
     Date lastModifiedFrom,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/TaskSpecification.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/TaskSpecification.java
@@ -104,6 +104,7 @@ public class TaskSpecification extends SpecificationSupport<TaskEntity, TaskSear
         applyDueDateFilters(root, criteriaBuilder);
         applyCandidateUserFilter(root);
         applyCandidateGroupFilter(root);
+        applyTypeFilter(root);
         if (!CollectionUtils.isEmpty(searchRequest.taskVariableFilters())) {
             SetJoin<TaskEntity, TaskVariableEntity> tvRoot = root.join(TaskEntity_.variables, JoinType.LEFT);
             filterConditions.addAll(

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/TaskSpecification.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/TaskSpecification.java
@@ -240,6 +240,12 @@ public class TaskSpecification extends SpecificationSupport<TaskEntity, TaskSear
         }
     }
 
+    private void applyTypeFilter(Root<TaskEntity> root) {
+        if (!CollectionUtils.isEmpty(searchRequest.type())) {
+            predicates.add(root.get(TaskEntity_.type).in(searchRequest.type()));
+        }
+    }
+
     private void applyCompletedByFilter(Root<TaskEntity> root) {
         if (!CollectionUtils.isEmpty(searchRequest.completedBy())) {
             predicates.add(root.get(TaskEntity_.completedBy).in(searchRequest.completedBy()));


### PR DESCRIPTION
I'm curious if this could spark some ideas around enabling FTS in the query service. 

This might not be a working example

I added type into the query so the trigram would only index on string variables to limit index size. Then you could enable it by passing type string in the query to enable the FTS search. The same idea could carry over to the process variables as well. 