### PR TITLE
AAE-39352 Add configuration support for Activiti Cloud Messaging Rabbit compression and decompression payloads

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/config/src/main/resources/activiti-cloud-query-config.properties
+++ b/activiti-cloud-examples/activiti-cloud-query/config/src/main/resources/activiti-cloud-query-config.properties
@@ -36,3 +36,4 @@ spring.cloud.stream.rabbit.bindings.functionRouterInput.consumer.prefetch=${ACT_
 spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.prefetch=${ACT_NOTIFICATIONS_GRAPHQL_ENGINE_EVENTS_CONSUMER_PREFETCH:20}
 
 activiti.cloud.messaging.rabbitmq.compress=true
+activiti.cloud.messaging.rabbitmq.compression-level=9

--- a/activiti-cloud-examples/activiti-cloud-query/config/src/main/resources/activiti-cloud-query-config.properties
+++ b/activiti-cloud-examples/activiti-cloud-query/config/src/main/resources/activiti-cloud-query-config.properties
@@ -34,3 +34,5 @@ activiti.cloud.messaging.function-router.routes.auditConsumer.enabled=true
 activiti.cloud.messaging.function-router.routes.queryConsumer.enabled=true
 spring.cloud.stream.rabbit.bindings.functionRouterInput.consumer.prefetch=${ACT_QUERY_CONSUMER_RABBIT_PREFETCH:20}
 spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.prefetch=${ACT_NOTIFICATIONS_GRAPHQL_ENGINE_EVENTS_CONSUMER_PREFETCH:20}
+
+activiti.cloud.messaging.rabbitmq.compress=true

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -15,12 +15,37 @@
  */
 package org.activiti.cloud.query.consumer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 
 @SpringBootTest(classes = { QueryConsumerApplication.class })
 public class QueryConsumerApplicationIT {
 
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
     @Test
     public void contextLoads() {}
+
+    @Test
+    void rabbitBinderCompression() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
+    }
+
+    @Test
+    void messagingPropertiesRabbitMqCompression() {
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
+    }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/rest/src/test/java/org/activiti/cloud/query/rest/QueryRestApplicationIT.java
@@ -30,6 +30,7 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import java.util.List;
 import java.util.Map;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.notifications.graphql.web.api.GraphQLQueryResult;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
@@ -40,6 +41,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -77,6 +79,12 @@ public class QueryRestApplicationIT {
 
     @Autowired
     private GraphQLSchema graphQLSchema;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     public void contextLoads() {
@@ -223,6 +231,20 @@ public class QueryRestApplicationIT {
         assertThat(result.getErrors()).isNull();
         assertThat(result.getData().toString())
             .isEqualTo("{Tasks={select=[{name=task1, assignee=testuser, priority=5}]}}");
+    }
+
+    @Test
+    void rabbitBinderCompression() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
+    }
+
+    @Test
+    void messagingPropertiesRabbitMqCompression() {
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
     }
 
     private HttpEntity entityWithAuthorizationHeader(String user, String password) {

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import java.util.Map;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.activiti.cloud.services.test.identity.IdentityTokenProducer;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -34,6 +35,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -64,6 +66,12 @@ public class QueryApplicationIT {
 
     @Autowired
     private IdentityTokenProducer identityTokenProducer;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     public void contextLoads() {
@@ -107,6 +115,20 @@ public class QueryApplicationIT {
             .extracting("list")
             .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
             .containsKeys("entries", "pagination");
+    }
+
+    @Test
+    void rabbitBinderCompression() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
+    }
+
+    @Test
+    void messagingPropertiesRabbitMqCompression() {
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
     }
 
     private HttpEntity entityWithAuthorizationHeader(String user, String password) {

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
@@ -22,3 +22,5 @@ spring.zipkin.enabled=false
 spring.zipkin.base-url=http://zipkin:80/
 spring.zipkin.sender.type=web
 management.tracing.sampling.probability=1.0
+
+activiti.cloud.messaging.rabbitmq.compress=true

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
@@ -24,3 +24,4 @@ spring.zipkin.sender.type=web
 management.tracing.sampling.probability=1.0
 
 activiti.cloud.messaging.rabbitmq.compress=true
+activiti.cloud.messaging.rabbitmq.compression-level=9

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppIT.java
@@ -26,6 +26,7 @@ import static org.springframework.cloud.function.context.FunctionRegistration.RE
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.examples.connectors.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = { CloudConnectorApp.class })
@@ -54,6 +56,12 @@ public class CloudConnectorAppIT {
 
     @Autowired
     private FunctionCatalog functionCatalog;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
 
     @Test
     public void contextShouldLoad() throws Exception {
@@ -83,6 +91,20 @@ public class CloudConnectorAppIT {
         Object jsonValue = objectMapper.readValue(json, Object.class);
         CustomPojo customPojo = objectMapper.convertValue(jsonValue, CustomPojo.class);
         assertThat(customPojo).isNotNull();
+    }
+
+    @Test
+    void rabbitBinderCompression() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
+    }
+
+    @Test
+    void messagingPropertiesRabbitMqCompression() {
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
     }
 
     private static String getRegisteredConnectorName(String functionName) {

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/main/resources/application.properties
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/main/resources/application.properties
@@ -25,3 +25,4 @@ project.manifest.file.path=classpath:/default-project.json
 activiti.cloud.swagger.rb-base-path=rb
 
 activiti.cloud.messaging.rabbitmq.compress=true
+activiti.cloud.messaging.rabbitmq.compression-level=9

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/main/resources/application.properties
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/main/resources/application.properties
@@ -23,3 +23,5 @@ activiti.cloud.application.name=default-app
 project.manifest.file.path=classpath:/default-project.json
 
 activiti.cloud.swagger.rb-base-path=rb
+
+activiti.cloud.messaging.rabbitmq.compress=true

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -17,18 +17,25 @@ package org.activiti.cloud.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest(classes = RuntimeBundleApplication.class)
+@SpringBootTest(
+    classes = RuntimeBundleApplication.class,
+    properties = {
+        "activiti.cloud.messaging.rabbitmq.compress=true", "activiti.cloud.messaging.rabbitmq.compression-level=9",
+    }
+)
 @ContextConfiguration(initializers = { KeycloakContainerApplicationInitializer.class })
 @Testcontainers
 public class RuntimeBundleApplicationIT {
@@ -40,8 +47,28 @@ public class RuntimeBundleApplicationIT {
     @Autowired
     private ApplicationContext applicationContext;
 
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private ActivitiCloudMessagingProperties messagingProperties;
+
     @Test
-    public void contextLoads() throws Exception {
+    public void contextLoads() {
         assertThat(applicationContext).isNotNull();
+    }
+
+    @Test
+    void rabbitBinderCompression() {
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
+    }
+
+    @Test
+    void messagingPropertiesRabbitMqCompression() {
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -122,6 +122,7 @@ public class ActivitiCloudMessagingProperties {
 
     private Map<String, InputConverterFunction> inputConverters;
 
+    @NestedConfigurationProperty
     private RabbitMqProperties rabbitmq = new RabbitMqProperties();
 
     public static class RabbitMqProperties {
@@ -129,6 +130,10 @@ public class ActivitiCloudMessagingProperties {
         private Boolean missingAnonymousQueuesFatal;
 
         private Boolean missingDurableQueuesFatal;
+
+        private Boolean compress = false;
+
+        private Integer compressionLevel = 1;
 
         public Boolean getMissingAnonymousQueuesFatal() {
             return missingAnonymousQueuesFatal;
@@ -144,6 +149,22 @@ public class ActivitiCloudMessagingProperties {
 
         public void setMissingDurableQueuesFatal(Boolean missingDurableQueuesFatal) {
             this.missingDurableQueuesFatal = missingDurableQueuesFatal;
+        }
+
+        public Boolean isCompress() {
+            return compress;
+        }
+
+        public void setCompress(Boolean compress) {
+            this.compress = compress;
+        }
+
+        public Integer getCompressionLevel() {
+            return compressionLevel;
+        }
+
+        public void setCompressionLevel(Integer compressionLevel) {
+            this.compressionLevel = compressionLevel;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -34,3 +34,7 @@ spring.cloud.stream.rabbit.bindings.functionRouterInput.consumer.exclusive=false
 spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.queue-name-group-only=true
 spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.durable-subscription=false
 spring.cloud.stream.rabbit.bindings.functionRouterAnonymousInput.consumer.exclusive=true
+
+# Default RabbitMq binder compression properties
+spring.cloud.stream.rabbit.default.producer.compress=${activiti.cloud.messaging.rabbitmq.compress:false}
+spring.cloud.stream.rabbit.binder.compression-level=${activiti.cloud.messaging.rabbitmq.compression-level:1}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ActivitiCloudMessagingAutoConfigurationTests.java
@@ -24,14 +24,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.config.ListenerContainerCustomizer;
+import org.springframework.core.env.Environment;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
-@SpringBootTest
+@SpringBootTest(
+    properties = {
+        "activiti.cloud.messaging.rabbitmq.compress=true", "activiti.cloud.messaging.rabbitmq.compression-level=9",
+    }
+)
 @SpringBootApplication
 public class ActivitiCloudMessagingAutoConfigurationTests {
 
     @Autowired
     private ActivitiCloudMessagingProperties messagingProperties;
+
+    @Autowired
+    private Environment environment;
 
     @Autowired(required = false)
     private ListenerContainerCustomizer<MessageListenerContainer> activitiRabbitMqMessageListenerContainerCustomizer;
@@ -47,5 +55,16 @@ public class ActivitiCloudMessagingAutoConfigurationTests {
         assertThat(messagingProperties.getRabbitmq().getMissingDurableQueuesFatal()).isTrue();
 
         assertThat(activitiRabbitMqMessageListenerContainerCustomizer).isNotNull();
+    }
+
+    @Test
+    public void rabbitMqCompressionConfiguration() {
+        assertThat(messagingProperties.getRabbitmq().isCompress()).isTrue();
+        assertThat(messagingProperties.getRabbitmq().getCompressionLevel()).isEqualTo(9);
+
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.binder.compression-level", Integer.class))
+            .isEqualTo(9);
+        assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.compress", Boolean.class))
+            .isTrue();
     }
 }


### PR DESCRIPTION
This PR adds Activiti messaging configuration support for the message payload compression for the RabbitMq binder. 

The message producer bindings will use `GZip` compression algorithm with the specified compression level (1-9) to encode payloads. The encoded message will have the `content_encoding=gzip` header for the consumers to be able to decompress messages. 

Message compression is disabled by default. To enable message compressor with compression level use the following configuration properties:

```
activiti.cloud.messaging.rabbitmq.compress=true
activiti.cloud.messaging.rabbitmq.compression-level=1 # from 1(FASTEST) to 9(BEST)
```

The expected reduction for the message size is 10x when using 9 compression level.

The provided examples have the compressor enabled with the compression level set to 9 for CI acceptance tests. 

https://hyland.atlassian.net/browse/AAE-39352