### PR TITLE
AAE-39919 Implement message router error handler definition support 

### DIFF
--- a/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/main/resources/application.properties
@@ -25,3 +25,6 @@ management.tracing.sampling.probability=1.0
 
 activiti.cloud.messaging.rabbitmq.compress=true
 activiti.cloud.messaging.rabbitmq.compression-level=9
+
+activiti.cloud.messaging.function-router.routes.example-connector.enabled=true
+activiti.cloud.messaging.function-router.group=${spring.application.name}

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/CloudConnectorAppFunctionRouterIT.java
@@ -17,6 +17,8 @@ package org.activiti.cloud.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
@@ -30,18 +32,55 @@ public class CloudConnectorAppFunctionRouterIT extends CloudConnectorAppIT {
 
     @Test
     void bindingServiceProperties() {
-        assertThat(bindingServiceProperties.getBindings()).doesNotContainKeys("functionRouterInput").isNotEmpty();
+        assertThat(bindingServiceProperties.getBindings()).isNotEmpty().containsOnlyKeys("functionRouterInput");
     }
 
     @Test
-    void functionRouter() {
+    void functionRouterEnabled() {
         var functionRouter = messagingProperties.getFunctionRouter();
 
         assertThat(functionRouter.isEnabled()).isTrue();
+    }
 
-        assertThat(functionRouter.getFunctionRoutes()).isEmpty();
-        assertThat(functionRouter.destinations()).isEmpty();
-        assertThat(functionRouter.registrations()).isEmpty();
+    @Test
+    void functionRouterRoutes() {
+        var functionRouter = messagingProperties.getFunctionRouter();
+
+        assertThat(functionRouter.getFunctionRoutes()).isNotEmpty().containsOnly("example-connector");
+    }
+
+    @Test
+    void functionRouterDestinations() {
+        var functionRouter = messagingProperties.getFunctionRouter();
+
+        assertThat(functionRouter.destinations())
+            .isNotEmpty()
+            .containsOnly(
+                Map.entry(
+                    "example-connector",
+                    "restconnector.POST,restConnector.GET,test-bpmn-error-connector.throwError,test-error-connector.throwError,miCloudConnector,headers.GET,Movies.getMovieDesc,ExampleConnector"
+                )
+            );
+    }
+
+    @Test
+    void functionRouterRegistrations() {
+        var functionRouter = messagingProperties.getFunctionRouter();
+
+        assertThat(functionRouter.registrations())
+            .isNotEmpty()
+            .containsOnly(
+                Map.entry("ExampleConnector", List.of("exampleConnectorConsumerConnector_registration")),
+                Map.entry("Movies.getMovieDesc", List.of("moviesDescriptionConsumerConnector_registration")),
+                Map.entry("headers.GET", List.of("headersConnectorConsumerConnector_registration")),
+                Map.entry("miCloudConnector", List.of("miCloudConnectorInputConnector_registration")),
+                Map.entry("restconnector.POST", List.of("restConnectorPOST_registration")),
+                Map.entry(
+                    "test-bpmn-error-connector.throwError",
+                    List.of("testBpmnErrorConnectorInputConnector_registration")
+                ),
+                Map.entry("test-error-connector.throwError", List.of("testErrorConnectorInputConnector_registration"))
+            );
     }
 
     @Test
@@ -54,6 +93,7 @@ public class CloudConnectorAppFunctionRouterIT extends CloudConnectorAppIT {
         )
             .isTrue();
 
-        assertThat(environment.getProperty("activiti.cloud.messaging.function-router.group", String.class)).isNull();
+        assertThat(environment.getProperty("activiti.cloud.messaging.function-router.group", String.class))
+            .isEqualTo("processing-connector");
     }
 }

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/connectors/TestBpmnErrorConnectorFunctionRouterIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/connectors/TestBpmnErrorConnectorFunctionRouterIT.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.examples.connectors;
+
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
+public class TestBpmnErrorConnectorFunctionRouterIT extends TestBpmnErrorConnectorIT {}

