### PR TITLE
AAE-42355 Force Docker API version to 1.44

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/liquibase/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/liquibase/pom.xml
@@ -136,6 +136,10 @@
         </executions>
         <configuration>
           <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+          <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
+          <systemPropertyVariables>
+            <api.version>1.44</api.version>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/activiti-cloud-examples/pom.xml
+++ b/activiti-cloud-examples/pom.xml
@@ -166,6 +166,10 @@
               <forkCount>1</forkCount>
               <useSystemClassLoader>false</useSystemClassLoader>
               <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+              <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
+              <systemPropertyVariables>
+                <api.version>1.44</api.version>
+              </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -685,6 +685,10 @@ limitations under the License.]]>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <argLine>@{argLine} -Xmx1024m</argLine>
+              <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
+              <systemPropertyVariables>
+                <api.version>1.44</api.version>
+              </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
As per title, temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491