### PR TITLE
AAE-25705 Add Multi Instance Output Mapping Integration Test for Call Activity

### DIFF
--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
+    <activiti.version>9.1.0-alpha.23</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-api/pom.xml
+++ b/activiti-cloud-api/pom.xml
@@ -12,7 +12,7 @@
   <name>Activiti Cloud :: Runtime API Parent</name>
   <packaging>pom</packaging>
   <properties>
-    <activiti.version>9.1.0-alpha.22</activiti.version>
+    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
   </properties>
   <modules>
     <module>activiti-cloud-api-dependencies</module>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-query-rest</module>
   </modules>
   <properties>
-    <activiti.version>9.1.0-alpha.22</activiti.version>
+    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-query-service/pom.xml
+++ b/activiti-cloud-query-service/pom.xml
@@ -19,7 +19,7 @@
     <module>activiti-cloud-starter-query-rest</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
+    <activiti.version>9.1.0-alpha.23</activiti.version>
   </properties>
   <!-- BoM Marker Dependencies -->
   <dependencies>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java
@@ -51,12 +51,14 @@ import org.activiti.engine.TaskService;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.services.connectors.conf.ConnectorImplementationsProvider;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.PagedModel;
@@ -67,6 +69,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @TestPropertySource("classpath:application-test.properties")
@@ -82,6 +85,9 @@ import org.springframework.test.context.TestPropertySource;
 public abstract class AbstractMQServiceTaskIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMQServiceTaskIT.class);
+
+    @MockitoBean
+    private BuildProperties buildProperties;
 
     @Autowired
     protected RuntimeService runtimeService;
@@ -502,6 +508,79 @@ public abstract class AbstractMQServiceTaskIT {
                         tuple(multiInstanceProcess.getId(), multiInstanceProcess.getProcessDefinitionKey())
                     )
             );
+    }
+
+    @Test
+    public void should_map_output_variables_from_multi_instance_document_batch_process() {
+        //given
+        ResponseEntity<CloudProcessInstance> processInstance = processInstanceRestTemplate.startProcess(
+            ProcessPayloadBuilder.start().withProcessDefinitionKey("Process_1770387614252").build()
+        );
+
+        waitForTaskOnProcessInstance(processInstance, "Wait");
+
+        await()
+            .untilAsserted(() -> {
+                //when
+                ResponseEntity<CollectionModel<CloudVariableInstance>> variablesResponse = processInstanceRestTemplate.getVariables(
+                    processInstance
+                );
+
+                //then
+                Collection<CloudVariableInstance> variables = variablesResponse.getBody().getContent();
+                assertThat(variables)
+                    .filteredOn(it -> "response".equals(it.getName()))
+                    .singleElement()
+                    .extracting(VariableInstance::getValue)
+                    .asInstanceOf(InstanceOfAssertFactories.list(Map.class))
+                    .containsExactlyInAnyOrder(
+                        Map.of(
+                            "document",
+                            Map.of(
+                                "id",
+                                "55",
+                                "fields",
+                                List.of(Map.of("id", "test", "value", "555")),
+                                "updated",
+                                true
+                            ),
+                            "index",
+                            4,
+                            "documentVar",
+                            "test 4"
+                        ),
+                        Map.of(
+                            "document",
+                            Map.of(
+                                "id",
+                                "44",
+                                "fields",
+                                List.of(Map.of("id", "test", "value", "444")),
+                                "updated",
+                                true
+                            ),
+                            "index",
+                            3,
+                            "documentVar",
+                            "test 3"
+                        ),
+                        Map.of(
+                            "document",
+                            Map.of(
+                                "id",
+                                "33",
+                                "fields",
+                                List.of(Map.of("id", "test", "value", "333")),
+                                "updated",
+                                true
+                            ),
+                            "index",
+                            2,
+                            "documentVar",
+                            "test 2"
+                        )
+                    );
+            });
     }
 
     private void resumeExecutionOfSingleInstance() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