--- a/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/connectors/TestErrorConnectorFunctionRouterIT.java
+++ b/activiti-cloud-examples/example-cloud-connector/starter/src/test/java/org/activiti/cloud/examples/connectors/TestErrorConnectorFunctionRouterIT.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2025 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.examples.connectors;
+
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "activiti.cloud.messaging.function-router.enabled=true" })
+public class TestErrorConnectorFunctionRouterIT extends TestBpmnErrorConnectorIT {}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -434,6 +434,8 @@ public class ActivitiCloudMessagingProperties {
         @NotEmpty
         private String group = "function-router";
 
+        private String errorHandlerDefinition;
+
         private int maxRetries = 3;
 
         private Duration retryInterval = Duration.ofMillis(10);
@@ -613,7 +615,8 @@ public class ActivitiCloudMessagingProperties {
                 maxRetries,
                 retryInterval,
                 consumer,
-                anonymous
+                anonymous,
+                errorHandlerDefinition
             );
         }
 
@@ -629,11 +632,20 @@ public class ActivitiCloudMessagingProperties {
                 .add("retryInterval=" + retryInterval)
                 .add("consumer=" + consumer)
                 .add("anonymous=" + anonymous)
+                .add("errorHandlerDefinition=" + errorHandlerDefinition)
                 .toString();
         }
 
         public FunctionRouterAnonymousProperties getAnonymous() {
             return anonymous;
+        }
+
+        public String getErrorHandlerDefinition() {
+            return errorHandlerDefinition;
+        }
+
+        public void setErrorHandlerDefinition(String errorHandlerDefinition) {
+            this.errorHandlerDefinition = errorHandlerDefinition;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/AbstractFunctionalBindingConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/AbstractFunctionalBindingConfiguration.java
@@ -17,9 +17,11 @@ package org.activiti.cloud.common.messaging.config;
 
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import org.activiti.cloud.common.messaging.functional.ConnectorGateway;
 import org.activiti.cloud.common.messaging.functional.ConsumerGateway;
 import org.springframework.beans.BeansException;
@@ -38,6 +40,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
@@ -135,5 +139,32 @@ public abstract class AbstractFunctionalBindingConfiguration implements Applicat
 
     protected MessageConverterConfigurer getMessageConverterConfigurer() {
         return applicationContext.getBean("messageConverterConfigurer", MessageConverterConfigurer.class);
+    }
+
+    protected String registerConnectorFlowFunction(IntegrationFlow connectorFlow, String beanName) {
+        final Consumer<Message<?>> connectorFlowFunction = connectorFlow.getInputChannel()::send;
+
+        final var connectorFlowFunctionRegistration = new FunctionRegistration<>(connectorFlowFunction)
+            .type(new MessageConsumerParametrizedType());
+
+        return registerFunctionRegistration(beanName, connectorFlowFunctionRegistration);
+    }
+
+    static class MessageConsumerParametrizedType implements ParameterizedType {
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return new Type[] { Message.class };
+        }
+
+        @Override
+        public Type getRawType() {
+            return Consumer.class;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsBeanPostProcessor.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ActivitiMessagingDestinationsBeanPostProcessor.java
@@ -181,6 +181,7 @@ public class ActivitiMessagingDestinationsBeanPostProcessor implements BeanPostP
                     bindingProperties.setDestination(destination);
                     bindingProperties.setGroup(new Base64UrlNamingStrategy(groupPrefix).generateName());
                     bindingProperties.setConsumer(functionRouter.getAnonymous().getConsumer());
+                    bindingProperties.setErrorHandlerDefinition(functionRouter.getErrorHandlerDefinition());
 
                     bindingServiceProperties.getBindings().put(FUNCTION_ROUTER_ANONYMOUS_INPUT, bindingProperties);
 
@@ -200,6 +201,7 @@ public class ActivitiMessagingDestinationsBeanPostProcessor implements BeanPostP
                     bindingProperties.setDestination(destination);
                     bindingProperties.setGroup(group);
                     bindingProperties.setConsumer(functionRouter.getConsumer());
+                    bindingProperties.setErrorHandlerDefinition(functionRouter.getErrorHandlerDefinition());
 
                     bindingServiceProperties.getBindings().put(FUNCTION_ROUTER_INPUT, bindingProperties);
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -92,31 +92,19 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                             final Type functionType = discoverFunctionType(bean, beanName);
                             final var functionRouter = messagingProperties.getFunctionRouter();
 
-                            FunctionRegistration functionRegistration = new FunctionRegistration(bean)
+                            FunctionRegistration<Object> functionRegistration = new FunctionRegistration<>(bean)
                                 .type(functionType);
 
-                            final var functionBeanName = registerFunctionRegistration(beanName, functionRegistration);
+                            final var functionDefinition = functionRouter.isEnabled()
+                                ? beanName.concat("Target")
+                                : beanName;
 
-                            if (functionRouter.isEnabled()) {
-                                Optional
-                                    .ofNullable(connectorBinding.connectorType())
-                                    .filter(StringUtils::hasText)
-                                    .map(resolveExpression)
-                                    .ifPresentOrElse(
-                                        connectorType ->
-                                            functionRouter.register(
-                                                connectorBinding.input(),
-                                                functionBeanName,
-                                                connectorType
-                                            ),
-                                        () -> functionRouter.register(connectorBinding.input(), functionBeanName)
-                                    );
-                            }
+                            registerFunctionRegistration(functionDefinition, functionRegistration);
 
                             responseDestination.set(connectorBinding.outputHeader());
 
                             GenericHandler<Message> handler = (message, headers) -> {
-                                FunctionInvocationWrapper function = functionFromDefinition(beanName);
+                                FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                                 Object result = function.apply(message);
 
                                 Message<?> response = null;
@@ -205,6 +193,24 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 .get();
 
                             integrationFlowContext.registration(inputChannelFlow).register();
+
+                            if (functionRouter.isEnabled()) {
+                                final var functionBeanName = registerConnectorFlowFunction(connectorFlow, beanName);
+
+                                Optional
+                                    .ofNullable(connectorBinding.connectorType())
+                                    .filter(StringUtils::hasText)
+                                    .map(resolveExpression)
+                                    .ifPresentOrElse(
+                                        connectorTypeName ->
+                                            functionRouter.register(
+                                                connectorBinding.input(),
+                                                functionBeanName,
+                                                connectorTypeName
+                                            ),
+                                        () -> functionRouter.register(connectorBinding.input(), functionBeanName)
+                                    );
+                            }
                         });
                 }
                 return bean;
