### PR TITLE
AAE-40552 Update LZ4 to 1.10.2

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-starter/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-starter/pom.xml
@@ -37,6 +37,18 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-kafka</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for older LZ4 dependency util a newer one will be used in Spring -->
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>${lz4-java.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -49,6 +49,8 @@
     <java-jwt.version>4.5.0</java-jwt.version>
     <!-- override resteasy vulnerable 0.8.3 version of org.apache.james dependencies -->
     <james.apache-mime4j.version>0.8.13</james.apache-mime4j.version>
+    <!-- Replacement for older LZ4 dependency util a newer one will be used in Spring -->
+    <lz4-java.version>1.10.2</lz4-java.version>
     <batik.version>1.19</batik.version>
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
   </properties>


### PR DESCRIPTION
This change is to update the LZ4 dependency coming from Spring Kafka.
Please note that the library was moved to a different owner - https://github.com/yawkat/lz4-java (Apache 2.0 license)