### PR TITLE
AAE-41248 Bump prettier-plugin-java to 1.6.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
           - markdown
         additional_dependencies:
           - prettier@2.7.1
-          - prettier-plugin-java@1.4.0
+          - prettier-plugin-java@1.6.2
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.31.2
     hooks:

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/filter/VariableFilter.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/filter/VariableFilter.java
@@ -18,5 +18,9 @@ package org.activiti.cloud.services.query.rest.filter;
 import jakarta.annotation.Nullable;
 
 public record VariableFilter(
-    @Nullable String processDefinitionKey, String name, VariableType type, String value, FilterOperator operator
+    @Nullable String processDefinitionKey,
+    String name,
+    VariableType type,
+    String value,
+    FilterOperator operator
 ) {}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/CloudRuntimeEntitySort.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/CloudRuntimeEntitySort.java
@@ -16,12 +16,15 @@
 package org.activiti.cloud.services.query.rest.payload;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.Collection;
 import org.activiti.cloud.services.query.rest.filter.VariableType;
 import org.springframework.data.domain.Sort;
 
 public record CloudRuntimeEntitySort(
-    String field, Sort.Direction direction, boolean isProcessVariable, String processDefinitionKey, VariableType type
+    String field,
+    Sort.Direction direction,
+    boolean isProcessVariable,
+    String processDefinitionKey,
+    VariableType type
 ) {
     /**
      * This constructor's purpose is to make deserialization of 'direction' case-insensitive.


### PR DESCRIPTION
The version is bumped to 1.6.2 because it is the last version with prettier version <= 2.7.1 as dependency . All 2.x version of prettier-java-plugin use prettier-version > 2.7.1.