@@ -216,12 +222,12 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
         flow.handle((payload, headers) -> {
             Message<?> newMessage = handleMessagingExceptionIfPossible(payload, headers)
                 .orElse(buildNewMessage(headers, payload));
-            Object destination = headers.get("spring.cloud.function.destination");
+            final var destination = headers.get("spring.cloud.function.destination", String.class);
             if (destination != null) {
                 int retryCount = getRetryCount(headers);
                 if (retryCount < maxRetry - 1) {
                     safeSleep(retryDelay);
-                    getStreamBridge().send((String) destination, newMessage);
+                    getStreamBridge().send(destination, newMessage);
                 } else {
                     LOGGER.error("Cannot retry message because retry limited exceeded: {}", maxRetry);
                 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
@@ -145,11 +145,11 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                             FunctionRegistration functionRegistration = new FunctionRegistration(bean)
                                 .type(functionType);
 
-                            var functionBeanName = registerFunctionRegistration(beanName, functionRegistration);
+                            final var functionDefinition = functionRouter.isEnabled()
+                                ? beanName.concat("Target")
+                                : beanName;
 
-                            if (functionRouter.isEnabled()) {
-                                functionRouter.register(functionBinding.input(), functionBeanName);
-                            }
+                            registerFunctionRegistration(functionDefinition, functionRegistration);
 
                             GenericSelector<Message<?>> selector = Optional
                                 .ofNullable(functionBinding)
@@ -160,7 +160,7 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                 .orElseGet(() -> new ExpressionEvaluatingSelector("true"));
 
                             if (Supplier.class.isInstance(bean)) {
-                                FunctionInvocationWrapper supplier = functionFromDefinition(beanName);
+                                FunctionInvocationWrapper supplier = functionFromDefinition(functionDefinition);
 
                                 IntegrationFlowBuilder supplierFlowBuilder = IntegrationFlow
                                     .fromSupplier(supplier)
@@ -176,7 +176,7 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                 integrationFlowContext.registration(supplierFlowBuilder.get()).register();
                             } else {
                                 GenericHandler<Message> handler = (message, headers) -> {
-                                    FunctionInvocationWrapper function = functionFromDefinition(beanName);
+                                    FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                                     return function.apply(message);
                                 };
 
@@ -201,12 +201,20 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                         .channel(functionBinding.output());
                                 }
 
+                                final var connectorFlow = functionFlowBuilder.get();
+
                                 IntegrationFlow inputChannelFlow = IntegrationFlow
                                     .from(functionBinding.input())
-                                    .gateway(functionFlowBuilder.get(), spec -> spec.replyTimeout(0L))
+                                    .gateway(connectorFlow, spec -> spec.replyTimeout(0L))
                                     .get();
 
                                 integrationFlowContext.registration(inputChannelFlow).register();
+
+                                if (functionRouter.isEnabled()) {
+                                    final var functionBeanName = registerConnectorFlowFunction(connectorFlow, beanName);
+
+                                    functionRouter.register(functionBinding.input(), functionBeanName);
+                                }
                             }
                         });
                 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -76,6 +76,7 @@ public class FunctionRouterConfiguration {
     public static final String FUNCTION_DESTINATION = "spring.cloud.function.destination";
     public static final String FUNCTION_ROUTER_INPUT = "functionRouterInput";
     public static final String FUNCTION_ROUTER_ANONYMOUS_INPUT = "functionRouterAnonymousInput";
+    public static final String CONNECTOR_TYPE = "connectorType";
 
     @Bean
     ApplicationRunner functionRouterConfigurationApplicationRunner(
@@ -140,8 +141,8 @@ public class FunctionRouterConfiguration {
         return (message, routingContext) -> {
             Optional
                 .ofNullable(message.getHeaders().get(FUNCTION_DESTINATION, String.class))
+                .or(() -> Optional.ofNullable(message.getHeaders().get(CONNECTOR_TYPE, String.class)))
                 .or(() -> Optional.ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class)))
-                .or(() -> Optional.ofNullable(message.getHeaders().get("connectorType", String.class)))
                 .map(messagingProperties.getFunctionRouter().registrations(routingContext)::get)
                 .filter(Predicate.not(Collection::isEmpty))
                 .ifPresentOrElse(

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -43,8 +44,10 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionProperties;
 import org.springframework.cloud.function.context.MessageRoutingCallback;
+import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry;
 import org.springframework.cloud.function.context.config.RoutingFunction;
 import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
@@ -54,9 +57,12 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.StringUtils;
 
 @AutoConfiguration(
     before = InputBindingConfiguration.class,
@@ -127,13 +133,15 @@ public class FunctionRouterConfiguration {
     @Bean
     BiConsumer<Message<?>, String> functionRouterMessageHandler(
         RoutingFunction routingFunction,
-        ActivitiCloudMessagingProperties messagingProperties
+        ActivitiCloudMessagingProperties messagingProperties,
+        FunctionCatalog functionCatalog
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
         return (message, routingContext) -> {
             Optional
                 .ofNullable(message.getHeaders().get(FUNCTION_DESTINATION, String.class))
                 .or(() -> Optional.ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class)))
+                .or(() -> Optional.ofNullable(message.getHeaders().get("connectorType", String.class)))
                 .map(messagingProperties.getFunctionRouter().registrations(routingContext)::get)
                 .filter(Predicate.not(Collection::isEmpty))
                 .ifPresentOrElse(
@@ -199,6 +207,31 @@ public class FunctionRouterConfiguration {
 
                             if (!errors.isEmpty()) {
                                 log.debug("Errors handling function route message request {}", errors);
+
+                                Optional
+                                    .ofNullable(messagingProperties.getFunctionRouter().getErrorHandlerDefinition())
+                                    .filter(StringUtils::hasText)
+                                    .map(functionCatalog::lookup)
+                                    .map(SimpleFunctionRegistry.FunctionInvocationWrapper.class::cast)
+                                    .ifPresent(errorHandlerDefinition -> {
+                                        errors
+                                            .stream()
+                                            .map(CompletionException.class::cast)
+                                            .map(CompletionException::getCause)
+                                            .map(exception -> {
+                                                if (exception instanceof MessagingException messagingException) {
+                                                    return new ErrorMessage(messagingException, message);
+                                                } else {
+                                                    return new ErrorMessage(
+                                                        new MessagingException(message, exception),
+                                                        message
+                                                    );
+                                                }
+                                            })
+                                            .forEach(errorMessage -> {
+                                                errorHandlerDefinition.accept(errorMessage);
+                                            });
+                                    });
                             } else {
                                 log.debug("Successfully completed function route message request {}", message);
                             }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -42,3 +42,5 @@ spring.cloud.stream.rabbit.binder.compression-level=${activiti.cloud.messaging.r
 # Default RabbitMq prefix properties
 spring.cloud.stream.rabbit.default.producer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
 spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
+
+activiti.cloud.messaging.function-router.error-handler-definition=${spring.cloud.stream.default.error-handler-definition:}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationFunctionRouterEnabledIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationFunctionRouterEnabledIT.java
@@ -15,13 +15,10 @@
  */
 package org.activiti.cloud.common.messaging.config.test;
 
-import static org.activiti.cloud.common.messaging.config.AbstractFunctionalBindingConfiguration.getInBinding;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_CONSUMER;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.QUERY_CONSUMER;
+import static org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration.FUNCTION_ROUTER_ANONYMOUS_INPUT;
+import static org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
@@ -29,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Import;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
@@ -41,32 +37,24 @@ import org.springframework.test.context.TestPropertySource;
         "activiti.cloud.messaging.function-router.routes.integrationRequests.enabled=true",
     }
 )
-@Import(FunctionBindingConfigurationFunctionRouterEnabledIT.ApplicationConfig.class)
-public class FunctionBindingConfigurationFunctionRouterEnabledIT extends FunctionBindingConfigurationIT {
+@Import(ConnectorConfigurationFunctionRouterEnabledIT.ApplicationConfig.class)
+public class ConnectorConfigurationFunctionRouterEnabledIT extends ConnectorConfigurationIT {
 
     @Autowired
     private BindingServiceProperties bindingServiceProperties;
 
     @Test
     @Override
-    void testInputBindingsDefinitions() {
-        Assertions.assertThat(context.getBean(COMMAND_CONSUMER, MessageChannel.class)).isNotNull();
-        Assertions
-            .assertThat(bindingServiceProperties.getInputBindings())
-            .doesNotContain(FUNCTION_COMMAND_CONSUMER_NAME);
-        Assertions
-            .assertThat(streamFunctionProperties.getBindings().get(getInBinding(FUNCTION_COMMAND_CONSUMER_NAME)))
-            .isNull();
-        Assertions.assertThat(context.getBean(AUDIT_CONSUMER, MessageChannel.class)).isNotNull();
-        Assertions.assertThat(bindingServiceProperties.getInputBindings()).doesNotContain(FUNCTION_AUDIT_CONSUMER_NAME);
-        Assertions
-            .assertThat(streamFunctionProperties.getBindings().get(getInBinding(FUNCTION_AUDIT_CONSUMER_NAME)))
-            .isNull();
-        Assertions.assertThat(context.getBean(QUERY_CONSUMER, MessageChannel.class)).isNotNull();
-        Assertions.assertThat(bindingServiceProperties.getInputBindings()).doesNotContain(FUNCTION_QUERY_CONSUMER_NAME);
-        Assertions
-            .assertThat(streamFunctionProperties.getBindings().get(getInBinding(FUNCTION_QUERY_CONSUMER_NAME)))
-            .isNull();
+    void defaultErrorHandlerDefinition() {
+        AssertionsForClassTypes
+            .assertThat(bindingServiceProperties.getBindingProperties(FUNCTION_ROUTER_INPUT))
+            .extracting(BindingProperties::getErrorHandlerDefinition)
+            .isEqualTo(MY_ERROR_HANDLER);
+
+        AssertionsForClassTypes
+            .assertThat(bindingServiceProperties.getBindingProperties(FUNCTION_ROUTER_ANONYMOUS_INPUT))
+            .extracting(BindingProperties::getErrorHandlerDefinition)
+            .isEqualTo(MY_ERROR_HANDLER);
     }
 
     @Test
@@ -81,11 +69,12 @@ public class FunctionBindingConfigurationFunctionRouterEnabledIT extends Functio
             .assertThat(bindings)
             .asInstanceOf(InstanceOfAssertFactories.map(String.class, BindingProperties.class))
             .containsOnlyKeys(
-                "auditProducer",
+                "functionRouterInput",
+                "functionRouterAnonymousInput",
                 "commandResults",
                 "integrationResults",
-                "functionRouterInput",
-                "functionRouterAnonymousInput"
+                "auditProducer",
+                "script.EXECUTE"
             );
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanExpressionContext;
@@ -84,6 +85,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
         "spring.cloud.stream.bindings.commandResults.destination=commandResults",
         "spring.cloud.stream.bindings.integrationRequests.destination=rest-connector.GET,rest-connector.POST,script.EXECUTE",
         "spring.cloud.stream.bindings.integrationResults.destination=integrationResults",
+        "spring.cloud.stream.bindings.[script.EXECUTE].destination=script.EXECUTE",
         "spring.cloud.stream.default.error-handler-definition=myErrorHandler",
     }
 )
@@ -186,7 +188,7 @@ public class ConnectorConfigurationIT {
         }
 
         @Bean(FUNCTION_NAME_D)
-        @ConnectorBinding(input = AUDIT_CONSUMER, output = COMMAND_RESULTS)
+        @ConnectorBinding(input = AUDIT_CONSUMER, output = COMMAND_RESULTS, connectorType = "engineEvents")
         public Connector<?, ?> auditProcessorVersionHandler() {
             return payload -> "TestVersion";
         }
@@ -385,6 +387,7 @@ public class ConnectorConfigurationIT {
             .withPayload(Map.of())
             .setHeader("appVersion", "6")
             .setHeader("resultDestination", "commandResults")
+            .setHeader("connectorType", "engineEvents")
             .build();
 
         // when
@@ -424,6 +427,7 @@ public class ConnectorConfigurationIT {
             .setHeader("type", "TestAuditConsumerC")
             .setHeader("appVersion", "1")
             .setHeader("resultDestination", "commandResults")
+            .setHeader(AmqpHeaders.RECEIVED_EXCHANGE, "engineEvents")
             .build();
         // when
         input.send(message, "engineEvents");
@@ -445,6 +449,7 @@ public class ConnectorConfigurationIT {
             .setHeader("type", "myErrorHandler")
             .setHeader("appVersion", "1")
             .setHeader("resultDestination", "commandResults")
+            .setHeader(AmqpHeaders.RECEIVED_EXCHANGE, "engineEvents")
             .build();
         // when
         input.send(message, "engineEvents");
@@ -524,19 +529,23 @@ public class ConnectorConfigurationIT {
         // when
         long start = System.currentTimeMillis();
         input.send(message, "script.EXECUTE");
-        long end = System.currentTimeMillis();
 
         //Check delay execution = (retries -1) * delay time. It is a bit greater because some operation overload
-        assertThat(end - start).isBetween(2000L, 2500L);
+        await()
+            .untilAsserted(() -> {
+                // then
+                verify(streamBridge, times(2)).send(eq("script.EXECUTE"), retryMessageCaptor.capture());
+                List<GenericMessage> retryMessages = retryMessageCaptor.getAllValues();
+                Assertions.assertThat(retryMessages).extracting("payload").containsExactly(payload, payload);
+                Assertions
+                    .assertThat(retryMessages)
+                    .extracting("headers")
+                    .extracting("x-retry-count")
+                    .containsExactly(1, 2);
 
-        // then
-        verify(streamBridge, times(2)).send(eq("script.EXECUTE"), retryMessageCaptor.capture());
-        List<GenericMessage> retryMessages = retryMessageCaptor.getAllValues();
-        Assertions.assertThat(retryMessages).extracting("payload").containsExactly(payload, payload);
-        Assertions.assertThat(retryMessages).extracting("headers").extracting("x-retry-count").containsExactly(1, 2);
-
-        Message<byte[]> reply = output.receive(2000, bindingResolver.getBindingDestination(COMMAND_RESULTS));
-        assertThat(reply).isNull();
+                Message<byte[]> reply = output.receive(2000, bindingResolver.getBindingDestination(COMMAND_RESULTS));
+                assertThat(reply).isNull();
+            });
     }
 
     @Captor

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionBindingConfigurationIT.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.common.messaging.config.test;
 
 import static org.activiti.cloud.common.messaging.config.AbstractFunctionalBindingConfiguration.getInBinding;
+import static org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration.FUNCTION_DESTINATION;
 import static org.activiti.cloud.common.messaging.config.InputBindingConfiguration.INPUT_BINDING;
 import static org.activiti.cloud.common.messaging.config.OutputBindingConfiguration.OUTPUT_BINDING;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
@@ -26,8 +27,10 @@ import static org.awaitility.Awaitility.await;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -66,13 +69,13 @@ import org.springframework.messaging.support.MessageBuilder;
 @Import({ TestChannelBinderConfiguration.class, TestBindingsChannelsConfiguration.class })
 public class FunctionBindingConfigurationIT {
 
-    private static final String FUNCTION_HANDLER_NAME = "queryConsumerHandler";
-    private static final String FUNCTION_PROCESSOR_NAME = "commandProcessorHandler";
-    private static final String FUNCTION_AUDIT_SUPPLIER_NAME = "auditProducer" + OUTPUT_BINDING;
-    private static final String FUNCTION_COMMAND_SUPPLIER_NAME = "commandResults" + OUTPUT_BINDING;
-    private static final String FUNCTION_COMMAND_CONSUMER_NAME = "commandConsumer" + INPUT_BINDING;
-    private static final String FUNCTION_AUDIT_CONSUMER_NAME = "auditConsumer" + INPUT_BINDING;
-    private static final String FUNCTION_QUERY_CONSUMER_NAME = "queryConsumer" + INPUT_BINDING;
+    static final String FUNCTION_HANDLER_NAME = "queryConsumerHandler";
+    static final String FUNCTION_PROCESSOR_NAME = "commandProcessorHandler";
+    static final String FUNCTION_AUDIT_SUPPLIER_NAME = "auditProducer" + OUTPUT_BINDING;
+    static final String FUNCTION_COMMAND_SUPPLIER_NAME = "commandResults" + OUTPUT_BINDING;
+    static final String FUNCTION_COMMAND_CONSUMER_NAME = "commandConsumer" + INPUT_BINDING;
+    static final String FUNCTION_AUDIT_CONSUMER_NAME = "auditConsumer" + INPUT_BINDING;
+    static final String FUNCTION_QUERY_CONSUMER_NAME = "queryConsumer" + INPUT_BINDING;
 
     private static Message<?> consumerMessage = null;
 
@@ -86,7 +89,7 @@ public class FunctionBindingConfigurationIT {
     private FunctionRegistry functionRegistry;
 
     @Autowired
-    private StreamFunctionProperties streamFunctionProperties;
+    protected StreamFunctionProperties streamFunctionProperties;
 
     @Autowired
     private BindingResolver bindingResolver;
@@ -95,13 +98,16 @@ public class FunctionBindingConfigurationIT {
     private BindingServiceProperties bindingServiceProperties;
 
     @Autowired
-    private ConfigurableApplicationContext context;
+    protected ConfigurableApplicationContext context;
 
     @Autowired
     private InputDestination input;
 
     @Autowired
     private OutputDestination output;
+
+    @Autowired
+    protected ActivitiCloudMessagingProperties messagingProperties;
 
     @TestConfiguration
     static class ApplicationConfig {
@@ -228,15 +234,18 @@ public class FunctionBindingConfigurationIT {
         Message<String> message = MessageBuilder.withPayload("Test").setHeader("type", "Test Consumer").build();
 
         // when
-        input.send(message, "engineEvents");
+        send(message, "engineEvents");
 
         // then
-        assertThat(consumerMessage).isNotNull();
-        assertThat(consumerMessage.getHeaders().get("type", String.class)).isEqualTo("Test Consumer");
+        await()
+            .untilAsserted(() -> {
+                assertThat(consumerMessage).isNotNull();
+                assertThat(consumerMessage.getHeaders().get("type", String.class)).isEqualTo("Test Consumer");
+            });
     }
 
     @Test
-    public void testFunctionBindings() throws InterruptedException {
+    public void testFunctionBindings() {
         // given
         Message<String> message = MessageBuilder.withPayload("Test").setHeader("type", "Test Consumer").build();
 
@@ -244,11 +253,11 @@ public class FunctionBindingConfigurationIT {
         channels.commandConsumer().send(message);
 
         // then
-        assertThat(consumerMessage).isNotNull();
-        assertThat(consumerMessage.getHeaders().get("type", String.class)).isEqualTo("Test Send");
-
         await()
             .untilAsserted(() -> {
+                assertThat(consumerMessage).isNotNull();
+                assertThat(consumerMessage.getHeaders().get("type", String.class)).isEqualTo("Test Send");
+
                 Message<?> outputMessage = output.receive(
                     1000,
                     bindingResolver.getBindingDestination(TestBindingsChannels.COMMAND_RESULTS)
@@ -256,5 +265,15 @@ public class FunctionBindingConfigurationIT {
                 assertThat(outputMessage).isNotNull();
                 assertThat(outputMessage.getHeaders().get("type", String.class)).isEqualTo("Test Reply");
             });
+    }
+
+    protected void send(Message<String> message, String destination) {
+        final var messageToSend = Optional
+            .of(message)
+            .filter(it -> messagingProperties.getFunctionRouter().isEnabled())
+            .map(it -> MessageBuilder.fromMessage(message).setHeader(FUNCTION_DESTINATION, destination).build())
+            .orElse(message);
+
+        input.send(messageToSend, destination);
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -519,6 +519,7 @@ public class FunctionRouterBindingConfigurationIT {
         Message<String> message = MessageBuilder
             .withPayload("GET http://localhost:8080")
             .setHeader(FUNCTION_DESTINATION, "rest.GET")
+            .setHeader("connectorType", "rest.GET")
             .build();
 
         // when
@@ -538,6 +539,7 @@ public class FunctionRouterBindingConfigurationIT {
         Message<String> message = MessageBuilder
             .withPayload("POST http://localhost:8080")
             .setHeader(FUNCTION_DESTINATION, "rest.POST")
+            .setHeader("connectorType", "rest.POST")
             .build();
 
         // when


### PR DESCRIPTION
This PR adds support for the error handler definition configuration for function router input bindings to fix the regression when propagating runtime errors from connectors back to runtime. 

It also makes sure the all connector binding annotations are effectively handled conditions when using message router in connectors.

https://hyland.atlassian.net/browse/AAE-39919