### PR TITLE
AAE-42376 Remove obsolete testcontainers workaround

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/liquibase/pom.xml
+++ b/activiti-cloud-examples/activiti-cloud-query/liquibase/pom.xml
@@ -136,10 +136,6 @@
         </executions>
         <configuration>
           <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-          <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
-          <systemPropertyVariables>
-            <api.version>1.44</api.version>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/activiti-cloud-examples/pom.xml
+++ b/activiti-cloud-examples/pom.xml
@@ -166,10 +166,6 @@
               <forkCount>1</forkCount>
               <useSystemClassLoader>false</useSystemClassLoader>
               <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-              <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
-              <systemPropertyVariables>
-                <api.version>1.44</api.version>
-              </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -688,10 +688,6 @@ limitations under the License.]]>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <argLine>@{argLine} -Xmx1024m</argLine>
-              <!-- temporary fix for https://github.com/testcontainers/testcontainers-java/issues/11491 -->
-              <systemPropertyVariables>
-                <api.version>1.44</api.version>
-              </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
As per title, verified this workaround should not be needed.