@@ -28,6 +28,12 @@ public interface ConnectorIntegrationChannels {
     String VALUE_PROCESSOR_CONSUMER = "valueProcessorConsumer";
     String RACE_CONDITIONS_MULTI_INSTANCE_CONSUMER = "raceConditionsMultiInstanceConsumer";
     String RACE_CONDITION_SINGLE_INSTANCE_CONSUMER = "raceConditionsSingleInstanceConsumer";
+    String SCRIPT_RUNTIME_CONSUMER = "scriptRuntimeConsumer";
+
+    @InputBinding(SCRIPT_RUNTIME_CONSUMER)
+    default SubscribableChannel scriptRuntimeConsumer() {
+        return MessageChannels.publishSubscribe(SCRIPT_RUNTIME_CONSUMER).getObject();
+    }
 
     @InputBinding(INTEGRATION_EVENTS_CONSUMER)
     default SubscribableChannel integrationEventsConsumer() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.starter.tests.runtime;
 
+import static org.activiti.cloud.starter.tests.runtime.ConnectorIntegrationChannels.SCRIPT_RUNTIME_CONSUMER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -313,6 +314,22 @@ public class ServiceTaskConsumerHandler {
                 throw new RuntimeException(e);
             }
             integrationResultSender.send(message.getPayload(), message.getPayload().getIntegrationContext());
+        };
+    }
+
+    @Bean
+    @FunctionBinding(input = SCRIPT_RUNTIME_CONSUMER)
+    public Consumer<Message<IntegrationRequest>> scriptRuntimeExecutor() {
+        return message -> {
+            final var integrationContext = message.getPayload().getIntegrationContext();
+
+            final Map<String, Object> testDocument = integrationContext.getInBoundVariable("testDocument");
+
+            testDocument.put("updated", true);
+
+            integrationContext.addOutBoundVariable("testDocument", testDocument);
+
+            integrationResultSender.send(message.getPayload(), integrationContext);
         };
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -62,6 +62,11 @@ spring.cloud.stream.bindings.canFailConnector.destination=connector.canFail
 spring.cloud.stream.bindings.canFailConnector.group=integration
 spring.cloud.stream.bindings.canFailConnector.contentType=application/json
 
+# script task connector
+spring.cloud.stream.bindings.scriptRuntimeConsumer.destination=script.EXECUTE
+spring.cloud.stream.bindings.scriptRuntimeConsumer.group=integration
+spring.cloud.stream.bindings.scriptRuntimeConsumer.contentType=application/json
+
 # Race condition test connectors
 spring.cloud.stream.bindings.raceConditionsMultiInstanceConsumer.destination=testRaceConditionMultipleInstances
 spring.cloud.stream.bindings.raceConditionsMultiInstanceConsumer.group=integration

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel-extensions.json
@@ -1,0 +1,120 @@
+{
+  "id": "process-0bf74e1a-7e06-439a-8163-4b29451a87db",
+  "type": "PROCESS",
+  "name": "parallel-process",
+  "key": "parallel-process-gmpel",
+  "extensions": {
+    "Process_1770387614252": {
+      "constants": {},
+      "mappings": {
+        "Activity_03t1ziz": {
+          "inputs": {
+            "testDoc": {
+              "type": "variable",
+              "value": "document"
+            },
+            "testIndex": {
+              "type": "variable",
+              "value": "documentIndex"
+            }
+          },
+          "outputs": {
+            "document": {
+              "type": "variable",
+              "value": "testDoc"
+            },
+            "index": {
+              "type": "variable",
+              "value": "testIndex"
+            },
+            "documentVar": {
+              "type": "variable",
+              "value": "testVar"
+            }
+          }
+        }
+      },
+      "properties": {
+        "33395f37-acff-400f-83a5-d53af0272cdc": {
+          "id": "33395f37-acff-400f-83a5-d53af0272cdc",
+          "name": "batchState",
+          "type": "json",
+          "model": {
+            "$ref": "#/$defs/primitive/json"
+          },
+          "required": false,
+          "ephemeral": false,
+          "value": {
+            "documents": [
+              {
+                "id": "11",
+                "fields": [
+                  {
+                    "id": "test",
+                    "value": "111"
+                  }
+                ]
+              },
+              {
+                "id": "22",
+                "fields": [
+                  {
+                    "id": "test",
+                    "value": "222"
+                  }
+                ]
+              },
+              {
+                "id": "33",
+                "fields": [
+                  {
+                    "id": "test",
+                    "value": "333"
+                  }
+                ]
+              },
+              {
+                "id": "44",
+                "fields": [
+                  {
+                    "id": "test",
+                    "value": "444"
+                  }
+                ]
+              },
+              {
+                "id": "55",
+                "fields": [
+                  {
+                    "id": "test",
+                    "value": "555"
+                  }
+                ]
+              }
+            ]
+          },
+          "description": "",
+          "category": "local"
+        },
+        "8121b267-82bb-43c7-bb3d-58b5c3192c17": {
+          "id": "8121b267-82bb-43c7-bb3d-58b5c3192c17",
+          "name": "response",
+          "type": "array",
+          "model": {
+            "type": "array",
+            "description": "Array of json items",
+            "items": {
+              "$ref": "#/$defs/primitive/json"
+            },
+            "examples": []
+          },
+          "required": false,
+          "ephemeral": false,
+          "description": "",
+          "category": "local"
+        }
+      },
+      "assignments": {}
+    }
+  }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel.bpmn20.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="model-0bf74e1a-7e06-439a-8163-4b29451a87db" name="parallel-process" targetNamespace="" exporter="Activiti Modeler" exporterVersion="3.0.0-beta.7" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_1770387614252" name="parallel-process" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>Flow_1gqkjdt</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="Event_0vvdh4i">
+      <bpmn2:incoming>SequenceFlow_14vqsnn</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="Flow_1gqkjdt" sourceRef="Event_1" targetRef="Activity_03t1ziz" />
+    <bpmn2:callActivity id="Activity_03t1ziz" name="Execute in Parallel" calledElement="Process_1770387490219" activiti:inheritBusinessKey="true">
+      <bpmn2:incoming>Flow_1gqkjdt</bpmn2:incoming>
+      <bpmn2:outgoing>Flow_1npon2t</bpmn2:outgoing>
+      <bpmn2:multiInstanceLoopCharacteristics activiti:collection="${batchState.documents}" activiti:elementVariable="document" activiti:elementIndexVariable="documentIndex">
+        <bpmn2:loopDataOutputRef>response</bpmn2:loopDataOutputRef>
+        <bpmn2:completionCondition>${nrOfCompletedInstances &gt;= nrOfActiveInstances}</bpmn2:completionCondition>
+      </bpmn2:multiInstanceLoopCharacteristics>
+    </bpmn2:callActivity>
+    <bpmn2:sequenceFlow id="Flow_1npon2t" sourceRef="Activity_03t1ziz" targetRef="Task_176uabb" />
+    <bpmn2:sequenceFlow id="SequenceFlow_14vqsnn" sourceRef="Task_176uabb" targetRef="Event_0vvdh4i" />
+    <bpmn2:userTask id="Task_176uabb" name="Wait" activiti:assignee="hruser">
+      <bpmn2:incoming>Flow_1npon2t</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_14vqsnn</bpmn2:outgoing>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1770387614252">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vvdh4i_di" bpmnElement="Event_0vvdh4i">
+        <dc:Bounds x="539" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03t1ziz_di" bpmnElement="Activity_03t1ziz">
+        <dc:Bounds x="254" y="81" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1gqkjdt_di" bpmnElement="Flow_1gqkjdt">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="254" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1npon2t_di" bpmnElement="Flow_1npon2t">
+        <di:waypoint x="354" y="121" />
+        <di:waypoint x="397" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_14vqsnn_di" bpmnElement="SequenceFlow_14vqsnn">
+        <di:waypoint x="497" y="121" />
+        <di:waypoint x="539" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0xe7el9_di" bpmnElement="Task_176uabb">
+        <dc:Bounds x="397" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd-extensions.json
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd-extensions.json
@@ -1,0 +1,75 @@
+{
+  "id": "process-6d34f760-a853-4f40-b60c-b85e2e812f5d",
+  "type": "PROCESS",
+  "name": "simple-process",
+  "key": "simple-process-wdhyd",
+  "extensions": {
+    "Process_1770387490219": {
+      "constants": {
+        "Activity_1wcnejq": {
+          "_activiti_script_": {
+            "value": "update-variable-tkuno"
+          }
+        }
+      },
+      "mappings": {
+        "Activity_1wcnejq": {
+          "inputs": {
+            "testDocument": {
+              "type": "variable",
+              "value": "testDoc"
+            }
+          },
+          "outputs": {
+            "testDoc": {
+              "type": "variable",
+              "value": "testDocument"
+            }
+          }
+        }
+      },
+      "properties": {
+        "57a03b3b-cd3d-4314-8716-9c1e7b1f7df8": {
+          "id": "57a03b3b-cd3d-4314-8716-9c1e7b1f7df8",
+          "name": "testDoc",
+          "type": "json",
+          "model": {
+            "$ref": "#/$defs/primitive/json"
+          },
+          "required": false,
+          "ephemeral": false,
+          "description": "",
+          "category": "input/output"
+        },
+        "89bd6640-c74d-4ab5-951a-854fceda725a": {
+          "id": "89bd6640-c74d-4ab5-951a-854fceda725a",
+          "name": "testIndex",
+          "type": "integer",
+          "model": {
+            "$ref": "#/$defs/primitive/integer"
+          },
+          "required": false,
+          "ephemeral": false,
+          "analytics": false,
+          "description": "",
+          "category": "input"
+        },
+        "71c2836d-206e-4518-b86a-6473eab0185b": {
+          "id": "71c2836d-206e-4518-b86a-6473eab0185b",
+          "name": "testVar",
+          "type": "string",
+          "model": {
+            "$ref": "#/$defs/primitive/string"
+          },
+          "required": false,
+          "ephemeral": false,
+          "analytics": false,
+          "value": "test ${testIndex}",
+          "description": "",
+          "category": "local"
+        }
+      },
+      "assignments": {}
+    }
+  }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd.bpmn20.xml
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-6d34f760-a853-4f40-b60c-b85e2e812f5d" name="simple-process" targetNamespace="" exporter="Activiti Modeler" exporterVersion="3.0.0-beta.7" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="Process_1770387490219" name="simple-process" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>Flow_0cir5tr</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="Event_1rita2m">
+      <bpmn2:incoming>Flow_12dvvb0</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="Flow_0cir5tr" sourceRef="Event_1" targetRef="Activity_1wcnejq" />
+    <bpmn2:serviceTask id="Activity_1wcnejq" name="Update value" implementation="script.EXECUTE">
+      <bpmn2:incoming>Flow_0cir5tr</bpmn2:incoming>
+      <bpmn2:outgoing>Flow_12dvvb0</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="Flow_12dvvb0" sourceRef="Activity_1wcnejq" targetRef="Event_1rita2m" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1770387490219">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rita2m_di" bpmnElement="Event_1rita2m">
+        <dc:Bounds x="538" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wcnejq_di" bpmnElement="Activity_1wcnejq">
+        <dc:Bounds x="346" y="81" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0cir5tr_di" bpmnElement="Flow_0cir5tr">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="346" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12dvvb0_di" bpmnElement="Flow_12dvvb0">
+        <di:waypoint x="446" y="121" />
+        <di:waypoint x="538" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -18,7 +18,8 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
+    <activiti.version>9.1.0-alpha.23</activiti.version>
+    <commons-fileupload.version>1.6.0</commons-fileupload.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-runtime-bundle-service/pom.xml
+++ b/activiti-cloud-runtime-bundle-service/pom.xml
@@ -18,8 +18,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-    <activiti.version>9.1.0-alpha.22</activiti.version>
-    <commons-fileupload.version>1.6.0</commons-fileupload.version>
+    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -37,8 +37,7 @@
   </modules>
   <properties>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
-    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
-    <commons-lang3.version>3.20.0</commons-lang3.version>
+    <activiti.version>9.1.0-alpha.23</activiti.version>
     <java-semver.version>0.10.2</java-semver.version>
     <resteasy.version>7.0.2.Final</resteasy.version>
     <logstash.version>9.0</logstash.version>

--- a/activiti-cloud-service-common/pom.xml
+++ b/activiti-cloud-service-common/pom.xml
@@ -37,7 +37,8 @@
   </modules>
   <properties>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
-    <activiti.version>9.1.0-alpha.22</activiti.version>
+    <activiti.version>0.0.1-PR-5353-2876-SNAPSHOT</activiti.version>
+    <commons-lang3.version>3.20.0</commons-lang3.version>
     <java-semver.version>0.10.2</java-semver.version>
     <resteasy.version>7.0.2.Final</resteasy.version>
     <logstash.version>9.0</logstash.version>


### PR DESCRIPTION

## Description

Updates the runtime-bundle integration test suite to reproduce/verify **multi-instance call activity output variable mapping**, and temporarily bumps the referenced Activiti dependency version to pick up the [engine-side fix](https://github.com/Activiti/Activiti/pull/5353) linked to [AAE-25705](https://hyland.atlassian.net/browse/AAE-25705).

**Changes:**
- Add new BPMN models + extensions JSON to exercise multi-instance call activity output collection.
- Extend test infrastructure (Spring Cloud Stream binding + consumer) and add a new IT assertion for the collected `response` variable.

Depends on https://github.com/Activiti/Activiti/pull/5353

### Reviewed changes

Copilot reviewed 12 out of 12 changed files in this pull request and generated 5 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| activiti-cloud-service-common/pom.xml | Updates `activiti.version` used for core/common dependency management. |
| activiti-cloud-runtime-bundle-service/pom.xml | Updates `activiti.version` for runtime bundle dependency management. |
| activiti-cloud-query-service/pom.xml | Updates `activiti.version` for query service dependency management. |
| activiti-cloud-api/pom.xml | Updates `activiti.version` for API BOM import. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd.bpmn20.xml | Adds called subprocess used by the call activity MI scenario. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-simple-process-wdhyd-extensions.json | Adds connector mappings/constants to update and map variables in the called subprocess. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel.bpmn20.xml | Adds parent process with parallel multi-instance call activity and loop output collection. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/multi-instance-call-activity-parallel-process-gmpel-extensions.json | Adds call activity input/output mappings and seed data (`batchState`). |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties | Adds binder configuration for the new `script.EXECUTE` test connector. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java | Adds a connector consumer that mutates a document and returns it as an outbound variable. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java | Adds a new input binding/channel for `scriptRuntimeConsumer`. |
| activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/AbstractMQServiceTaskIT.java | Adds a new IT that asserts MI call activity output mapping into a collected `response` variable. |
</details>



[AAE-25705]: https://hyland.atlassian.net/browse/AAE-25705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