### PR TITLE
AAE-42642 Fix Duplicate key value violates unique constraint "bpmn_activity_pkey"

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseBPMNActivityEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/BaseBPMNActivityEventHandler.java
@@ -47,7 +47,7 @@ public abstract class BaseBPMNActivityEventHandler {
         }
 
         if (bpmnActivityEntity == null) {
-            bpmnActivityEntity = createBpmnActivityEntity(event);
+            bpmnActivityEntity = entityManager.merge(createBpmnActivityEntity(event));
         }
 
         return bpmnActivityEntity;

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.model.impl.BPMNActivityImpl;
@@ -315,25 +316,11 @@ class QueryBPMNActivityIT {
         //when
         eventsAggregator.sendAll();
 
-        final List<CompletableFuture<Throwable>> startedServiceTasks = IntStream
-            .range(0, 100)
-            .mapToObj(i ->
-                CompletableFuture.supplyAsync(() -> {
-                    eventsAggregator.addEvents(
-                        new CloudBPMNActivityStartedEventImpl(serviceTaskActivity, processDefinitionId, process.getId())
-                    );
-
-                    eventsAggregator.sendAll();
-
-                    return eventsAggregator.getException();
-                })
-            )
-            .toList();
-
-        final var startedSuccess = CompletableFuture
-            .allOf(startedServiceTasks.toArray(CompletableFuture[]::new))
-            .thenApply(v -> startedServiceTasks.stream().map(CompletableFuture::join).allMatch(Objects::isNull))
-            .join();
+        final var startedSuccess = withSupplyAsyncEventsSendResult(() ->
+            new CloudRuntimeEvent[] {
+                new CloudBPMNActivityStartedEventImpl(serviceTaskActivity, processDefinitionId, process.getId()),
+            }
+        );
 
         assertThat(startedSuccess).isTrue();
 
@@ -362,29 +349,11 @@ class QueryBPMNActivityIT {
                     );
             });
 
-        final List<CompletableFuture<Throwable>> completedServiceTasks = IntStream
-            .range(0, 100)
-            .mapToObj(i ->
-                CompletableFuture.supplyAsync(() -> {
-                    eventsAggregator.addEvents(
-                        new CloudBPMNActivityCompletedEventImpl(
-                            serviceTaskActivity,
-                            processDefinitionId,
-                            process.getId()
-                        )
-                    );
-
-                    eventsAggregator.sendAll();
-
-                    return eventsAggregator.getException();
-                })
-            )
-            .toList();
-
-        final var completedSuccess = CompletableFuture
-            .allOf(completedServiceTasks.toArray(CompletableFuture[]::new))
-            .thenApply(v -> completedServiceTasks.stream().map(CompletableFuture::join).allMatch(Objects::isNull))
-            .join();
+        final var completedSuccess = withSupplyAsyncEventsSendResult(() ->
+            new CloudRuntimeEvent[] {
+                new CloudBPMNActivityCompletedEventImpl(serviceTaskActivity, processDefinitionId, process.getId()),
+            }
+        );
 
         assertThat(completedSuccess).isTrue();
 
@@ -536,5 +505,26 @@ class QueryBPMNActivityIT {
                         tuple("decisiontask-sequence", CloudBPMNActivity.BPMNActivityStatus.COMPLETED)
                     );
             });
