### PR TITLE
AAE-39613 Log error when invalid access token instance problem occurs

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtAccessTokenValidator.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/JwtAccessTokenValidator.java
@@ -47,7 +47,7 @@ public class JwtAccessTokenValidator {
             .map(check -> {
                 boolean valid = check.isValid(accessToken);
                 if (!valid) {
-                    LOGGER.debug("Token invalid because the {} validation has failed.", check.getClass().toString());
+                    LOGGER.error("Token invalid because the {} validation has failed.", check.getClass().toString());
                 }
                 return valid;
             })

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/validator/ExpiredValidationCheck.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/services/common/security/jwt/validator/ExpiredValidationCheck.java
@@ -39,7 +39,7 @@ public class ExpiredValidationCheck implements AbastractTimeValidationCheck {
                 currentTime > accessToken.getExpiresAt().toEpochMilli()
             );
         if (!result) {
-            LOGGER.debug("Current time {} is greater than expiration time {}", currentTime, accessToken.getExpiresAt());
+            LOGGER.error("Current time {} is greater than expiration time {}", currentTime, accessToken.getExpiresAt());
         }
         return result;
     }


### PR DESCRIPTION
The change would be consistent to existing validators like: `IsNotBeforeValidationCheck`
and being an error it would be log the problem at error level