### PR TITLE
AAE-41244 The endpoint /processInstance must be able to filter by linked process instance id and root process instance id

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/ProcessInstanceSearchRequest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/payload/ProcessInstanceSearchRequest.java
@@ -44,6 +44,7 @@ public class ProcessInstanceSearchRequest implements CloudRuntimeEntityFilterReq
     private Boolean includeSubprocesses;
     private Set<String> linkedProcessInstanceId;
     private Set<String> linkedProcessInstanceType;
+    private Set<String> processRelatedTo;
 
     public ProcessInstanceSearchRequest() {}
 
@@ -68,7 +69,8 @@ public class ProcessInstanceSearchRequest implements CloudRuntimeEntityFilterReq
         CloudRuntimeEntitySort sort,
         Boolean includeSubprocesses,
         Set<String> linkedProcessInstanceId,
-        Set<String> linkedProcessInstanceType
+        Set<String> linkedProcessInstanceType,
+        Set<String> processRelatedTo
     ) {
         this.id = id;
         this.parentId = parentId;
@@ -91,6 +93,7 @@ public class ProcessInstanceSearchRequest implements CloudRuntimeEntityFilterReq
         this.includeSubprocesses = includeSubprocesses;
         this.linkedProcessInstanceId = linkedProcessInstanceId;
         this.linkedProcessInstanceType = linkedProcessInstanceType;
+        this.processRelatedTo = processRelatedTo;
     }
 
     @Override
@@ -279,5 +282,13 @@ public class ProcessInstanceSearchRequest implements CloudRuntimeEntityFilterReq
 
     public void setLinkedProcessInstanceType(Set<String> linkedProcessInstanceType) {
         this.linkedProcessInstanceType = linkedProcessInstanceType;
+    }
+
+    public Set<String> getProcessRelatedTo() {
+        return processRelatedTo;
+    }
+
+    public void setProcessRelatedTo(Set<String> processRelatedTo) {
+        this.processRelatedTo = processRelatedTo;
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/ProcessInstanceSpecification.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/specification/ProcessInstanceSpecification.java
@@ -30,7 +30,6 @@ import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.query.model.TaskCandidateUserEntity_;
 import org.activiti.cloud.services.query.model.TaskEntity_;
 import org.activiti.cloud.services.query.rest.payload.ProcessInstanceSearchRequest;
-import org.jspecify.annotations.NonNull;
 import org.springframework.util.CollectionUtils;
 
 @CountOverFullWindow
@@ -95,6 +94,7 @@ public class ProcessInstanceSpecification
         applyIncludeSubprocesses(root);
         applyLinkedProcessInstanceId(root);
         applyLinkedProcessInstanceType(root);
+        applyProcessRelatedTo(root, criteriaBuilder);
         return super.toPredicate(root, query, criteriaBuilder);
     }
 
@@ -250,6 +250,17 @@ public class ProcessInstanceSpecification
                             .get(TaskCandidateUserEntity_.userId),
                         userId
                     )
+                )
+            );
+        }
+    }
+
+    private void applyProcessRelatedTo(Root<ProcessInstanceEntity> root, CriteriaBuilder criteriaBuilder) {
+        if (!CollectionUtils.isEmpty(searchRequest.getProcessRelatedTo())) {
+            predicates.add(
+                criteriaBuilder.or(
+                    root.get(ProcessInstanceEntity_.linkedProcessInstanceId).in(searchRequest.getProcessRelatedTo()),
+                    root.get(ProcessInstanceEntity_.rootProcessInstanceId).in(searchRequest.getProcessRelatedTo())
                 )
             );
         }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
@@ -19,14 +19,17 @@ import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.activiti.cloud.services.query.util.QueryTestUtils.linkedProcessesPath;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.ProcessVariableKey;
 import org.activiti.cloud.services.query.util.ProcessInstanceSearchRequestBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -256,5 +259,48 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
                     Map.of("id", linkedProcessInstance2.getId())
                 )
             );