+    }
+
+    private Boolean withSupplyAsyncEventsSendResult(Supplier<CloudRuntimeEvent[]> supplier) {
+        final List<CompletableFuture<Throwable>> completedServiceTasks = IntStream
+            .range(0, 100)
+            .mapToObj(i ->
+                CompletableFuture.supplyAsync(() -> {
+                    synchronized (eventsAggregator) {
+                        eventsAggregator.addEvents(supplier.get());
+                        eventsAggregator.sendAll();
+
+                        return eventsAggregator.getException();
+                    }
+                })
+            )
+            .toList();
+
+        return CompletableFuture
+            .allOf(completedServiceTasks.toArray(CompletableFuture[]::new))
+            .thenApply(v -> completedServiceTasks.stream().map(CompletableFuture::join).allMatch(Objects::isNull))
+            .join();
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -26,8 +26,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.model.impl.BPMNActivityImpl;
 import org.activiti.api.runtime.model.impl.BPMNSequenceFlowImpl;
@@ -63,6 +66,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -111,11 +115,14 @@ class QueryBPMNActivityIT {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private SubscribableChannel errorChannel;
+
     @BeforeEach
     void setUp() throws IOException {
         identityTokenProducer.withTestUser("hruser");
 
-        eventsAggregator = new EventsAggregator(producer);
+        eventsAggregator = new EventsAggregator(producer).errorChannel(errorChannel);
 
         ProcessDefinitionImpl processDefinition = new ProcessDefinitionImpl();
         processDefinition.setId(processDefinitionId);
@@ -270,7 +277,7 @@ class QueryBPMNActivityIT {
     }
 
     @Test
-    void shouldHandleCyclicalBpmnServiceTaskEvents() {
+    void shouldHandleMultiInstanceWithAsyncBeforeBpmnServiceTaskEvents() {
         //given
         ProcessInstanceImpl process = new ProcessInstanceImpl();
         process.setId(UUID.randomUUID().toString());
@@ -288,26 +295,47 @@ class QueryBPMNActivityIT {
         sequenceFlow.setProcessDefinitionId(process.getProcessDefinitionId());
         sequenceFlow.setProcessInstanceId(process.getId());
 
-        BPMNActivityImpl servitTaskActivity = new BPMNActivityImpl(
+        BPMNActivityImpl serviceTaskActivity = new BPMNActivityImpl(
             "serviceTaskActivity",
             "Run Service Task",
             "serviceTask"
         );
-        servitTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
-        servitTaskActivity.setProcessInstanceId(process.getId());
-        servitTaskActivity.setExecutionId("executionId");
+        serviceTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        serviceTaskActivity.setProcessInstanceId(process.getId());
+        serviceTaskActivity.setExecutionId("executionId");
 
         eventsAggregator.addEvents(
             new CloudProcessCreatedEventImpl(process),
             new CloudProcessStartedEventImpl(process),
             new CloudBPMNActivityStartedEventImpl(startActivity, processDefinitionId, process.getId()),
             new CloudBPMNActivityCompletedEventImpl(startActivity, processDefinitionId, process.getId()),
-            new CloudSequenceFlowTakenEventImpl(sequenceFlow),
-            new CloudBPMNActivityStartedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
+            new CloudSequenceFlowTakenEventImpl(sequenceFlow)
         );
 
         //when
         eventsAggregator.sendAll();
+
+        final List<CompletableFuture<Throwable>> startedServiceTasks = IntStream
+            .range(0, 100)
+            .mapToObj(i ->
+                CompletableFuture.supplyAsync(() -> {
+                    eventsAggregator.addEvents(
+                        new CloudBPMNActivityStartedEventImpl(serviceTaskActivity, processDefinitionId, process.getId())
+                    );
+
+                    eventsAggregator.sendAll();
+
+                    return eventsAggregator.getException();
+                })
+            )
+            .toList();
+
+        final var startedSuccess = CompletableFuture
+            .allOf(startedServiceTasks.toArray(CompletableFuture[]::new))
+            .thenApply(v -> startedServiceTasks.stream().map(CompletableFuture::join).allMatch(Objects::isNull))
+            .join();
+
+        assertThat(startedSuccess).isTrue();
 
         await()
             .untilAsserted(() -> {
@@ -327,19 +355,38 @@ class QueryBPMNActivityIT {
                             BPMNActivityEntity.BPMNActivityStatus.COMPLETED
                         ),
                         tuple(
-                            servitTaskActivity.getElementId(),
-                            servitTaskActivity.getActivityType(),
+                            serviceTaskActivity.getElementId(),
+                            serviceTaskActivity.getActivityType(),
                             BPMNActivityEntity.BPMNActivityStatus.STARTED
                         )
                     );
             });
 
-        eventsAggregator.addEvents(
-            new CloudBPMNActivityCompletedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
-        );
+        final List<CompletableFuture<Throwable>> completedServiceTasks = IntStream
+            .range(0, 100)
+            .mapToObj(i ->
+                CompletableFuture.supplyAsync(() -> {
+                    eventsAggregator.addEvents(
+                        new CloudBPMNActivityCompletedEventImpl(
+                            serviceTaskActivity,
+                            processDefinitionId,
+                            process.getId()
+                        )
+                    );
 
-        //when
-        eventsAggregator.sendAll();
+                    eventsAggregator.sendAll();
+
+                    return eventsAggregator.getException();
+                })
+            )
+            .toList();
+
+        final var completedSuccess = CompletableFuture
+            .allOf(completedServiceTasks.toArray(CompletableFuture[]::new))
+            .thenApply(v -> completedServiceTasks.stream().map(CompletableFuture::join).allMatch(Objects::isNull))
+            .join();
+
+        assertThat(completedSuccess).isTrue();
 
         await()
             .untilAsserted(() -> {
@@ -359,104 +406,8 @@ class QueryBPMNActivityIT {
                             BPMNActivityEntity.BPMNActivityStatus.COMPLETED
                         ),
                         tuple(
-                            servitTaskActivity.getElementId(),
-                            servitTaskActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
-                        )
-                    );
-            });
-
-        BPMNSequenceFlowImpl sequenceFlow2 = new BPMNSequenceFlowImpl(
-            "sf-2",
-            "reviewTaskActivity",
-            "employeeTaskActivity"
-        );
-        sequenceFlow2.setProcessDefinitionId(process.getProcessDefinitionId());
-        sequenceFlow2.setProcessInstanceId(process.getId());
-
-        BPMNActivityImpl employeeTaskActivity = new BPMNActivityImpl("employeeTaskActivity", "Employee", "userTask");
-        employeeTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
-        employeeTaskActivity.setProcessInstanceId(process.getId());
-        employeeTaskActivity.setExecutionId("executionId");
-
-        BPMNSequenceFlowImpl sequenceFlow3 = new BPMNSequenceFlowImpl(
-            "sf-3",
-            "employeeTaskActivity",
-            "reviewTaskActivity"
-        );
-        sequenceFlow3.setProcessDefinitionId(process.getProcessDefinitionId());
-        sequenceFlow3.setProcessInstanceId(process.getId());
-
-        eventsAggregator.addEvents(
-            new CloudSequenceFlowTakenEventImpl(sequenceFlow2),
-            new CloudBPMNActivityStartedEventImpl(employeeTaskActivity, processDefinitionId, process.getId()),
-            new CloudBPMNActivityCompletedEventImpl(employeeTaskActivity, processDefinitionId, process.getId()),
-            new CloudSequenceFlowTakenEventImpl(sequenceFlow3),
-            new CloudBPMNActivityStartedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
-        );
-
-        eventsAggregator.sendAll();
-
-        await()
-            .untilAsserted(() -> {
-                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
-
-                assertThat(activities).hasSize(3);
-                assertThat(activities)
-                    .extracting(
-                        BPMNActivityEntity::getElementId,
-                        BPMNActivityEntity::getActivityType,
-                        BPMNActivityEntity::getStatus
-                    )
-                    .containsOnly(
-                        tuple(
-                            startActivity.getElementId(),
-                            startActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
-                        ),
-                        tuple(
-                            employeeTaskActivity.getElementId(),
-                            employeeTaskActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
-                        ),
-                        tuple(
-                            servitTaskActivity.getElementId(),
-                            servitTaskActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.STARTED
-                        )
-                    );
-            });
-        eventsAggregator.addEvents(
-            new CloudBPMNActivityCompletedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
-        );
-
-        eventsAggregator.sendAll();
-
-        await()
-            .untilAsserted(() -> {
-                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
-
-                assertThat(activities).hasSize(3);
-                assertThat(activities)
-                    .extracting(
-                        BPMNActivityEntity::getElementId,
-                        BPMNActivityEntity::getActivityType,
-                        BPMNActivityEntity::getStatus
-                    )
-                    .containsOnly(
-                        tuple(
-                            startActivity.getElementId(),
-                            startActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
-                        ),
-                        tuple(
-                            employeeTaskActivity.getElementId(),
-                            employeeTaskActivity.getActivityType(),
-                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
-                        ),
-                        tuple(
-                            servitTaskActivity.getElementId(),
-                            servitTaskActivity.getActivityType(),
+                            serviceTaskActivity.getElementId(),
+                            serviceTaskActivity.getActivityType(),
                             BPMNActivityEntity.BPMNActivityStatus.COMPLETED
                         )
                     );

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -66,6 +66,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
@@ -264,6 +265,200 @@ class QueryBPMNActivityIT {
                             reviewTaskActivity.getElementId(),
                             reviewTaskActivity.getActivityType(),
                             BPMNActivityEntity.BPMNActivityStatus.STARTED
+                        )
+                    );
+            });
+    }
+
+    @Test
+    void shouldHandleCyclicalBpmnServiceTaskEvents() {
+        //given
+        ProcessInstanceImpl process = new ProcessInstanceImpl();
+        process.setId(UUID.randomUUID().toString());
+        process.setName("process");
+        process.setProcessDefinitionKey("mySimpleProcess2");
+        process.setProcessDefinitionId(processDefinitionId);
+        process.setProcessDefinitionVersion(1);
+
+        BPMNActivityImpl startActivity = new BPMNActivityImpl("startEvent1", "", "startEvent");
+        startActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        startActivity.setProcessInstanceId(process.getId());
+        startActivity.setExecutionId("executionId");
+
+        BPMNSequenceFlowImpl sequenceFlow = new BPMNSequenceFlowImpl("sf-1", "startEvent1", "reviewTaskActivity");
+        sequenceFlow.setProcessDefinitionId(process.getProcessDefinitionId());
+        sequenceFlow.setProcessInstanceId(process.getId());
+
+        BPMNActivityImpl servitTaskActivity = new BPMNActivityImpl(
+            "serviceTaskActivity",
+            "Run Service Task",
+            "serviceTask"
+        );
+        servitTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        servitTaskActivity.setProcessInstanceId(process.getId());
+        servitTaskActivity.setExecutionId("executionId");
+
+        eventsAggregator.addEvents(
+            new CloudProcessCreatedEventImpl(process),
+            new CloudProcessStartedEventImpl(process),
+            new CloudBPMNActivityStartedEventImpl(startActivity, processDefinitionId, process.getId()),
+            new CloudBPMNActivityCompletedEventImpl(startActivity, processDefinitionId, process.getId()),
+            new CloudSequenceFlowTakenEventImpl(sequenceFlow),
+            new CloudBPMNActivityStartedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
+        );
+
+        //when
+        eventsAggregator.sendAll();
+
+        await()
+            .untilAsserted(() -> {
+                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+                assertThat(activities).hasSize(2);
+                assertThat(activities)
+                    .extracting(
+                        BPMNActivityEntity::getElementId,
+                        BPMNActivityEntity::getActivityType,
+                        BPMNActivityEntity::getStatus
+                    )
+                    .containsExactly(
+                        tuple(
+                            startActivity.getElementId(),
+                            startActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            servitTaskActivity.getElementId(),
+                            servitTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.STARTED
+                        )
+                    );
+            });
+
+        eventsAggregator.addEvents(
+            new CloudBPMNActivityCompletedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
+        );
+
+        //when
+        eventsAggregator.sendAll();
+
+        await()
+            .untilAsserted(() -> {
+                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+                assertThat(activities).hasSize(2);
+                assertThat(activities)
+                    .extracting(
+                        BPMNActivityEntity::getElementId,
+                        BPMNActivityEntity::getActivityType,
+                        BPMNActivityEntity::getStatus
+                    )
+                    .containsExactly(
+                        tuple(
+                            startActivity.getElementId(),
+                            startActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            servitTaskActivity.getElementId(),
+                            servitTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        )
+                    );
+            });
+
+        BPMNSequenceFlowImpl sequenceFlow2 = new BPMNSequenceFlowImpl(
+            "sf-2",
+            "reviewTaskActivity",
+            "employeeTaskActivity"
+        );
+        sequenceFlow2.setProcessDefinitionId(process.getProcessDefinitionId());
+        sequenceFlow2.setProcessInstanceId(process.getId());
+
+        BPMNActivityImpl employeeTaskActivity = new BPMNActivityImpl("employeeTaskActivity", "Employee", "userTask");
+        employeeTaskActivity.setProcessDefinitionId(process.getProcessDefinitionId());
+        employeeTaskActivity.setProcessInstanceId(process.getId());
+        employeeTaskActivity.setExecutionId("executionId");
+
+        BPMNSequenceFlowImpl sequenceFlow3 = new BPMNSequenceFlowImpl(
+            "sf-3",
+            "employeeTaskActivity",
+            "reviewTaskActivity"
+        );
+        sequenceFlow3.setProcessDefinitionId(process.getProcessDefinitionId());
+        sequenceFlow3.setProcessInstanceId(process.getId());
+
+        eventsAggregator.addEvents(
+            new CloudSequenceFlowTakenEventImpl(sequenceFlow2),
+            new CloudBPMNActivityStartedEventImpl(employeeTaskActivity, processDefinitionId, process.getId()),
+            new CloudBPMNActivityCompletedEventImpl(employeeTaskActivity, processDefinitionId, process.getId()),
+            new CloudSequenceFlowTakenEventImpl(sequenceFlow3),
+            new CloudBPMNActivityStartedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
+        );
+
+        eventsAggregator.sendAll();
+
+        await()
+            .untilAsserted(() -> {
+                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+                assertThat(activities).hasSize(3);
+                assertThat(activities)
+                    .extracting(
+                        BPMNActivityEntity::getElementId,
+                        BPMNActivityEntity::getActivityType,
+                        BPMNActivityEntity::getStatus
+                    )
+                    .containsOnly(
+                        tuple(
+                            startActivity.getElementId(),
+                            startActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            employeeTaskActivity.getElementId(),
+                            employeeTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            servitTaskActivity.getElementId(),
+                            servitTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.STARTED
+                        )
+                    );
+            });
+        eventsAggregator.addEvents(
+            new CloudBPMNActivityCompletedEventImpl(servitTaskActivity, processDefinitionId, process.getId())
+        );
+
+        eventsAggregator.sendAll();
+
+        await()
+            .untilAsserted(() -> {
+                List<BPMNActivityEntity> activities = bpmnActivityRepository.findByProcessInstanceId(process.getId());
+
+                assertThat(activities).hasSize(3);
+                assertThat(activities)
+                    .extracting(
+                        BPMNActivityEntity::getElementId,
+                        BPMNActivityEntity::getActivityType,
+                        BPMNActivityEntity::getStatus
+                    )
+                    .containsOnly(
+                        tuple(
+                            startActivity.getElementId(),
+                            startActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            employeeTaskActivity.getElementId(),
+                            employeeTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
+                        ),
+                        tuple(
+                            servitTaskActivity.getElementId(),
+                            servitTaskActivity.getActivityType(),
+                            BPMNActivityEntity.BPMNActivityStatus.COMPLETED
                         )
                     );
             });

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -66,7 +66,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryBPMNActivityIT.java
@@ -510,16 +510,7 @@ class QueryBPMNActivityIT {
     private Boolean withSupplyAsyncEventsSendResult(Supplier<CloudRuntimeEvent[]> supplier) {
         final List<CompletableFuture<Throwable>> completedServiceTasks = IntStream
             .range(0, 100)
-            .mapToObj(i ->
-                CompletableFuture.supplyAsync(() -> {
-                    synchronized (eventsAggregator) {
-                        eventsAggregator.addEvents(supplier.get());
-                        eventsAggregator.sendAll();
-
-                        return eventsAggregator.getException();
-                    }
-                })
-            )
+            .mapToObj(i -> CompletableFuture.supplyAsync(() -> eventsAggregator.sendAll(supplier.get()).orElse(null)))
             .toList();
 
         return CompletableFuture

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -446,8 +446,6 @@ public class ActivitiCloudMessagingProperties {
         @NestedConfigurationProperty
         private ConsumerProperties consumer = new ConsumerProperties();
 
-        private Integer parallelism = Runtime.getRuntime().availableProcessors() * 2;
-
         public boolean isEnabled() {
             return enabled;
         }
@@ -618,8 +616,7 @@ public class ActivitiCloudMessagingProperties {
                 retryInterval,
                 consumer,
                 anonymous,
-                errorHandlerDefinition,
-                parallelism
+                errorHandlerDefinition
             );
         }
 
@@ -636,7 +633,6 @@ public class ActivitiCloudMessagingProperties {
                 .add("consumer=" + consumer)
                 .add("anonymous=" + anonymous)
                 .add("errorHandlerDefinition=" + errorHandlerDefinition)
-                .add("parallelism=" + parallelism)
                 .toString();
         }
 
@@ -650,14 +646,6 @@ public class ActivitiCloudMessagingProperties {
 
         public void setErrorHandlerDefinition(String errorHandlerDefinition) {
             this.errorHandlerDefinition = errorHandlerDefinition;
-        }
-
-        public Integer getParallelism() {
-            return parallelism;
-        }
-
-        public void setParallelism(Integer parallelism) {
-            this.parallelism = parallelism;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -446,6 +446,8 @@ public class ActivitiCloudMessagingProperties {
         @NestedConfigurationProperty
         private ConsumerProperties consumer = new ConsumerProperties();
 
+        private Integer parallelism = Runtime.getRuntime().availableProcessors() * 2;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -616,7 +618,8 @@ public class ActivitiCloudMessagingProperties {
                 retryInterval,
                 consumer,
                 anonymous,
-                errorHandlerDefinition
+                errorHandlerDefinition,
+                parallelism
             );
         }
 
@@ -633,6 +636,7 @@ public class ActivitiCloudMessagingProperties {
                 .add("consumer=" + consumer)
                 .add("anonymous=" + anonymous)
                 .add("errorHandlerDefinition=" + errorHandlerDefinition)
+                .add("parallelism=" + parallelism)
                 .toString();
         }
 
@@ -646,6 +650,14 @@ public class ActivitiCloudMessagingProperties {
 
         public void setErrorHandlerDefinition(String errorHandlerDefinition) {
             this.errorHandlerDefinition = errorHandlerDefinition;
+        }
+
+        public Integer getParallelism() {
+            return parallelism;
+        }
+
+        public void setParallelism(Integer parallelism) {
+            this.parallelism = parallelism;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -23,11 +23,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -132,10 +136,31 @@ public class FunctionRouterConfiguration {
     }
 
     @Bean
+    Function<Message<?>, ExecutorService> functionExecutor(ActivitiCloudMessagingProperties messagingProperties) {
+        final AtomicInteger sequence = new AtomicInteger(0);
+        final var parallelism = messagingProperties.getFunctionRouter().getParallelism();
+
+        final var executors = IntStream
+            .range(0, parallelism + 1)
+            .mapToObj(i -> Executors.newSingleThreadExecutor())
+            .toList();
+
+        return message ->
+            Optional
+                .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
+                .map(String::hashCode)
+                .or(() -> Optional.of(sequence.getAndIncrement()))
+                .map(it -> Math.abs(it % parallelism))
+                .map(executors::get)
+                .get();
+    }
+
+    @Bean
     BiConsumer<Message<?>, String> functionRouterMessageHandler(
         RoutingFunction routingFunction,
         ActivitiCloudMessagingProperties messagingProperties,
-        FunctionCatalog functionCatalog
+        FunctionCatalog functionCatalog,
+        Function<Message<?>, ExecutorService> functionExecutor
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
 
@@ -176,7 +201,10 @@ public class FunctionRouterConfiguration {
                             .map(functionRequest ->
                                 supplyAsyncWithRetry(
                                         () ->
-                                            CompletableFuture.supplyAsync(() -> routingFunction.apply(functionRequest)),
+                                            CompletableFuture.supplyAsync(
+                                                () -> routingFunction.apply(functionRequest),
+                                                functionExecutor.apply(functionRequest)
+                                            ),
                                         functionRouter.getMaxRetries(),
                                         functionRouter.getRetryInterval()
                                     )

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.common.messaging.config;
 
 import static org.activiti.cloud.common.messaging.config.CompletableFutureRetry.supplyAsyncWithRetry;
 
+import jakarta.annotation.PreDestroy;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -139,22 +141,7 @@ public class FunctionRouterConfiguration {
     @Bean
     @ConditionalOnMissingBean
     Function<String, ExecutorService> functionExecutorFactory() {
-        final Function<String, ExecutorService> executorServiceFactory = registration ->
-            Executors.newSingleThreadScheduledExecutor(runnable -> {
-                final var thread = new Thread(runnable);
-                thread.setName(registration);
-
-                return thread;
-            });
-
-        return new Function<>() {
-            final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
-
-            @Override
-            public ExecutorService apply(String registration) {
-                return executors.computeIfAbsent(registration, executorServiceFactory);
-            }
-        };
+        return new FunctionExecutorFactory();
     }
 
     @Bean
@@ -372,5 +359,56 @@ public class FunctionRouterConfiguration {
                 return bean;
             }
         };
+    }
+
+    public static class FunctionExecutorFactory implements Function<String, ExecutorService> {
+
+        final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+
+        final Function<String, ExecutorService> executorServiceFactory = registration ->
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                final var thread = new Thread(runnable);
+                thread.setName(registration);
+
+                return thread;
+            });
+
+        public FunctionExecutorFactory() {}
+
+        @Override
+        public ExecutorService apply(String key) {
+            return executors.computeIfAbsent(key, executorServiceFactory);
+        }
+
+        @PreDestroy
+        public void shutdown() {
+            executors.values().forEach(ExecutorService::shutdown);
+
+            awaitTermination(5, TimeUnit.SECONDS);
+
+            executors.clear();
+        }
+
+        public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+            final var cfs = executors
+                .values()
+                .stream()
+                .map(executor ->
+                    CompletableFuture.supplyAsync(() -> {
+                        try {
+                            return executor.awaitTermination(timeout, unit);
+                        } catch (InterruptedException ignored) {
+                            Thread.currentThread().interrupt();
+                        }
+
+                        return false;
+                    })
+                )
+                .toArray(CompletableFuture[]::new);
+
+            CompletableFuture.allOf(cfs).join();
+
+            return true;
+        }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
@@ -66,7 +67,6 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.StringUtils;
 
 @AutoConfiguration(
@@ -139,29 +139,52 @@ public class FunctionRouterConfiguration {
     @Bean
     @ConditionalOnMissingBean
     Function<String, ExecutorService> functionExecutorFactory() {
-        return registration ->
+        final Function<String, ExecutorService> executorServiceFactory = registration ->
             Executors.newSingleThreadScheduledExecutor(runnable -> {
                 final var thread = new Thread(runnable);
                 thread.setName(registration);
 
                 return thread;
             });
+
+        return new Function<>() {
+            final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+
+            @Override
+            public ExecutorService apply(String registration) {
+                return executors.computeIfAbsent(registration, executorServiceFactory);
+            }
+        };
     }
 
     @Bean
-    Function<Message<?>, ExecutorService> functionExecutor(Function<String, ExecutorService> functionExecutorFactory) {
-        final Map<String, ExecutorService> executors = new ConcurrentReferenceHashMap<>();
+    Function<Message<?>, String> functionRegistrationSelector() {
+        return new Function<>() {
+            @Override
+            public String apply(Message<?> message) {
+                return Optional
+                    .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
+                    .filter(Predicate.not(String::isBlank))
+                    .orElseThrow(() ->
+                        new MessageDispatchingException(
+                            String.format("Message header %s is required", FunctionProperties.FUNCTION_DEFINITION)
+                        )
+                    );
+            }
+        };
+    }
 
-        return message ->
-            Optional
-                .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
-                .filter(Predicate.not(String::isBlank))
-                .map(registration -> executors.computeIfAbsent(registration, functionExecutorFactory))
-                .orElseThrow(() ->
-                    new MessageDispatchingException(
-                        String.format("Message header %s is required", FunctionProperties.FUNCTION_DEFINITION)
-                    )
-                );
+    @Bean
+    Function<Message<?>, ExecutorService> functionExecutorSelector(
+        Function<Message<?>, String> functionRegistrationSelector,
+        Function<String, ExecutorService> functionExecutorFactory
+    ) {
+        return new Function<>() {
+            @Override
+            public ExecutorService apply(Message<?> message) {
+                return functionRegistrationSelector.andThen(functionExecutorFactory).apply(message);
+            }
+        };
     }
 
     @Bean
@@ -169,7 +192,7 @@ public class FunctionRouterConfiguration {
         RoutingFunction routingFunction,
         ActivitiCloudMessagingProperties messagingProperties,
         FunctionCatalog functionCatalog,
-        Function<Message<?>, ExecutorService> functionExecutor
+        Function<Message<?>, ExecutorService> functionExecutorSelector
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
 
@@ -212,7 +235,7 @@ public class FunctionRouterConfiguration {
                                         () ->
                                             CompletableFuture.supplyAsync(
                                                 () -> routingFunction.apply(functionRequest),
-                                                functionExecutor.apply(functionRequest)
+                                                functionExecutorSelector.apply(functionRequest)
                                             ),
                                         functionRouter.getMaxRetries(),
                                         functionRouter.getRetryInterval()

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -362,7 +362,7 @@ public class FunctionRouterConfiguration {
         };
     }
 
-    static class FunctionExecutorFactory implements Function<String, ExecutorService> {
+    public static class FunctionExecutorFactory implements Function<String, ExecutorService> {
 
         private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.common.messaging.config;
 import static org.activiti.cloud.common.messaging.config.CompletableFutureRetry.supplyAsyncWithRetry;
 
 import jakarta.annotation.PreDestroy;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -365,6 +366,7 @@ public class FunctionRouterConfiguration {
     public static class FunctionExecutorFactory implements Function<String, ExecutorService> {
 
         private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+        private Duration timeout = Duration.ofSeconds(5);
 
         private final Function<String, ExecutorService> executorServiceFactory = registration ->
             Executors.newSingleThreadScheduledExecutor(runnable -> {
@@ -386,7 +388,7 @@ public class FunctionRouterConfiguration {
             try {
                 shutdown();
 
-                if (!awaitTermination(5, TimeUnit.SECONDS)) {
+                if (!awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
                     shutdownNow();
                 }
             } catch (InterruptedException e) {
@@ -430,6 +432,10 @@ public class FunctionRouterConfiguration {
             } catch (ExecutionException e) {
                 throw new InterruptedException();
             }
+        }
+
+        public void setTimeout(Duration timeout) {
+            this.timeout = timeout;
         }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -17,19 +17,13 @@ package org.activiti.cloud.common.messaging.config;
 
 import static org.activiti.cloud.common.messaging.config.CompletableFutureRetry.supplyAsyncWithRetry;
 
-import jakarta.annotation.PreDestroy;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -142,8 +136,8 @@ public class FunctionRouterConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    Function<String, ExecutorService> functionExecutorFactory() {
-        return new FunctionExecutorFactory();
+    Function<String, ExecutorService> functionRouterExecutorFactory() {
+        return new FunctionRouterExecutorFactory();
     }
 
     @Bean
@@ -166,12 +160,12 @@ public class FunctionRouterConfiguration {
     @Bean
     Function<Message<?>, ExecutorService> functionExecutorSelector(
         Function<Message<?>, String> functionRegistrationSelector,
-        Function<String, ExecutorService> functionExecutorFactory
+        Function<String, ExecutorService> functionRouterExecutorFactory
     ) {
         return new Function<>() {
             @Override
             public ExecutorService apply(Message<?> message) {
-                return functionRegistrationSelector.andThen(functionExecutorFactory).apply(message);
+                return functionRegistrationSelector.andThen(functionRouterExecutorFactory).apply(message);
             }
         };
     }
@@ -361,81 +355,5 @@ public class FunctionRouterConfiguration {
                 return bean;
             }
         };
-    }
-
-    public static class FunctionExecutorFactory implements Function<String, ExecutorService> {
-
-        private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
-        private Duration timeout = Duration.ofSeconds(5);
-
-        private final Function<String, ExecutorService> executorServiceFactory = registration ->
-            Executors.newSingleThreadScheduledExecutor(runnable -> {
-                final var thread = new Thread(runnable);
-                thread.setName(registration);
-
-                return thread;
-            });
-
-        public FunctionExecutorFactory() {}
-
-        @Override
-        public ExecutorService apply(String key) {
-            return executors.computeIfAbsent(key, executorServiceFactory);
-        }
-
-        @PreDestroy
-        public void destroy() {
-            try {
-                shutdown();
-
-                if (!awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
-                    shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                shutdownNow();
-            } finally {
-                executors.clear();
-            }
-        }
-
-        public void shutdown() {
-            executors.values().forEach(ExecutorService::shutdown);
-        }
-
-        public void shutdownNow() {
-            executors.values().forEach(ExecutorService::shutdownNow);
-        }
-
-        public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
-            final var cfs = executors
-                .values()
-                .stream()
-                .map(executor ->
-                    CompletableFuture.supplyAsync(() -> {
-                        try {
-                            return executor.awaitTermination(timeout, unit);
-                        } catch (InterruptedException ignored) {
-                            Thread.currentThread().interrupt();
-                        }
-
-                        return false;
-                    })
-                )
-                .toList();
-
-            try {
-                return CompletableFuture
-                    .allOf(cfs.toArray(CompletableFuture[]::new))
-                    .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
-                    .get();
-            } catch (ExecutionException e) {
-                throw new InterruptedException();
-            }
-        }
-
-        public void setTimeout(Duration timeout) {
-            this.timeout = timeout;
-        }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -361,11 +362,11 @@ public class FunctionRouterConfiguration {
         };
     }
 
-    public static class FunctionExecutorFactory implements Function<String, ExecutorService> {
+    static class FunctionExecutorFactory implements Function<String, ExecutorService> {
 
-        final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+        private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
 
-        final Function<String, ExecutorService> executorServiceFactory = registration ->
+        private final Function<String, ExecutorService> executorServiceFactory = registration ->
             Executors.newSingleThreadScheduledExecutor(runnable -> {
                 final var thread = new Thread(runnable);
                 thread.setName(registration);
@@ -381,15 +382,30 @@ public class FunctionRouterConfiguration {
         }
 
         @PreDestroy
-        public void shutdown() {
-            executors.values().forEach(ExecutorService::shutdown);
+        public void destroy() {
+            try {
+                shutdown();
 
-            awaitTermination(5, TimeUnit.SECONDS);
-
-            executors.clear();
+                if (!awaitTermination(5, TimeUnit.SECONDS)) {
+                    shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                shutdownNow();
+            } finally {
+                executors.clear();
+            }
         }
 
-        public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+        public void shutdown() {
+            executors.values().forEach(ExecutorService::shutdown);
+        }
+
+        public void shutdownNow() {
+            executors.values().forEach(ExecutorService::shutdownNow);
+        }
+
+        public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
             final var cfs = executors
                 .values()
                 .stream()
@@ -404,11 +420,16 @@ public class FunctionRouterConfiguration {
                         return false;
                     })
                 )
-                .toArray(CompletableFuture[]::new);
+                .toList();
 
-            CompletableFuture.allOf(cfs).join();
-
-            return true;
+            try {
+                return CompletableFuture
+                    .allOf(cfs.toArray(CompletableFuture[]::new))
+                    .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
+                    .get();
+            } catch (ExecutionException e) {
+                throw new InterruptedException();
+            }
         }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -142,19 +142,15 @@ public class FunctionRouterConfiguration {
 
     @Bean
     Function<Message<?>, String> functionRegistrationSelector() {
-        return new Function<>() {
-            @Override
-            public String apply(Message<?> message) {
-                return Optional
-                    .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
-                    .filter(Predicate.not(String::isBlank))
-                    .orElseThrow(() ->
-                        new MessageDispatchingException(
-                            String.format("Message header %s is required", FunctionProperties.FUNCTION_DEFINITION)
-                        )
-                    );
-            }
-        };
+        return message ->
+            Optional
+                .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
+                .filter(Predicate.not(String::isBlank))
+                .orElseThrow(() ->
+                    new MessageDispatchingException(
+                        String.format("Message header %s is required", FunctionProperties.FUNCTION_DEFINITION)
+                    )
+                );
     }
 
     @Bean
@@ -162,12 +158,7 @@ public class FunctionRouterConfiguration {
         Function<Message<?>, String> functionRegistrationSelector,
         Function<String, ExecutorService> functionRouterExecutorFactory
     ) {
-        return new Function<>() {
-            @Override
-            public ExecutorService apply(Message<?> message) {
-                return functionRegistrationSelector.andThen(functionRouterExecutorFactory).apply(message);
-            }
-        };
+        return message -> functionRegistrationSelector.andThen(functionRouterExecutorFactory).apply(message);
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -25,13 +25,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -47,6 +45,7 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionProperties;
@@ -57,6 +56,7 @@ import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
@@ -66,6 +66,7 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.StringUtils;
 
 @AutoConfiguration(
@@ -136,23 +137,31 @@ public class FunctionRouterConfiguration {
     }
 
     @Bean
-    Function<Message<?>, ExecutorService> functionExecutor(ActivitiCloudMessagingProperties messagingProperties) {
-        final AtomicInteger sequence = new AtomicInteger(0);
-        final var parallelism = messagingProperties.getFunctionRouter().getParallelism();
+    @ConditionalOnMissingBean
+    Function<String, ExecutorService> functionExecutorFactory() {
+        return registration ->
+            Executors.newSingleThreadScheduledExecutor(runnable -> {
+                final var thread = new Thread(runnable);
+                thread.setName(registration);
 
-        final var executors = IntStream
-            .range(0, parallelism + 1)
-            .mapToObj(i -> Executors.newSingleThreadExecutor())
-            .toList();
+                return thread;
+            });
+    }
+
+    @Bean
+    Function<Message<?>, ExecutorService> functionExecutor(Function<String, ExecutorService> functionExecutorFactory) {
+        final Map<String, ExecutorService> executors = new ConcurrentReferenceHashMap<>();
 
         return message ->
             Optional
                 .ofNullable(message.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class))
-                .map(String::hashCode)
-                .or(() -> Optional.of(sequence.getAndIncrement()))
-                .map(it -> Math.abs(it % parallelism))
-                .map(executors::get)
-                .get();
+                .filter(Predicate.not(String::isBlank))
+                .map(registration -> executors.computeIfAbsent(registration, functionExecutorFactory))
+                .orElseThrow(() ->
+                    new MessageDispatchingException(
+                        String.format("Message header %s is required", FunctionProperties.FUNCTION_DEFINITION)
+                    )
+                );
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +48,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         try {
             shutdown();
 
-            if (!awaitTermination(timeout)) {
+            if (!awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
                 shutdownNow();
             }
         } catch (InterruptedException e) {
@@ -68,14 +67,14 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         executors.values().forEach(ExecutorService::shutdownNow);
     }
 
-    public boolean awaitTermination(final Duration timeout) throws InterruptedException {
+    public boolean awaitTermination(final long timeout, TimeUnit timeUnit) throws InterruptedException {
         final var cfs = executors
             .values()
             .stream()
             .map(executor ->
                 CompletableFuture.supplyAsync(() -> {
                     try {
-                        return executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                        return executor.awaitTermination(timeout, timeUnit);
                     } catch (InterruptedException ignored) {
                         Thread.currentThread().interrupt();
                     }
@@ -85,14 +84,10 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
             )
             .toList();
 
-        try {
-            return CompletableFuture
-                .allOf(cfs.toArray(CompletableFuture[]::new))
-                .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
-                .get();
-        } catch (ExecutionException e) {
-            throw new InterruptedException();
-        }
+        return CompletableFuture
+            .allOf(cfs.toArray(CompletableFuture[]::new))
+            .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
+            .join();
     }
 
     public void setTimeout(Duration timeout) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -39,8 +39,6 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
             return thread;
         });
 
-    public FunctionRouterExecutorFactory() {}
-
     @Override
     public ExecutorService apply(String key) {
         return executors.computeIfAbsent(key, executorServiceFactory);
@@ -51,7 +49,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         try {
             shutdown();
 
-            if (!awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
+            if (!awaitTermination(timeout)) {
                 shutdownNow();
             }
         } catch (InterruptedException e) {
@@ -70,14 +68,14 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         executors.values().forEach(ExecutorService::shutdownNow);
     }
 
-    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+    public boolean awaitTermination(final Duration timeout) throws InterruptedException {
         final var cfs = executors
             .values()
             .stream()
             .map(executor ->
                 CompletableFuture.supplyAsync(() -> {
                     try {
-                        return executor.awaitTermination(timeout, unit);
+                        return executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS);
                     } catch (InterruptedException ignored) {
                         Thread.currentThread().interrupt();
                     }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public class FunctionRouterExecutorFactory implements Function<String, ExecutorService> {
+
+    private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
+    private Duration timeout = Duration.ofSeconds(5);
+
+    private final Function<String, ExecutorService> executorServiceFactory = registration ->
+        Executors.newSingleThreadScheduledExecutor(runnable -> {
+            final var thread = new Thread(runnable);
+            thread.setName(registration);
+
+            return thread;
+        });
+
+    public FunctionRouterExecutorFactory() {}
+
+    @Override
+    public ExecutorService apply(String key) {
+        return executors.computeIfAbsent(key, executorServiceFactory);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        try {
+            shutdown();
+
+            if (!awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
+                shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            shutdownNow();
+        } finally {
+            executors.clear();
+        }
+    }
+
+    public void shutdown() {
+        executors.values().forEach(ExecutorService::shutdown);
+    }
+
+    public void shutdownNow() {
+        executors.values().forEach(ExecutorService::shutdownNow);
+    }
+
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        final var cfs = executors
+            .values()
+            .stream()
+            .map(executor ->
+                CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return executor.awaitTermination(timeout, unit);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+
+                    return false;
+                })
+            )
+            .toList();
+
+        try {
+            return CompletableFuture
+                .allOf(cfs.toArray(CompletableFuture[]::new))
+                .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
+                .get();
+        } catch (ExecutionException e) {
+            throw new InterruptedException();
+        }
+    }
+
+    public void setTimeout(Duration timeout) {
+        this.timeout = timeout;
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -841,28 +841,30 @@ public class FunctionRouterBindingConfigurationIT {
             .setHeader(FUNCTION_DEFINITION, "foo_registration")
             .build();
 
-        final AtomicReference<Thread> threadHolder = new AtomicReference<>();
         final var phaser = new Phaser(2);
-
-        //when
         final var functionExecutor = functionExecutorSelector.apply(message);
-
-        functionExecutor.submit(() -> {
+        final var futureResult = functionExecutor.submit(() -> {
             try {
                 phaser.arriveAndAwaitAdvance();
-                Thread.sleep(200);
-                threadHolder.set(Thread.currentThread());
+                synchronized (this) {
+                    wait();
+                }
+
+                return "never";
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+
+            return null;
         });
 
         phaser.arriveAndAwaitAdvance();
 
+        //when
         functionRouterExecutorFactory.destroy();
 
-        assertThat(threadHolder.get()).isNull();
-
+        //then
+        assertThat(futureResult.resultNow()).isNull();
         assertThatThrownBy(() -> functionExecutor.submit(() -> {})).isInstanceOf(RejectedExecutionException.class);
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -30,6 +30,7 @@ import static org.activiti.cloud.common.messaging.config.test.TestBindingsChanne
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.REST_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.SCRIPT_RUNTIME_CONSUMER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.springframework.cloud.function.context.FunctionProperties.FUNCTION_DEFINITION;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -50,6 +52,7 @@ import java.util.stream.IntStream;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
+import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
 import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -177,6 +180,9 @@ public class FunctionRouterBindingConfigurationIT {
 
     @Autowired
     private Function<Message<?>, ExecutorService> functionExecutorSelector;
+
+    @Autowired
+    private FunctionRouterConfiguration.FunctionExecutorFactory functionExecutorFactory;
 
     @TestConfiguration
     static class ApplicationConfig {
@@ -823,6 +829,36 @@ public class FunctionRouterBindingConfigurationIT {
         //then
         assertThat(executionThreadMap.values().stream().distinct().count()).isEqualTo(1);
         assertThat(IntStream.range(0, 100).boxed().toList()).isEqualTo(executionOrder);
+    }
+
+    @Test
+    void functionExecutorShouldAwaitTerminatingTasksOnDestroy() {
+        //given
+        final Message<String> message = MessageBuilder
+            .withPayload("foo")
+            .setHeader(FUNCTION_DEFINITION, "foo_registration")
+            .build();
+
+        final AtomicReference<Thread> threadHolder = new AtomicReference<>();
+
+        //when
+        final var functionExecutor = functionExecutorSelector.apply(message);
+
+        functionExecutor.submit(() -> {
+            try {
+                Thread.sleep(500);
+                threadHolder.set(Thread.currentThread());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        functionExecutorFactory.destroy();
+
+        assertThat(threadHolder.get()).isNotNull();
+
+        assertThatThrownBy(() -> functionExecutor.submit(() -> threadHolder.set(Thread.currentThread())))
+            .isInstanceOf(RejectedExecutionException.class);
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -31,12 +31,14 @@ import static org.activiti.cloud.common.messaging.config.test.TestBindingsChanne
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.SCRIPT_RUNTIME_CONSUMER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.springframework.cloud.function.context.FunctionProperties.FUNCTION_DEFINITION;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -169,6 +171,9 @@ public class FunctionRouterBindingConfigurationIT {
     @Autowired
     private Environment environment;
 
+    @Autowired
+    private Function<Message<?>, ExecutorService> functionExecutorSelector;
+
     @TestConfiguration
     static class ApplicationConfig {
 
@@ -177,6 +182,8 @@ public class FunctionRouterBindingConfigurationIT {
         public Consumer<Message<?>> queryConsumerHandler() {
             return message -> {
                 queryMessage.set(message);
+
+                assertThat(Thread.currentThread().getName()).isEqualTo("queryConsumerHandler_registration");
             };
         }
 
@@ -185,6 +192,8 @@ public class FunctionRouterBindingConfigurationIT {
         public Consumer<Message<?>> auditConsumerHandler() {
             return message -> {
                 auditMessage.set(message);
+
+                assertThat(Thread.currentThread().getName()).isEqualTo("auditConsumerHandler_registration");
             };
         }
 
@@ -760,6 +769,28 @@ public class FunctionRouterBindingConfigurationIT {
             )
         )
             .isTrue();
+    }
+
+    @Test
+    void functionExecutorSelector() {
+        //given
+        final Message<String> message = MessageBuilder
+            .withPayload("foo")
+            .setHeader(FUNCTION_DEFINITION, "foo_registration")
+            .build();
+
+        final AtomicReference<Thread> threadHolder = new AtomicReference<>();
+
+        //when
+        final var functionExecutor = functionExecutorSelector.apply(message);
+
+        functionExecutor.submit(() -> threadHolder.set(Thread.currentThread()));
+
+        //then
+        await()
+            .untilAsserted(() -> {
+                assertThat(threadHolder.get()).isNotNull().extracting(Thread::getName).isEqualTo("foo_registration");
+            });
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -36,13 +36,17 @@ import static org.springframework.cloud.function.context.FunctionRegistration.RE
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
@@ -772,7 +776,7 @@ public class FunctionRouterBindingConfigurationIT {
     }
 
     @Test
-    void functionExecutorSelector() {
+    void functionExecutorSelectorShouldExecuteFunctionInTheNamedThread() {
         //given
         final Message<String> message = MessageBuilder
             .withPayload("foo")
@@ -791,6 +795,34 @@ public class FunctionRouterBindingConfigurationIT {
             .untilAsserted(() -> {
                 assertThat(threadHolder.get()).isNotNull().extracting(Thread::getName).isEqualTo("foo_registration");
             });
+    }
+
+    @Test
+    void functionExecutorShouldExecuteSameFunctionByTheSameThreadInTheSameOrder() {
+        //given
+        final Map<Integer, String> executionThreadMap = new ConcurrentHashMap<>();
+        final List<Integer> executionOrder = new LinkedList<>();
+
+        //when
+        final var executions = IntStream
+            .range(0, 100)
+            .mapToObj(i -> MessageBuilder.withPayload(i).setHeader(FUNCTION_DEFINITION, "foo_registration").build())
+            .map(m ->
+                CompletableFuture.runAsync(
+                    () -> {
+                        executionThreadMap.put(m.getPayload(), Thread.currentThread().getName());
+                        executionOrder.add(m.getPayload());
+                    },
+                    functionExecutorSelector.apply(m)
+                )
+            )
+            .toArray(CompletableFuture[]::new);
+
+        CompletableFuture.allOf(executions).join();
+
+        //then
+        assertThat(executionThreadMap.values().stream().distinct().count()).isEqualTo(1);
+        assertThat(IntStream.range(0, 100).boxed().toList()).isEqualTo(executionOrder);
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -834,25 +835,29 @@ public class FunctionRouterBindingConfigurationIT {
     @Test
     void functionExecutorShouldAwaitTerminatingTasksOnDestroy() {
         //given
-        functionRouterExecutorFactory.setTimeout(Duration.ofSeconds(1));
+        functionRouterExecutorFactory.setTimeout(Duration.ofMillis(100));
         final Message<String> message = MessageBuilder
             .withPayload("foo")
             .setHeader(FUNCTION_DEFINITION, "foo_registration")
             .build();
 
         final AtomicReference<Thread> threadHolder = new AtomicReference<>();
+        final var phaser = new Phaser(2);
 
         //when
         final var functionExecutor = functionExecutorSelector.apply(message);
 
         functionExecutor.submit(() -> {
             try {
-                Thread.sleep(2000);
+                phaser.arriveAndAwaitAdvance();
+                Thread.sleep(200);
                 threadHolder.set(Thread.currentThread());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         });
+
+        phaser.arriveAndAwaitAdvance();
 
         functionRouterExecutorFactory.destroy();
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -52,7 +52,7 @@ import java.util.stream.IntStream;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
-import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
+import org.activiti.cloud.common.messaging.config.FunctionRouterExecutorFactory;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
 import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -182,7 +182,7 @@ public class FunctionRouterBindingConfigurationIT {
     private Function<Message<?>, ExecutorService> functionExecutorSelector;
 
     @Autowired
-    private FunctionRouterConfiguration.FunctionExecutorFactory functionExecutorFactory;
+    private FunctionRouterExecutorFactory functionRouterExecutorFactory;
 
     @TestConfiguration
     static class ApplicationConfig {
@@ -834,7 +834,7 @@ public class FunctionRouterBindingConfigurationIT {
     @Test
     void functionExecutorShouldAwaitTerminatingTasksOnDestroy() {
         //given
-        functionExecutorFactory.setTimeout(Duration.ofSeconds(1));
+        functionRouterExecutorFactory.setTimeout(Duration.ofSeconds(1));
         final Message<String> message = MessageBuilder
             .withPayload("foo")
             .setHeader(FUNCTION_DEFINITION, "foo_registration")
@@ -854,7 +854,7 @@ public class FunctionRouterBindingConfigurationIT {
             }
         });
 
-        functionExecutorFactory.destroy();
+        functionRouterExecutorFactory.destroy();
 
         assertThat(threadHolder.get()).isNull();
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -834,6 +834,7 @@ public class FunctionRouterBindingConfigurationIT {
     @Test
     void functionExecutorShouldAwaitTerminatingTasksOnDestroy() {
         //given
+        functionExecutorFactory.setTimeout(Duration.ofSeconds(1));
         final Message<String> message = MessageBuilder
             .withPayload("foo")
             .setHeader(FUNCTION_DEFINITION, "foo_registration")
@@ -846,7 +847,7 @@ public class FunctionRouterBindingConfigurationIT {
 
         functionExecutor.submit(() -> {
             try {
-                Thread.sleep(500);
+                Thread.sleep(2000);
                 threadHolder.set(Thread.currentThread());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -855,10 +856,9 @@ public class FunctionRouterBindingConfigurationIT {
 
         functionExecutorFactory.destroy();
 
-        assertThat(threadHolder.get()).isNotNull();
+        assertThat(threadHolder.get()).isNull();
 
-        assertThatThrownBy(() -> functionExecutor.submit(() -> threadHolder.set(Thread.currentThread())))
-            .isInstanceOf(RejectedExecutionException.class);
+        assertThatThrownBy(() -> functionExecutor.submit(() -> {})).isInstanceOf(RejectedExecutionException.class);
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/EventsAggregator.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/EventsAggregator.java
@@ -55,6 +55,13 @@ public class EventsAggregator implements MessageHandler {
         return sentEvents.toArray(CloudRuntimeEvent[]::new);
     }
 
+    public Optional<Throwable> sendAll(CloudRuntimeEvent<?, ?>[] events) {
+        errorMessageRef.set(null);
+        producer.send(events);
+
+        return Optional.ofNullable(getException());
+    }
+
     @Override
     public void handleMessage(Message<?> message) throws MessagingException {
         errorMessageRef.set(message);


### PR DESCRIPTION
- [x] Use the EntityManager's merge to initialize BPMN Activity Entity in the Hibernate memory session to upsert entity if it exists in the database due to the concurrent handling of multi-instance service tasks with async before characteristics. 

- [x] Implement function router executor factory to ensure that messages with the same destination function registration are executed sequentially in a dedicated thread, while different function registrations are processed in parallel. This is achieved by using function destination header mapping to a specific single threaded executor service. 

Fixes: https://hyland.atlassian.net/browse/AAE-42642