### PR TITLE
AAE-43069 Reduce CI build time with parallelism and Sonar decoupling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       version: ${{ steps.update-pom-to-next-version.outputs.next-prerelease }}
-    env:
-      JACOCO_MERGED_FILE: ${{ github.workspace }}/target/jacoco-merged.exec
+      m2-uploaded-group-path: ${{ steps.m2-inclusion-pattern.outputs.group-path }}
 
     steps:
       - name: Checkout repository
@@ -116,29 +115,11 @@ jobs:
             TEST_OPTS="-DskipTests=true"
             echo "::warning::Tests are being skipped due to 'skip-tests' label. This PR cannot be merged until the label is removed."
           fi
-          mvn -DskipAcceptanceTests=true -DunitTests.parallel=true -T 1C install $TEST_OPTS ${{ env.MAVEN_CLI_OPTS }}
+          mvn -DskipAcceptanceTests=true -DunitTests.parallel=true -DunitTests.dynamicFactor=2 -T 2C install $TEST_OPTS ${{ env.MAVEN_CLI_OPTS }}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
-      - name: Merge JaCoCo execution files
-        shell: bash
-        run: mvn -N jacoco:merge -Djacoco.destFile=${{ env.JACOCO_MERGED_FILE }}
-
-      - name: Generate coverage reports
-        shell: bash
-        run: mvn jacoco:report -Djacoco.dataFile=${{ env.JACOCO_MERGED_FILE }}
-
-      - name: Run SonarCloud analysis
-        if: ${{ env.SONAR_TOKEN != '' }}
-        shell: bash
-        run: mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=activiti -Dsonar.projectKey=Activiti_activiti-cloud -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco*/jacoco.xml
-        env:
-          MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Remove running docker containers
         run: docker rm -f $(docker ps -a -q)
@@ -147,6 +128,42 @@ jobs:
       - name: Echo Longest Tests run
         shell: bash
         run: find . -name TEST-*.xml -exec grep -h testcase {} \; | awk -F '"' '{printf("%s#%s() - %.3fms\n", $4, $2, $6); }' | sort -n -k 3 | tail -20
+
+      - name: Merge JaCoCo execution files
+        shell: bash
+        run: mvn -N jacoco:merge -Djacoco.destFile=${{ github.workspace }}/target/jacoco-merged.exec
+
+      - name: Generate coverage reports
+        shell: bash
+        run: mvn jacoco:report -Djacoco.dataFile=${{ github.workspace }}/target/jacoco-merged.exec
+
+      - name: Upload target folders
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: target-activiti-cloud
+          path: |
+            ${{ github.workspace }}/**/target/classes
+            ${{ github.workspace }}/**/target/test-classes
+            ${{ github.workspace }}/**/target/site
+          retention-days: 1
+
+      - name: Get m2 inclusion pattern
+        id: m2-inclusion-pattern
+        shell: bash
+        run: |
+          M2_GROUP_RELATIVE_PATH="$(yq e '.project.groupId | sub("\.", "/")' pom.xml)"
+          M2_GROUP_FULL_PATH="~/.m2/repository/${M2_GROUP_RELATIVE_PATH}"
+          VERSION=$(yq e '.project.version' pom.xml)
+          INCLUSION_PATTERN="${M2_GROUP_FULL_PATH}/**/${VERSION}"
+          echo "group-path=$M2_GROUP_FULL_PATH" >> $GITHUB_OUTPUT
+          echo "pattern=$INCLUSION_PATTERN" >> $GITHUB_OUTPUT
+
+      - name: Upload M2 build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: m2-activiti-cloud
+          path: ${{ steps.m2-inclusion-pattern.outputs.pattern }}
+          retention-days: 1
 
       - name: Login to DockerHub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -165,6 +182,28 @@ jobs:
 
       - name: Build Activiti Cloud Identity Adapter
         run: make docker/activiti-cloud-identity-adapter
+
+  sonar:
+    runs-on: ubuntu-latest
+    needs:
+      - pre-checks
+      - build
+    if: ${{ needs.pre-checks.outputs.skip != 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: SonarCloud Scan
+        uses: Alfresco/alfresco-build-tools/.github/actions/sonar-scan-on-built-project@40f2376b812403b51e0cea49eaff04c1b8d65cfd # v15.7.1
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        with:
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          sonar-project: 'Activiti_activiti-cloud'
+          java-version: '25'
+          m2-uploaded-group-path: ${{ needs.build.outputs.m2-uploaded-group-path }}
+          ghcr-username: ${{ github.actor }}
+          ghcr-password: ${{ secrets.GITHUB_TOKEN }}
 
   acceptance-tests:
     runs-on: ubuntu-latest
@@ -351,6 +390,7 @@ jobs:
     needs:
       - pre-checks
       - build
+      - sonar
       - acceptance-tests
     steps:
       - name: Check build and acceptance-tests results
@@ -358,6 +398,8 @@ jobs:
           ${{
               contains(needs.build.result, 'failure')
            || contains(needs.build.result, 'cancelled')
+           || contains(needs.sonar.result, 'failure')
+           || contains(needs.sonar.result, 'cancelled')
            || contains(needs.acceptance-tests.result, 'failure')
            || contains(needs.acceptance-tests.result, 'cancelled')
           }}


### PR DESCRIPTION
- Increase Maven module parallelism from -T 1C to -T 2C
- Increase JUnit parallel dynamic factor from 1 to 2
- Move SonarCloud analysis to a separate parallel job
- Parallelize Docker image builds