+    }
+
+    @Test
+    void should_return_AllRelatedToProcessInstancesForASpecificProcess() {
+        ProcessInstanceEntity rootProcessInstance = queryTestUtils
+            .buildProcessInstance()
+            .withName("root-process")
+            .withInitiator(USER)
+            .buildAndSave();
+
+        ProcessInstanceEntity subProcessInstance = queryTestUtils
+            .buildProcessInstance()
+            .withName("sub-process")
+            .withInitiator(USER)
+            .withRootProcessInstanceId(rootProcessInstance.getId())
+            .buildAndSave();
+        ProcessInstanceEntity linkedProcessInstance = queryTestUtils
+            .buildProcessInstance()
+            .withName("linked-process")
+            .withLinkedProcessInstanceId(rootProcessInstance.getId())
+            .buildAndSave();
+
+        ProcessInstanceSearchRequestBuilder requestBuilder = new ProcessInstanceSearchRequestBuilder()
+            .withProcessRelatedTo(rootProcessInstance.getId());
+
+        given()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(requestBuilder.buildJson())
+            .when()
+            .post(getSearchEndpoint())
+            .then()
+            .statusCode(200)
+            .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
+            .body(PROCESS_INSTANCE_IDS_JSON_PATH, not(hasItem(rootProcessInstance.getId())))
+            .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(subProcessInstance.getId()))
+            .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(linkedProcessInstance.getId()))//            .body( //            .body(linkedProcessesPath("linked-process-2"), hasSize(0)) //            .body(linkedProcessesPath("linked-process-1"), hasSize(0))
+        //                linkedProcessesPath("root-process"),
+        //                containsInAnyOrder(
+        //                    Map.of("id", linkedProcessInstance1.getId()),
+        //                    Map.of("id", linkedProcessInstance2.getId())
+        //                )
+        //            )
+        ;
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntitySearchAdminControllerIT.java
@@ -25,11 +25,9 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.activiti.QueryRestTestApplication;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
-import org.activiti.cloud.services.query.model.ProcessVariableKey;
 import org.activiti.cloud.services.query.util.ProcessInstanceSearchRequestBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -294,13 +292,6 @@ class ProcessInstanceEntitySearchAdminControllerIT extends AbstractProcessInstan
             .body(PROCESS_INSTANCES_JSON_PATH, hasSize(2))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, not(hasItem(rootProcessInstance.getId())))
             .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(subProcessInstance.getId()))
-            .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(linkedProcessInstance.getId()))//            .body( //            .body(linkedProcessesPath("linked-process-2"), hasSize(0)) //            .body(linkedProcessesPath("linked-process-1"), hasSize(0))
-        //                linkedProcessesPath("root-process"),
-        //                containsInAnyOrder(
-        //                    Map.of("id", linkedProcessInstance1.getId()),
-        //                    Map.of("id", linkedProcessInstance2.getId())
-        //                )
-        //            )
-        ;
+            .body(PROCESS_INSTANCE_IDS_JSON_PATH, hasItem(linkedProcessInstance.getId()));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/ProcessInstanceBuilder.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/ProcessInstanceBuilder.java
@@ -167,4 +167,9 @@ public class ProcessInstanceBuilder {
         process.setTasks(tasks);
         return processInstanceRepository.save(process);
     }
+
+    public ProcessInstanceBuilder withRootProcessInstanceId(String rootProcessInstanceId) {
+        process.setRootProcessInstanceId(rootProcessInstanceId);
+        return this;
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/ProcessInstanceSearchRequestBuilder.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/ProcessInstanceSearchRequestBuilder.java
@@ -52,6 +52,7 @@ public class ProcessInstanceSearchRequestBuilder {
     private Boolean includeSubprocesses;
     private Set<String> linkedProcessInstanceId;
     private Set<String> linkedProcessInstanceType;
+    private Set<String> processRelatedTo;
 
     public ProcessInstanceSearchRequestBuilder withIds(String... ids) {
         this.ids = Set.of(ids);
@@ -172,6 +173,11 @@ public class ProcessInstanceSearchRequestBuilder {
         return this;
     }
 
+    public ProcessInstanceSearchRequestBuilder withProcessRelatedTo(String... processRelatedToIds) {
+        this.processRelatedTo = Set.of(processRelatedToIds);
+        return this;
+    }
+
     public ProcessInstanceSearchRequest build() {
         if (processVariableFilters != null) {
             Set<ProcessVariableKey> keysFromFilters = processVariableFilters
@@ -207,7 +213,8 @@ public class ProcessInstanceSearchRequestBuilder {
             sort,
             includeSubprocesses,
             linkedProcessInstanceId,
-            linkedProcessInstanceType
+            linkedProcessInstanceType,
+            processRelatedTo
         );
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -7363,7 +7363,7 @@
           "includeSubprocesses": {
             "type": "boolean"
           },
-          "linkedProcessInstanceId":{"items":{"type":"string"},"type":"array","uniqueItems":true},"linkedProcessInstanceType":{"items":{"type":"string"},"type":"array","uniqueItems":true}
+          "linkedProcessInstanceId":{"items":{"type":"string"},"type":"array","uniqueItems":true},"linkedProcessInstanceType":{"items":{"type":"string"},"type":"array","uniqueItems":true}, "processRelatedTo":{"type":"array","items":{"type":"string"},"uniqueItems":true}
         },
         "title" : "ProcessInstanceSearchRequest_ProcessVariables"
       },


### PR DESCRIPTION
This PR fixes https://github.com/Activiti/Activiti/issues/5285