### PR TITLE
AAE-43060 Suppress stacktrace for 404

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/EntityFinder.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/EntityFinder.java
@@ -16,7 +16,6 @@
 package org.activiti.cloud.services.query.app.repository;
 
 import com.querydsl.core.types.Predicate;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.CrudRepository;
@@ -29,7 +28,7 @@ public class EntityFinder {
     }
 
     private <T> T getEntity(Optional<T> result, String notFoundMessage) {
-        return result.orElseThrow(() -> new EntityNotFoundException(notFoundMessage));
+        return result.orElseThrow(() -> new QueryEntityNotFoundException(notFoundMessage));
     }
 
     public <T> T findOne(QuerydslPredicateExecutor<T> predicateExecutor, Predicate predicate, String notFoundMessage) {

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/QueryEntityNotFoundException.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/QueryEntityNotFoundException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app.repository;
+
+public class QueryEntityNotFoundException extends RuntimeException {
+
+    public QueryEntityNotFoundException(String message) {
+        super(message, null, false, false);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
@@ -66,7 +66,8 @@ public class EntityFinderTest {
         //when
         assertThatExceptionOfType(QueryEntityNotFoundException.class)
             .isThrownBy(() -> entityFinder.findById(repository, processInstanceId, "Error"))
-            .withMessageContaining("Error");
+            .withMessageContaining("Error")
+            .satisfies(ex -> assertThat(ex.getStackTrace()).isEmpty());
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/test/java/org/activiti/cloud/services/query/app/repository/EntityFinderTest.java
@@ -21,7 +21,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import com.querydsl.core.types.Predicate;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,7 @@ public class EntityFinderTest {
 
         //then
         //when
-        assertThatExceptionOfType(EntityNotFoundException.class)
+        assertThatExceptionOfType(QueryEntityNotFoundException.class)
             .isThrownBy(() -> entityFinder.findById(repository, processInstanceId, "Error"))
             .withMessageContaining("Error");
     }
@@ -92,7 +91,7 @@ public class EntityFinderTest {
 
         //then
         //when
-        assertThatExceptionOfType(EntityNotFoundException.class)
+        assertThatExceptionOfType(QueryEntityNotFoundException.class)
             .isThrownBy(() -> entityFinder.findOne(repository, predicate, "Error"))
             .withMessageContaining("Error");
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
@@ -83,7 +83,7 @@ public class CommonExceptionHandlerQuery {
         QueryEntityNotFoundException ex,
         HttpServletResponse response
     ) {
-        LOGGER.debug(ex.getMessage(), ex);
+        LOGGER.debug(ex.getMessage());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }
@@ -94,7 +94,7 @@ public class CommonExceptionHandlerQuery {
         EntityNotFoundException ex,
         HttpServletResponse response
     ) {
-        LOGGER.debug(ex.getMessage(), ex);
+        LOGGER.debug(ex.getMessage());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.query.rest;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.api.model.shared.model.ActivitiErrorMessage;
 import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.cloud.common.error.attributes.ErrorAttributesMessageSanitizer;
@@ -76,12 +77,24 @@ public class CommonExceptionHandlerQuery {
         );
     }
 
+    @ExceptionHandler(QueryEntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public EntityModel<ActivitiErrorMessage> handleAppException(
+        QueryEntityNotFoundException ex,
+        HttpServletResponse response
+    ) {
+        LOGGER.debug(ex.getMessage(), ex);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public EntityModel<ActivitiErrorMessage> handleAppException(
         EntityNotFoundException ex,
         HttpServletResponse response
     ) {
+        LOGGER.debug(ex.getMessage(), ex);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         return EntityModel.of(new ActivitiErrorMessageImpl(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/CommonExceptionHandlerQuery.java
@@ -17,10 +17,10 @@ package org.activiti.cloud.services.query.rest;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
-import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.api.model.shared.model.ActivitiErrorMessage;
 import org.activiti.api.runtime.model.impl.ActivitiErrorMessageImpl;
 import org.activiti.cloud.common.error.attributes.ErrorAttributesMessageSanitizer;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.core.common.spring.security.policies.ActivitiForbiddenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminController.java
@@ -16,8 +16,8 @@
 package org.activiti.cloud.services.query.rest;
 
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
-import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.rest.assembler.IntegrationContextRepresentationModelAssembler;
 import org.springframework.hateoas.EntityModel;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminController.java
@@ -15,8 +15,8 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.rest.assembler.IntegrationContextRepresentationModelAssembler;
@@ -52,7 +52,7 @@ public class IntegrationContextAdminController {
         IntegrationContextEntity entity = repository
             .findById(integrationContextId)
             .orElseThrow(() ->
-                new EntityNotFoundException(
+                new QueryEntityNotFoundException(
                     "Unable to find integration context for the given id: '" + integrationContextId + "'"
                 )
             );

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminController.java
@@ -16,9 +16,9 @@
 package org.activiti.cloud.services.query.rest;
 
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
-import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
 import org.activiti.cloud.services.query.rest.assembler.IntegrationContextRepresentationModelAssembler;
 import org.springframework.data.domain.Page;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminController.java
@@ -15,8 +15,8 @@
  */
 package org.activiti.cloud.services.query.rest;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
 import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
 import org.activiti.cloud.services.query.model.IntegrationContextEntity;
@@ -74,7 +74,7 @@ public class ServiceTaskIntegrationContextAdminController {
         if (page.hasContent()) {
             return representationModelAssembler.toModel(page.getContent().getFirst());
         } else {
-            throw new EntityNotFoundException(
+            throw new QueryEntityNotFoundException(
                 "Unable to find integration context entity for the given id:'" + serviceTaskId + "'"
             );
         }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminControllerIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.rest;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.util.Optional;
+import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.conf.QueryRestWebMvcAutoConfiguration;
+import org.activiti.cloud.services.query.app.repository.EntityFinder;
+import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
+import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.VariableRepository;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(IntegrationContextAdminController.class)
+@Import(
+    { QueryRestWebMvcAutoConfiguration.class, CommonModelAutoConfiguration.class, AlfrescoWebAutoConfiguration.class }
+)
+@EnableSpringDataWebSupport
+@AutoConfigureMockMvc
+@WithMockUser
+@TestPropertySource(locations = "classpath:application-test.properties")
+class IntegrationContextAdminControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IntegrationContextRepository integrationContextRepository;
+
+    @MockitoBean
+    private ProcessInstanceRepository processInstanceRepository;
+
+    @MockitoBean
+    private TaskCandidateUserRepository taskCandidateUserRepository;
+
+    @MockitoBean
+    private TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    @MockitoBean
+    private SecurityManager securityManager;
+
+    @MockitoBean
+    private SecurityPoliciesManager securityPoliciesManager;
+
+    @MockitoBean
+    private SecurityPoliciesProperties securityPoliciesProperties;
+
+    @MockitoBean
+    private TaskRepository taskRepository;
+
+    @MockitoBean
+    private VariableRepository processVariableRepository;
+
+    @MockitoBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockitoBean
+    private ProcessInstanceService processInstanceService;
+
+    @MockitoBean
+    private EntityManagerFactory entityManagerFactory;
+
+    @MockitoBean
+    private EntityFinder entityFinder;
+
+    @Test
+    void shouldReturnNotFoundWhenIntegrationContextDoesNotExist() throws Exception {
+        //given
+        String integrationContextId = "nonexistent-id";
+        given(integrationContextRepository.findById(integrationContextId)).willReturn(Optional.empty());
+
+        //when
+        mockMvc
+            .perform(
+                get("/admin/v1/integration-contexts/{integrationContextId}", integrationContextId)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            //then
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.entry.code").value(404))
+            .andExpect(
+                jsonPath("$.entry.message")
+                    .value(
+                        "Unable to find integration context for the given id: '" + integrationContextId + "'"
+                    )
+            );
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/IntegrationContextAdminControllerIT.java
@@ -116,9 +116,7 @@ class IntegrationContextAdminControllerIT {
             .andExpect(jsonPath("$.entry.code").value(404))
             .andExpect(
                 jsonPath("$.entry.message")
-                    .value(
-                        "Unable to find integration context for the given id: '" + integrationContextId + "'"
-                    )
+                    .value("Unable to find integration context for the given id: '" + integrationContextId + "'")
             );
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
@@ -272,8 +272,13 @@ class ProcessInstanceAdminControllerIT {
     void shouldReturnNotFoundWhenProcessInstanceDoesNotExist() throws Exception {
         //given
         String processInstanceId = "nonexistent-id";
-        willThrow(new QueryEntityNotFoundException("Unable to find process instance for the given id:'" + processInstanceId + "'"))
-            .given(processInstanceAdminService).findById(processInstanceId);
+        willThrow(
+            new QueryEntityNotFoundException(
+                "Unable to find process instance for the given id:'" + processInstanceId + "'"
+            )
+        )
+            .given(processInstanceAdminService)
+            .findById(processInstanceId);
 
         //when
         mockMvc
@@ -284,6 +289,9 @@ class ProcessInstanceAdminControllerIT {
             //then
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.entry.code").value(404))
-            .andExpect(jsonPath("$.entry.message").value("Unable to find process instance for the given id:'" + processInstanceId + "'"));
+            .andExpect(
+                jsonPath("$.entry.message")
+                    .value("Unable to find process instance for the given id:'" + processInstanceId + "'")
+            );
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
@@ -40,6 +40,7 @@ import org.activiti.cloud.conf.QueryRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
@@ -265,5 +266,24 @@ class ProcessInstanceAdminControllerIT {
             //then
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.list.entries").isEmpty());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenProcessInstanceDoesNotExist() throws Exception {
+        //given
+        String processInstanceId = "nonexistent-id";
+        willThrow(new QueryEntityNotFoundException("Unable to find process instance for the given id:'" + processInstanceId + "'"))
+            .given(processInstanceAdminService).findById(processInstanceId);
+
+        //when
+        mockMvc
+            .perform(
+                get("/admin/v1/process-instances/{processInstanceId}", processInstanceId)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            //then
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.entry.code").value(404))
+            .andExpect(jsonPath("$.entry.message").value("Unable to find process instance for the given id:'" + processInstanceId + "'"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceAdminControllerIT.java
@@ -295,4 +295,31 @@ class ProcessInstanceAdminControllerIT {
                     .value("Unable to find process instance for the given id:'" + processInstanceId + "'")
             );
     }
+
+    @Test
+    void shouldReturnNotFoundWhenJpaEntityNotFoundExceptionIsThrown() throws Exception {
+        //given
+        String processInstanceId = "nonexistent-id";
+        willThrow(
+            new jakarta.persistence.EntityNotFoundException(
+                "Unable to find process instance for the given id:'" + processInstanceId + "'"
+            )
+        )
+            .given(processInstanceAdminService)
+            .findById(processInstanceId);
+
+        //when
+        mockMvc
+            .perform(
+                get("/admin/v1/process-instances/{processInstanceId}", processInstanceId)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            //then
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.entry.code").value(404))
+            .andExpect(
+                jsonPath("$.entry.message")
+                    .value("Unable to find process instance for the given id:'" + processInstanceId + "'")
+            );
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerHelperIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerHelperIT.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.querydsl.core.types.Predicate;
-import jakarta.persistence.EntityNotFoundException;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -372,7 +372,7 @@ class ProcessInstanceControllerHelperIT {
             assertThatThrownBy(() ->
                     processInstanceControllerHelper.linkProcessInstances(request, invalidMainProcessInstanceId)
                 )
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(QueryEntityNotFoundException.class)
                 .hasMessage("Unable to find process for the given id:'" + invalidMainProcessInstanceId + "'");
         }
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerHelperIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerHelperIT.java
@@ -22,13 +22,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.querydsl.core.types.Predicate;
-import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.query.rest.helper.ProcessInstanceControllerHelper;

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -42,6 +43,7 @@ import org.activiti.cloud.conf.QueryRestWebMvcAutoConfiguration;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ProcessDefinitionRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.QueryEntityNotFoundException;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
@@ -316,5 +318,24 @@ class ProcessInstanceControllerTest {
             )
             //then
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenProcessInstanceDoesNotExist() throws Exception {
+        //given
+        String processInstanceId = "nonexistent-id";
+        willThrow(new QueryEntityNotFoundException("Unable to find process for the given id:'" + processInstanceId + "'"))
+            .given(processInstanceService).subprocesses(any(), any(), any());
+
+        //when
+        mockMvc
+            .perform(
+                get("/v1/process-instances/{processInstanceId}/subprocesses", processInstanceId)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            //then
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.entry.code").value(404))
+            .andExpect(jsonPath("$.entry.message").value("Unable to find process for the given id:'" + processInstanceId + "'"));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceControllerTest.java
@@ -324,8 +324,11 @@ class ProcessInstanceControllerTest {
     void shouldReturnNotFoundWhenProcessInstanceDoesNotExist() throws Exception {
         //given
         String processInstanceId = "nonexistent-id";
-        willThrow(new QueryEntityNotFoundException("Unable to find process for the given id:'" + processInstanceId + "'"))
-            .given(processInstanceService).subprocesses(any(), any(), any());
+        willThrow(
+            new QueryEntityNotFoundException("Unable to find process for the given id:'" + processInstanceId + "'")
+        )
+            .given(processInstanceService)
+            .subprocesses(any(), any(), any());
 
         //when
         mockMvc
@@ -336,6 +339,8 @@ class ProcessInstanceControllerTest {
             //then
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.entry.code").value(404))
-            .andExpect(jsonPath("$.entry.message").value("Unable to find process for the given id:'" + processInstanceId + "'"));
+            .andExpect(
+                jsonPath("$.entry.message").value("Unable to find process for the given id:'" + processInstanceId + "'")
+            );
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminControllerIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.conf.QueryRestWebMvcAutoConfiguration;
+import org.activiti.cloud.services.query.app.repository.EntityFinder;
+import org.activiti.cloud.services.query.app.repository.IntegrationContextRepository;
+import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
+import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.VariableRepository;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesManager;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+@WebMvcTest(ServiceTaskIntegrationContextAdminController.class)
+@Import(
+    { QueryRestWebMvcAutoConfiguration.class, CommonModelAutoConfiguration.class, AlfrescoWebAutoConfiguration.class }
+)
+@EnableSpringDataWebSupport
+@AutoConfigureMockMvc
+@WithMockUser
+@TestPropertySource(locations = "classpath:application-test.properties")
+class ServiceTaskIntegrationContextAdminControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IntegrationContextRepository integrationContextRepository;
+
+    @MockitoBean
+    private ProcessInstanceRepository processInstanceRepository;
+
+    @MockitoBean
+    private TaskCandidateUserRepository taskCandidateUserRepository;
+
+    @MockitoBean
+    private TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    @MockitoBean
+    private SecurityManager securityManager;
+
+    @MockitoBean
+    private SecurityPoliciesManager securityPoliciesManager;
+
+    @MockitoBean
+    private SecurityPoliciesProperties securityPoliciesProperties;
+
+    @MockitoBean
+    private TaskRepository taskRepository;
+
+    @MockitoBean
+    private VariableRepository processVariableRepository;
+
+    @MockitoBean
+    private ProcessInstanceAdminService processInstanceAdminService;
+
+    @MockitoBean
+    private ProcessInstanceService processInstanceService;
+
+    @MockitoBean
+    private EntityManagerFactory entityManagerFactory;
+
+    @MockitoBean
+    private EntityFinder entityFinder;
+
+    @Test
+    void shouldReturnNotFoundWhenServiceTaskHasNoIntegrationContext() throws Exception {
+        //given
+        String serviceTaskId = "proc1:client1:exec1";
+        given(
+            integrationContextRepository.findByProcessInstanceIdAndClientIdAndExecutionId(
+                eq("proc1"),
+                eq("client1"),
+                eq("exec1"),
+                any(Pageable.class)
+            )
+        ).willReturn(new PageImpl<>(List.of()));
+
+        //when
+        mockMvc
+            .perform(
+                get("/admin/v1/service-tasks/{serviceTaskId}/integration-context", serviceTaskId)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            //then
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.entry.code").value(404))
+            .andExpect(
+                jsonPath("$.entry.message")
+                    .value(
+                        "Unable to find integration context entity for the given id:'" + serviceTaskId + "'"
+                    )
+            );
+    }
+
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ServiceTaskIntegrationContextAdminControllerIT.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import jakarta.persistence.EntityManagerFactory;
+import java.util.List;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
@@ -49,8 +50,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
 
 @WebMvcTest(ServiceTaskIntegrationContextAdminController.class)
 @Import(
@@ -115,7 +114,8 @@ class ServiceTaskIntegrationContextAdminControllerIT {
                 eq("exec1"),
                 any(Pageable.class)
             )
-        ).willReturn(new PageImpl<>(List.of()));
+        )
+            .willReturn(new PageImpl<>(List.of()));
 
         //when
         mockMvc
@@ -128,10 +128,7 @@ class ServiceTaskIntegrationContextAdminControllerIT {
             .andExpect(jsonPath("$.entry.code").value(404))
             .andExpect(
                 jsonPath("$.entry.message")
-                    .value(
-                        "Unable to find integration context entity for the given id:'" + serviceTaskId + "'"
-                    )
+                    .value("Unable to find integration context entity for the given id:'" + serviceTaskId + "'")
             );
     }
-
 }


### PR DESCRIPTION
When a resource is not found (e.g., process instance, integration context), the query service was logging a full stacktrace for jakarta.persistence.EntityNotFoundException. Since a 404 is an expected outcome and not an error, this noise pollutes logs and APM traces, making it harder to identify real issues.

AAE-43060