### PR TITLE
AAE-41073  Fix function router exchange header fallback with RabbitMq prefix enabled

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -138,10 +138,22 @@ public class FunctionRouterConfiguration {
         FunctionCatalog functionCatalog
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
+
         return (message, routingContext) -> {
             Optional
                 .ofNullable(message.getHeaders().get(FUNCTION_DESTINATION, String.class))
                 .or(() -> Optional.ofNullable(message.getHeaders().get(CONNECTOR_TYPE, String.class)))
+                .or(() ->
+                    Optional
+                        .ofNullable(messagingProperties.getRabbitmq().getPrefix())
+                        .filter(Predicate.not(String::isBlank))
+                        .flatMap(prefix ->
+                            Optional
+                                .ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class))
+                                .filter(exchange -> exchange.startsWith(prefix))
+                                .map(exchange -> exchange.substring(prefix.length()))
+                        )
+                )
                 .or(() -> Optional.ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class)))
                 .map(messagingProperties.getFunctionRouter().registrations(routingContext)::get)
                 .filter(Predicate.not(Collection::isEmpty))

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -587,6 +587,29 @@ public class FunctionRouterBindingConfigurationIT {
     }
 
     @Test
+    void testConnectorBindingsAmqpHeadersWithPrefix() {
+        withRabbitMqPrefix(
+            "myapp.",
+            prefix -> {
+                // given
+                Message<String> message = MessageBuilder
+                    .withPayload("run_test();")
+                    .setHeader(AmqpHeaders.RECEIVED_EXCHANGE, prefix.concat("script.EXECUTE"))
+                    .build();
+
+                // when
+                input.send(message, "script.EXECUTE");
+
+                // then
+                await()
+                    .untilAsserted(() -> {
+                        assertThat(connectorPayload.get()).isNotNull().isEqualTo("run_test();");
+                    });
+            }
+        );
+    }
+
+    @Test
     void messagingProperties() {
         assertThat(messagingProperties.getFunctionRouter().getMaxRetries()).isEqualTo(4);
         assertThat(messagingProperties.getFunctionRouter().getRetryInterval()).isEqualTo(Duration.ofMillis(100));
@@ -737,5 +760,17 @@ public class FunctionRouterBindingConfigurationIT {
             )
         )
             .isTrue();
+    }
+
+    void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {
+        final var current = messagingProperties.getRabbitmq().getPrefix();
+
+        try {
+            messagingProperties.getRabbitmq().setPrefix(prefix);
+
+            runnable.accept(prefix);
+        } finally {
+            messagingProperties.getRabbitmq().setPrefix(current);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://hyland.atlassian.net/browse/AAE-41073