### PR TITLE
AAE-43503 Upgrade Spring Security to 6.5.9

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -83,8 +83,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- AAE-43503: Temporary fix for CVE-2026-22732. Remove after Spring Boot upgrade.
-           Must be imported BEFORE spring-boot-dependencies so it wins for spring-security artifacts. -->
+      <!-- AAE-43503: Temporary fix for CVE-2026-22732. Remove after Spring Boot upgrade. -->
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-bom</artifactId>

--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -23,6 +23,8 @@
     <netty.version>4.1.130.Final</netty.version>
     <jackson.version>2.21.1</jackson.version>
     <tomcat-embed-core.version>10.1.52</tomcat-embed-core.version>
+    <!-- AAE-43503: Temporary fix for CVE-2026-22732. Remove after Spring Boot upgrade -->
+    <spring-security.version>6.5.9</spring-security.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -78,6 +80,15 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- AAE-43503: Temporary fix for CVE-2026-22732. Remove after Spring Boot upgrade.
+           Must be imported BEFORE spring-boot-dependencies so it wins for spring-security artifacts. -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring-security.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Import spring-security-bom:6.5.9 before spring-boot-dependencies in activiti-cloud-build-dependencies-parent so it takes precedence for spring-security artifact versions. This is the upstream fix that will resolve the vulnerability for all downstream consumers.
