### PR TITLE
AAE-39909 Bump com.github.dasniko:testcontainers-keycloak to 4.0.0

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/services/common/security/JwtPrincipalRolesProviderChainTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/test/java/org/activiti/cloud/services/common/security/JwtPrincipalRolesProviderChainTest.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.services.common.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,12 +30,11 @@ import org.activiti.cloud.services.common.security.jwt.JwtPrincipalRolesProvider
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.KeycloakPrincipal;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class JwtPrincipalRolesProviderChainTest {
+class JwtPrincipalRolesProviderChainTest {
 
     private JwtPrincipalRolesProviderChain subject;
 
@@ -47,14 +45,14 @@ public class JwtPrincipalRolesProviderChainTest {
     PrincipalRolesProvider provider2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         subject = new JwtPrincipalRolesProviderChain(Arrays.asList(provider1, provider2));
     }
 
     @Test
-    public void testGetRoles() {
+    void testGetRoles() {
         // given
-        Principal principal = mock(KeycloakPrincipal.class);
+        Principal principal = mock(Principal.class);
         when(provider1.getRoles(any())).thenReturn(null);
         when(provider2.getRoles(any())).thenReturn(Arrays.asList("role1", "role2"));
 
@@ -64,26 +62,24 @@ public class JwtPrincipalRolesProviderChainTest {
         // then
         assertThat(result).isNotEmpty().containsExactly("role1", "role2");
 
-        verify(provider1).getRoles(eq(principal));
-        verify(provider2).getRoles(eq(principal));
+        verify(provider1).getRoles(principal);
+        verify(provider2).getRoles(principal);
     }
 
     @Test
-    public void testGetRolesSecurityException() {
+    void testGetRolesSecurityException() {
         // given
-        Principal principal = mock(KeycloakPrincipal.class);
+        Principal principal = mock(Principal.class);
         when(provider1.getRoles(any())).thenReturn(null);
         when(provider2.getRoles(any())).thenReturn(null);
 
         // when
-        Throwable thrown = catchThrowable(() -> {
-            subject.getRoles(principal);
-        });
+        Throwable thrown = catchThrowable(() -> subject.getRoles(principal));
 
         // then
         assertThat(thrown).isInstanceOf(SecurityException.class);
 
-        verify(provider1).getRoles(eq(principal));
-        verify(provider2).getRoles(eq(principal));
+        verify(provider1).getRoles(principal);
+        verify(provider2).getRoles(principal);
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>activiti-cloud-services-test-containers</artifactId>
   <name>Activiti Cloud Services :: Test Containers</name>
   <properties>
-    <testcontainers-keycloak.version>3.3.1</testcontainers-keycloak.version>
+    <testcontainers-keycloak.version>4.0.0</testcontainers-keycloak.version>
   </properties>
   <dependencies>
     <dependency>

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -16,19 +16,30 @@
 package org.activiti.cloud.services.test.containers;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
+import java.time.Duration;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
 public class KeycloakContainerApplicationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    private static KeycloakContainer keycloakContainer = new KeycloakContainer("quay.io/keycloak/keycloak:26.1.0")
+    private static KeycloakContainer keycloakContainer = new KeycloakContainer("quay.io/keycloak/keycloak:24.0.3")
         .withAdminUsername("admin")
         .withAdminPassword("admin")
         .withRealmImportFile("activiti-realm.json")
+        .waitingFor(legacyHealthCheckStrategy())
         .withReuse(true);
+
+    // Remove once Keycloak is migrated to >= 25
+    private static @NotNull WaitStrategy legacyHealthCheckStrategy() {
+        return Wait.forHttp("/health/started")
+            .forPort(8080)
+            .withStartupTimeout(Duration.ofMinutes(2));
+    }
 
     @Override
     public void initialize(ConfigurableApplicationContext context) {

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -36,9 +36,7 @@ public class KeycloakContainerApplicationInitializer
 
     // Remove once Keycloak is migrated to >= 25
     private static @NotNull WaitStrategy legacyHealthCheckStrategy() {
-        return Wait.forHttp("/health/started")
-            .forPort(8080)
-            .withStartupTimeout(Duration.ofMinutes(2));
+        return Wait.forHttp("/health/started").forPort(8080).withStartupTimeout(Duration.ofMinutes(2));
     }
 
     @Override

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -34,7 +34,7 @@ public class KeycloakContainerApplicationInitializer
         .waitingFor(legacyHealthCheckStrategy())
         .withReuse(true);
 
-    // Remove once Keycloak is migrated to >= 25
+    // Remove once Keycloak is migrated to >= 25. See: https://github.com/dasniko/testcontainers-keycloak/pull/142
     private static @NotNull WaitStrategy legacyHealthCheckStrategy() {
         return Wait.forHttp("/health/started").forPort(8080).withStartupTimeout(Duration.ofMinutes(2));
     }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-containers/src/main/java/org/activiti/cloud/services/test/containers/KeycloakContainerApplicationInitializer.java
@@ -24,7 +24,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 public class KeycloakContainerApplicationInitializer
     implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    private static KeycloakContainer keycloakContainer = new KeycloakContainer("quay.io/keycloak/keycloak:24.0.3")
+    private static KeycloakContainer keycloakContainer = new KeycloakContainer("quay.io/keycloak/keycloak:26.1.0")
         .withAdminUsername("admin")
         .withAdminPassword("admin")
         .withRealmImportFile("activiti-realm.json")


### PR DESCRIPTION
Main changes are due to:
- removal of `keycloak-core` from test suite (`KeycloakPrincipal` does not exist anymore in test scope as the new `testcontainers-keycloak` does not bring it in transitively anymore)
- `testcontainers-keycloak` by default now assumes the new default management port `9000` should be used for the startup health check, this does not work well with [Keycloak < 25 as this does not expose management endpoints via a separate server.](https://www.keycloak.org/docs/latest/upgrading/index.html#management-port-for-metrics-and-health-endpoints)