### PR TITLE
AAE-43340 Adding severity as an attribute to the INCIDENT_CREATED audit events v2

### DIFF
--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationRequestImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/IntegrationRequestImpl.java
@@ -27,6 +27,8 @@ public class IntegrationRequestImpl extends CloudRuntimeEntityImpl implements In
 
     private String errorDestination;
 
+    private String incidentDestination;
+
     public IntegrationRequestImpl() {}
 
     public IntegrationRequestImpl(IntegrationContext integrationContext) {
@@ -57,5 +59,14 @@ public class IntegrationRequestImpl extends CloudRuntimeEntityImpl implements In
 
     public void setErrorDestination(String errorDestination) {
         this.errorDestination = errorDestination;
+    }
+
+    @Override
+    public String getIncidentDestination() {
+        return incidentDestination;
+    }
+
+    public void setIncidentDestination(String incidentDestination) {
+        this.incidentDestination = incidentDestination;
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIncidentCreatedEventImpl.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/main/java/org/activiti/cloud/api/process/model/impl/events/CloudIncidentCreatedEventImpl.java
@@ -24,6 +24,7 @@ import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.IncidentContext;
 import org.activiti.cloud.api.process.model.IncidentEvent;
 import org.activiti.cloud.api.process.model.IncidentEvent.IncidentEventType;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 
 public class CloudIncidentCreatedEventImpl
     extends CloudRuntimeEventImpl<IncidentContext, IncidentEventType>
@@ -33,6 +34,7 @@ public class CloudIncidentCreatedEventImpl
     private String errorMessage;
     private List<StackTraceElement> stackTraceElements;
     private String errorClassName;
+    private IncidentSeverity severity = IncidentSeverity.ERROR;
 
     public CloudIncidentCreatedEventImpl() {}
 
@@ -53,6 +55,11 @@ public class CloudIncidentCreatedEventImpl
         setEntityId(incidentContext.getExecutionId());
     }
 
+    public CloudIncidentCreatedEventImpl(Throwable error, IncidentContext incidentContext, IncidentSeverity severity) {
+        this(error, incidentContext);
+        this.severity = Objects.requireNonNullElse(severity, IncidentSeverity.ERROR);
+    }
+
     public CloudIncidentCreatedEventImpl(
         String id,
         Long timestamp,
@@ -67,6 +74,20 @@ public class CloudIncidentCreatedEventImpl
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.stackTraceElements = stackTraceElements;
+    }
+
+    public CloudIncidentCreatedEventImpl(
+        String id,
+        Long timestamp,
+        IncidentContext entity,
+        String errorClassName,
+        String errorCode,
+        String errorMessage,
+        List<StackTraceElement> stackTraceElements,
+        IncidentSeverity severity
+    ) {
+        this(id, timestamp, entity, errorClassName, errorCode, errorMessage, stackTraceElements);
+        this.severity = Objects.requireNonNullElse(severity, IncidentSeverity.ERROR);
     }
 
     @Override
@@ -92,6 +113,16 @@ public class CloudIncidentCreatedEventImpl
     @Override
     public String getErrorCode() {
         return errorCode;
+    }
+
+    @Override
+    public IncidentSeverity getSeverity() {
+        return severity;
+    }
+
+    @Override
+    public void setSeverity(IncidentSeverity severity) {
+        this.severity = Objects.requireNonNullElse(severity, IncidentSeverity.ERROR);
     }
 
     protected Throwable findRootCause(Throwable throwable) {

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/test/java/org/activiti/cloud/api/process/model/impl/events/ConnectorIncidentEventTest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/test/java/org/activiti/cloud/api/process/model/impl/events/ConnectorIncidentEventTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.api.process.model.impl.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.ConnectorIncidentEvent;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
+import org.junit.jupiter.api.Test;
+
+class ConnectorIncidentEventTest {
+
+    @Test
+    void should_createWithAllFields() {
+        IntegrationContext context = mock(IntegrationContext.class);
+        Exception exception = new RuntimeException("test error");
+
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(context, exception, IncidentSeverity.WARNING);
+
+        assertThat(event.getIntegrationContext()).isSameAs(context);
+        assertThat(event.getException()).isSameAs(exception);
+        assertThat(event.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
+    }
+
+    @Test
+    void should_createWithNoArgConstructor() {
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent();
+
+        assertThat(event.getIntegrationContext()).isNull();
+        assertThat(event.getException()).isNull();
+        assertThat(event.getSeverity()).isNull();
+    }
+
+    @Test
+    void should_supportSetters() {
+        IntegrationContext context = mock(IntegrationContext.class);
+        Exception exception = new RuntimeException("error");
+
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent();
+        event.setIntegrationContext(context);
+        event.setException(exception);
+        event.setSeverity(IncidentSeverity.ERROR);
+
+        assertThat(event.getIntegrationContext()).isSameAs(context);
+        assertThat(event.getException()).isSameAs(exception);
+        assertThat(event.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void should_beEqual_whenSameFields() {
+        IntegrationContext context = mock(IntegrationContext.class);
+        Exception exception = new RuntimeException("error");
+
+        ConnectorIncidentEvent event1 = new ConnectorIncidentEvent(context, exception, IncidentSeverity.WARNING);
+        ConnectorIncidentEvent event2 = new ConnectorIncidentEvent(context, exception, IncidentSeverity.WARNING);
+
+        assertThat(event1).isEqualTo(event2);
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode());
+    }
+
+    @Test
+    void should_notBeEqual_whenDifferentSeverity() {
+        IntegrationContext context = mock(IntegrationContext.class);
+        Exception exception = new RuntimeException("error");
+
+        ConnectorIncidentEvent event1 = new ConnectorIncidentEvent(context, exception, IncidentSeverity.WARNING);
+        ConnectorIncidentEvent event2 = new ConnectorIncidentEvent(context, exception, IncidentSeverity.ERROR);
+
+        assertThat(event1).isNotEqualTo(event2);
+    }
+
+    @Test
+    void should_notBeEqual_whenDifferentException() {
+        IntegrationContext context = mock(IntegrationContext.class);
+
+        ConnectorIncidentEvent event1 = new ConnectorIncidentEvent(
+            context,
+            new RuntimeException("one"),
+            IncidentSeverity.WARNING
+        );
+        ConnectorIncidentEvent event2 = new ConnectorIncidentEvent(
+            context,
+            new RuntimeException("two"),
+            IncidentSeverity.WARNING
+        );
+
+        assertThat(event1).isNotEqualTo(event2);
+    }
+
+    @Test
+    void should_haveToString() {
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(
+            null,
+            new RuntimeException("test"),
+            IncidentSeverity.WARNING
+        );
+
+        assertThat(event.toString()).contains("WARNING").contains("test");
+    }
+}

--- a/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/test/java/org/activiti/cloud/api/process/model/impl/events/IntegrationRequestImplTest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model-impl/src/test/java/org/activiti/cloud/api/process/model/impl/events/IntegrationRequestImplTest.java
@@ -37,4 +37,19 @@ public class IntegrationRequestImplTest {
         IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
         assertThat(integrationRequest.getAppVersion()).isEqualTo("1");
     }
+
+    @Test
+    public void should_setAndGetIncidentDestination() {
+        given(integrationContext.getAppVersion()).willReturn("1");
+        IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
+        integrationRequest.setIncidentDestination("connectorIncident_myApp");
+        assertThat(integrationRequest.getIncidentDestination()).isEqualTo("connectorIncident_myApp");
+    }
+
+    @Test
+    public void should_returnNullIncidentDestination_whenNotSet() {
+        given(integrationContext.getAppVersion()).willReturn("1");
+        IntegrationRequestImpl integrationRequest = new IntegrationRequestImpl(integrationContext);
+        assertThat(integrationRequest.getIncidentDestination()).isNull();
+    }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
@@ -15,15 +15,10 @@
  */
 package org.activiti.cloud.api.process.model;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.util.Objects;
 import org.activiti.api.process.model.IntegrationContext;
 
-public class ConnectorIncidentEvent implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
+public class ConnectorIncidentEvent {
 
     private IntegrationContext integrationContext;
     private Exception exception;

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
@@ -28,7 +28,6 @@ public class ConnectorIncidentEvent implements Serializable {
     private IntegrationContext integrationContext;
     private Exception exception;
     private IncidentSeverity severity;
-    private String targetAppName;
 
     public ConnectorIncidentEvent() {}
 
@@ -37,19 +36,9 @@ public class ConnectorIncidentEvent implements Serializable {
         Exception exception,
         IncidentSeverity severity
     ) {
-        this(integrationContext, exception, severity, null);
-    }
-
-    public ConnectorIncidentEvent(
-        IntegrationContext integrationContext,
-        Exception exception,
-        IncidentSeverity severity,
-        String targetAppName
-    ) {
         this.integrationContext = integrationContext;
         this.exception = exception;
         this.severity = severity;
-        this.targetAppName = targetAppName;
     }
 
     public IntegrationContext getIntegrationContext() {
@@ -76,14 +65,6 @@ public class ConnectorIncidentEvent implements Serializable {
         this.severity = severity;
     }
 
-    public String getTargetAppName() {
-        return targetAppName;
-    }
-
-    public void setTargetAppName(String targetAppName) {
-        this.targetAppName = targetAppName;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -92,28 +73,17 @@ public class ConnectorIncidentEvent implements Serializable {
         return (
             Objects.equals(integrationContext, that.integrationContext) &&
             Objects.equals(exception, that.exception) &&
-            severity == that.severity &&
-            Objects.equals(targetAppName, that.targetAppName)
+            severity == that.severity
         );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(integrationContext, exception, severity, targetAppName);
+        return Objects.hash(integrationContext, exception, severity);
     }
 
     @Override
     public String toString() {
-        return (
-            "ConnectorIncidentEvent{" +
-            "exception=" +
-            exception +
-            ", severity=" +
-            severity +
-            ", targetAppName='" +
-            targetAppName +
-            '\'' +
-            '}'
-        );
+        return "ConnectorIncidentEvent{" + "exception=" + exception + ", severity=" + severity + '}';
     }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/ConnectorIncidentEvent.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.api.process.model;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+import org.activiti.api.process.model.IntegrationContext;
+
+public class ConnectorIncidentEvent implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private IntegrationContext integrationContext;
+    private Exception exception;
+    private IncidentSeverity severity;
+    private String targetAppName;
+
+    public ConnectorIncidentEvent() {}
+
+    public ConnectorIncidentEvent(
+        IntegrationContext integrationContext,
+        Exception exception,
+        IncidentSeverity severity
+    ) {
+        this(integrationContext, exception, severity, null);
+    }
+
+    public ConnectorIncidentEvent(
+        IntegrationContext integrationContext,
+        Exception exception,
+        IncidentSeverity severity,
+        String targetAppName
+    ) {
+        this.integrationContext = integrationContext;
+        this.exception = exception;
+        this.severity = severity;
+        this.targetAppName = targetAppName;
+    }
+
+    public IntegrationContext getIntegrationContext() {
+        return integrationContext;
+    }
+
+    public void setIntegrationContext(IntegrationContext integrationContext) {
+        this.integrationContext = integrationContext;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
+    public IncidentSeverity getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(IncidentSeverity severity) {
+        this.severity = severity;
+    }
+
+    public String getTargetAppName() {
+        return targetAppName;
+    }
+
+    public void setTargetAppName(String targetAppName) {
+        this.targetAppName = targetAppName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConnectorIncidentEvent that = (ConnectorIncidentEvent) o;
+        return (
+            Objects.equals(integrationContext, that.integrationContext) &&
+            Objects.equals(exception, that.exception) &&
+            severity == that.severity &&
+            Objects.equals(targetAppName, that.targetAppName)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(integrationContext, exception, severity, targetAppName);
+    }
+
+    @Override
+    public String toString() {
+        return (
+            "ConnectorIncidentEvent{" +
+            "exception=" +
+            exception +
+            ", severity=" +
+            severity +
+            ", targetAppName='" +
+            targetAppName +
+            '\'' +
+            '}'
+        );
+    }
+}

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IncidentSeverity.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IncidentSeverity.java
@@ -16,7 +16,6 @@
 package org.activiti.cloud.api.process.model;
 
 public enum IncidentSeverity {
-    FATAL,
     ERROR,
     WARNING,
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IncidentSeverity.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IncidentSeverity.java
@@ -15,24 +15,8 @@
  */
 package org.activiti.cloud.api.process.model;
 
-import java.util.List;
-import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
-import org.activiti.cloud.api.process.model.IncidentEvent.IncidentEventType;
-
-public interface IncidentEvent extends CloudRuntimeEvent<IncidentContext, IncidentEventType> {
-    String getErrorCode();
-
-    List<StackTraceElement> getStackTraceElements();
-
-    String getErrorMessage();
-
-    String getErrorClassName();
-
-    IncidentSeverity getSeverity();
-
-    void setSeverity(IncidentSeverity severity);
-
-    enum IncidentEventType {
-        INCIDENT_CREATED,
-    }
+public enum IncidentSeverity {
+    FATAL,
+    ERROR,
+    WARNING,
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
@@ -25,7 +25,5 @@ public interface IntegrationRequest extends CloudRuntimeEntity {
 
     String getErrorDestination();
 
-    String getIncidentDestination() {
-        return null;
-    }
+    String getIncidentDestination();
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
@@ -24,4 +24,6 @@ public interface IntegrationRequest extends CloudRuntimeEntity {
     String getResultDestination();
 
     String getErrorDestination();
+
+    String getIncidentDestination();
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
@@ -25,5 +25,7 @@ public interface IntegrationRequest extends CloudRuntimeEntity {
 
     String getErrorDestination();
 
-    String getIncidentDestination();
+    default String getIncidentDestination() {
+        return null;
+    }
 }

--- a/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
+++ b/activiti-cloud-api/activiti-cloud-api-process-model/src/main/java/org/activiti/cloud/api/process/model/IntegrationRequest.java
@@ -25,5 +25,7 @@ public interface IntegrationRequest extends CloudRuntimeEntity {
 
     String getErrorDestination();
 
-    String getIncidentDestination();
+    String getIncidentDestination() {
+        return null;
+    }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerChannelHandlerImplTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerChannelHandlerImplTest.java
@@ -27,6 +27,7 @@ import org.activiti.api.process.model.events.ProcessRuntimeEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.IncidentEvent.IncidentEventType;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.audit.api.converters.APIEventToEntityConverters;
 import org.activiti.cloud.services.audit.api.converters.EventToEntityConverter;
@@ -121,7 +122,8 @@ class AuditConsumerChannelHandlerImplTest {
             "ErrorClassName",
             "ERROR_CODE",
             "Error message",
-            List.of(new StackTraceElement[0])
+            List.of(new StackTraceElement[0]),
+            IncidentSeverity.WARNING
         );
         incidentEvent.setAppName("test-app");
         incidentEvent.setServiceName("test-service");
@@ -144,5 +146,6 @@ class AuditConsumerChannelHandlerImplTest {
         assertThat(savedEntity.getMessageId()).isEqualTo(messageId.toString());
         assertThat(savedEntity.getSequenceNumber()).isEqualTo(0);
         assertThat(savedEntity.getErrorCode()).isEqualTo("ERROR_CODE");
+        assertThat(savedEntity.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.h2.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.h2.schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE audit_event ADD COLUMN IF NOT EXISTS severity varchar(255);
+UPDATE audit_event SET severity = 'ERROR' WHERE severity IS NULL AND event_type = 'INCIDENT_CREATED';

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.oracle.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.oracle.schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE audit_event ADD severity varchar2(255);
+UPDATE audit_event SET severity = 'ERROR' WHERE severity IS NULL AND event_type = 'INCIDENT_CREATED';

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.pg.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/20-alter.pg.schema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE audit_event ADD COLUMN IF NOT EXISTS severity varchar(255);
+UPDATE audit_event SET severity = 'ERROR' WHERE severity IS NULL AND event_type = 'INCIDENT_CREATED';

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/changelog/h2.schema.sql
@@ -51,6 +51,7 @@ create table audit_event
     candidate_starter_user     text,
     candidate_starter_group    text,
     ephemeral_variable         boolean,
+    severity                   varchar(255),
     primary key (id)
 );
 

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-liquibase/src/main/resources/config/audit/liquibase/master.xml
@@ -366,4 +366,31 @@
       splitStatements="true"
       stripComments="true"/>
   </changeSet>
+  <changeSet author="activiti-audit" runInTransaction="false"
+    id="alter20-schema" dbms="postgresql">
+    <sqlFile dbms="postgresql"
+      encoding="utf8"
+      path="changelog/20-alter.pg.schema.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
+  <changeSet author="activiti-audit" runInTransaction="false"
+    id="alter20-oracle-schema" dbms="oracle">
+    <sqlFile dbms="oracle"
+      encoding="utf8"
+      path="changelog/20-alter.oracle.schema.sql"
+      relativeToChangelogFile="true"
+      splitStatements="false"
+      stripComments="true"/>
+  </changeSet>
+  <changeSet author="activiti-audit"
+    id="h2-schema-alter20" dbms="h2">
+    <sqlFile dbms="h2"
+      encoding="utf8"
+      path="changelog/20-alter.h2.schema.sql"
+      relativeToChangelogFile="true"
+      splitStatements="true"
+      stripComments="true"/>
+  </changeSet>
 </databaseChangeLog>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverter.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverter.java
@@ -50,7 +50,8 @@ public class IncidentCreatedEventConverter extends BaseEventToEntityConverter {
             incidentCreatedEventEntity.getErrorClassName(),
             incidentCreatedEventEntity.getErrorCode(),
             incidentCreatedEventEntity.getErrorMessage(),
-            incidentCreatedEventEntity.getStackTraceElements()
+            incidentCreatedEventEntity.getStackTraceElements(),
+            incidentCreatedEventEntity.getSeverity()
         );
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/events/IncidentAuditEventEntity.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/main/java/org/activiti/cloud/services/audit/jpa/events/IncidentAuditEventEntity.java
@@ -17,9 +17,12 @@ package org.activiti.cloud.services.audit.jpa.events;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import org.activiti.cloud.api.process.model.IncidentContext;
 import org.activiti.cloud.api.process.model.IncidentEvent;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.audit.jpa.converters.json.IncidentContextJpaJsonConverter;
 
 @MappedSuperclass
@@ -29,11 +32,15 @@ public abstract class IncidentAuditEventEntity extends AuditEventEntity {
     @Column(columnDefinition = "text")
     private IncidentContext incidentContext;
 
+    @Enumerated(EnumType.STRING)
+    private IncidentSeverity severity;
+
     public IncidentAuditEventEntity() {}
 
     public IncidentAuditEventEntity(IncidentEvent cloudEvent) {
         super(cloudEvent);
         setIncidentContext(cloudEvent.getEntity());
+        this.severity = cloudEvent.getSeverity();
     }
 
     public IncidentContext getIncidentContext() {
@@ -44,12 +51,22 @@ public abstract class IncidentAuditEventEntity extends AuditEventEntity {
         this.incidentContext = incidentContext;
     }
 
+    public IncidentSeverity getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(IncidentSeverity severity) {
+        this.severity = severity;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder
             .append("IncidentAuditEventEntity [IncidentAuditEventEntity=")
             .append(incidentContext)
+            .append(", severity=")
+            .append(severity)
             .append(", toString()=")
             .append(super.toString())
             .append("]");

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverterTest.java
@@ -56,6 +56,7 @@ class IncidentCreatedEventConverterTest {
     @Test
     void shouldCreateEventEntityWithDefaultSeverity() {
         var event = getIncidentCreatedEvent();
+        event.setSequenceNumber(0);
 
         var entity = this.incidentCreatedEventConverter.createEventEntity(event);
 
@@ -69,6 +70,7 @@ class IncidentCreatedEventConverterTest {
             new IncidentContextImpl(),
             IncidentSeverity.WARNING
         );
+        event.setSequenceNumber(0);
 
         var entity = this.incidentCreatedEventConverter.createEventEntity(event);
 
@@ -91,6 +93,7 @@ class IncidentCreatedEventConverterTest {
     @Test
     void shouldRoundTripDefaultSeverity() {
         var createdEvent = getIncidentCreatedEvent();
+        createdEvent.setSequenceNumber(0);
         var entity = new IncidentCreatedEventEntity(createdEvent);
 
         var event = (CloudIncidentCreatedEventImpl) this.incidentCreatedEventConverter.createAPIEvent(entity);
@@ -105,6 +108,7 @@ class IncidentCreatedEventConverterTest {
             new IncidentContextImpl(),
             IncidentSeverity.WARNING
         );
+        createdEvent.setSequenceNumber(0);
         var entity = new IncidentCreatedEventEntity(createdEvent);
 
         var event = (CloudIncidentCreatedEventImpl) this.incidentCreatedEventConverter.createAPIEvent(entity);

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverterTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-model/src/test/java/org/activiti/cloud/services/audit/jpa/converters/IncidentCreatedEventConverterTest.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.audit.jpa.converters;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.cloud.api.process.model.IncidentEvent.IncidentEventType;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.IncidentContextImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.audit.jpa.events.IncidentCreatedEventEntity;
@@ -53,6 +54,28 @@ class IncidentCreatedEventConverterTest {
     }
 
     @Test
+    void shouldCreateEventEntityWithDefaultSeverity() {
+        var event = getIncidentCreatedEvent();
+
+        var entity = this.incidentCreatedEventConverter.createEventEntity(event);
+
+        assertThat(entity.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void shouldCreateEventEntityWithExplicitSeverity() {
+        var event = new CloudIncidentCreatedEventImpl(
+            new IllegalArgumentException("Test Exception"),
+            new IncidentContextImpl(),
+            IncidentSeverity.WARNING
+        );
+
+        var entity = this.incidentCreatedEventConverter.createEventEntity(event);
+
+        assertThat(entity.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
+    }
+
+    @Test
     void shouldCreateAPIEvent() {
         var createdEvent = getIncidentCreatedEvent();
         createdEvent.setSequenceNumber(100);
@@ -63,6 +86,30 @@ class IncidentCreatedEventConverterTest {
         assertThat(event.getErrorMessage()).isEqualTo("Test Exception");
         assertThat(event.getErrorClassName()).isEqualTo(IllegalArgumentException.class.getName());
         assertThat(event.getEntity()).isEqualTo(entity.getIncidentContext());
+    }
+
+    @Test
+    void shouldRoundTripDefaultSeverity() {
+        var createdEvent = getIncidentCreatedEvent();
+        var entity = new IncidentCreatedEventEntity(createdEvent);
+
+        var event = (CloudIncidentCreatedEventImpl) this.incidentCreatedEventConverter.createAPIEvent(entity);
+
+        assertThat(event.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void shouldRoundTripExplicitWarningSeverity() {
+        var createdEvent = new CloudIncidentCreatedEventImpl(
+            new IllegalArgumentException("Test Exception"),
+            new IncidentContextImpl(),
+            IncidentSeverity.WARNING
+        );
+        var entity = new IncidentCreatedEventEntity(createdEvent);
+
+        var event = (CloudIncidentCreatedEventImpl) this.incidentCreatedEventConverter.createAPIEvent(entity);
+
+        assertThat(event.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
     }
 
     private CloudIncidentCreatedEventImpl getIncidentCreatedEvent() {

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -136,7 +136,8 @@ public class RuntimeBundleApplicationIT {
                 "commandConsumer_default-app.my-runtime-bundle",
                 "asyncExecutorJobs_default-app.my-runtime-bundle",
                 "integrationResult_my-runtime-bundle.my-runtime-bundle",
-                "integrationError_my-runtime-bundle.my-runtime-bundle"
+                "integrationError_my-runtime-bundle.my-runtime-bundle",
+                "connectorIncident.my-runtime-bundle"
             );
     }
 
@@ -157,7 +158,8 @@ public class RuntimeBundleApplicationIT {
                 "messageEvents_default-app",
                 "signalEvent",
                 "integrationResult_my-runtime-bundle",
-                "integrationError_my-runtime-bundle"
+                "integrationError_my-runtime-bundle",
+                "connectorIncident"
             );
     }
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterEnabledIT.java
@@ -58,7 +58,8 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
                 "messageEvents_default-app",
                 "signalEvent",
                 "integrationResult_my-runtime-bundle",
-                "integrationError_my-runtime-bundle"
+                "integrationError_my-runtime-bundle",
+                "connectorIncident"
             );
     }
 
@@ -69,6 +70,7 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
                 "commandConsumer",
                 "integrationErrorsConsumer",
                 "integrationResultsConsumer",
+                "connectorIncidentConsumer",
                 "myCmdResults",
                 "signalConsumer",
                 "messageConnectorInput",
@@ -114,6 +116,7 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
                 "commandConsumer",
                 "integrationErrorsConsumer",
                 "integrationResultsConsumer",
+                "connectorIncidentConsumer",
                 "myCmdResults",
                 "signalConsumer",
                 "messageConnectorInput",
@@ -125,6 +128,7 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
                 "commandConsumer",
                 "integrationErrorsConsumer",
                 "integrationResultsConsumer",
+                "connectorIncidentConsumer",
                 "myCmdResults",
                 "signalConsumer",
                 "messageConnectorInput",
@@ -138,6 +142,7 @@ public class RuntimeBundleFunctionRouterEnabledIT extends RuntimeBundleApplicati
                 "messageEvents_default-app",
                 "integrationResult_my-runtime-bundle",
                 "integrationError_my-runtime-bundle",
+                "connectorIncident",
                 "signalEvent"
             );
     }

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleFunctionRouterRabbitMqPrefixIT.java
@@ -44,7 +44,8 @@ public class RuntimeBundleFunctionRouterRabbitMqPrefixIT extends RuntimeBundleFu
                 "default-app.messageEvents_default-app",
                 "default-app.signalEvent",
                 "default-app.integrationResult_my-runtime-bundle",
-                "default-app.integrationError_my-runtime-bundle"
+                "default-app.integrationError_my-runtime-bundle",
+                "default-app.connectorIncident"
             );
     }
 

--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleRabbitmqPrefixIT.java
@@ -57,7 +57,8 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
                 "default-app.commandConsumer_default-app.my-runtime-bundle",
                 "default-app.asyncExecutorJobs_default-app.my-runtime-bundle",
                 "default-app.integrationResult_my-runtime-bundle.my-runtime-bundle",
-                "default-app.integrationError_my-runtime-bundle.my-runtime-bundle"
+                "default-app.integrationError_my-runtime-bundle.my-runtime-bundle",
+                "default-app.connectorIncident.my-runtime-bundle"
             );
     }
 
@@ -74,7 +75,8 @@ public class RuntimeBundleRabbitmqPrefixIT extends RuntimeBundleApplicationIT {
                 "default-app.messageEvents_default-app",
                 "default-app.signalEvent",
                 "default-app.integrationResult_my-runtime-bundle",
-                "default-app.integrationError_my-runtime-bundle"
+                "default-app.integrationError_my-runtime-bundle",
+                "default-app.connectorIncident"
             );
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandler.java
@@ -33,10 +33,12 @@ public class ConnectorIncidentEventHandler implements Consumer<ConnectorIncident
 
     @Override
     public void accept(ConnectorIncidentEvent event) {
-        LOGGER.debug(
-            "Received connector incident event for process instance: {}",
-            event.getIntegrationContext() != null ? event.getIntegrationContext().getProcessInstanceId() : "unknown"
-        );
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                "Received connector incident event for process instance: {}",
+                event.getIntegrationContext() != null ? event.getIntegrationContext().getProcessInstanceId() : "unknown"
+            );
+        }
         incidentService.createAndSendIncidentEvent(
             event.getIntegrationContext(),
             event.getException(),

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.services.connectors.channel;
+
+import java.util.function.Consumer;
+import org.activiti.cloud.api.process.model.ConnectorIncidentEvent;
+import org.activiti.cloud.services.events.services.IncidentService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectorIncidentEventHandler implements Consumer<ConnectorIncidentEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorIncidentEventHandler.class);
+
+    private final IncidentService incidentService;
+
+    public ConnectorIncidentEventHandler(IncidentService incidentService) {
+        this.incidentService = incidentService;
+    }
+
+    @Override
+    public void accept(ConnectorIncidentEvent event) {
+        LOGGER.debug(
+            "Received connector incident event for process instance: {}",
+            event.getIntegrationContext() != null ? event.getIntegrationContext().getProcessInstanceId() : "unknown"
+        );
+        incidentService.createAndSendIncidentEvent(
+            event.getIntegrationContext(),
+            event.getException(),
+            event.getSeverity()
+        );
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/IntegrationRequestBuilder.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/IntegrationRequestBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.services.connectors.channel;
 
+import static org.activiti.services.connectors.channel.ProcessEngineIntegrationChannels.CONNECTOR_INCIDENT_CONSUMER;
 import static org.activiti.services.connectors.channel.ProcessEngineIntegrationChannels.INTEGRATION_ERRORS_CONSUMER;
 import static org.activiti.services.connectors.channel.ProcessEngineIntegrationChannels.INTEGRATION_RESULTS_CONSUMER;
 
@@ -42,6 +43,7 @@ public class IntegrationRequestBuilder implements Serializable {
 
         integrationRequest.setErrorDestination(bindingResolver.getBindingDestination(INTEGRATION_ERRORS_CONSUMER));
         integrationRequest.setResultDestination(bindingResolver.getBindingDestination(INTEGRATION_RESULTS_CONSUMER));
+        integrationRequest.setIncidentDestination(bindingResolver.getBindingDestination(CONNECTOR_INCIDENT_CONSUMER));
 
         runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(integrationRequest);
         return integrationRequest;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ProcessEngineIntegrationChannels.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ProcessEngineIntegrationChannels.java
@@ -24,6 +24,8 @@ public interface ProcessEngineIntegrationChannels {
 
     String INTEGRATION_ERRORS_CONSUMER = "integrationErrorsConsumer";
 
+    String CONNECTOR_INCIDENT_CONSUMER = "connectorIncidentConsumer";
+
     @InputBinding(INTEGRATION_RESULTS_CONSUMER)
     default SubscribableChannel integrationResultsConsumer() {
         return MessageChannels.publishSubscribe(INTEGRATION_RESULTS_CONSUMER).getObject();
@@ -32,5 +34,10 @@ public interface ProcessEngineIntegrationChannels {
     @InputBinding(INTEGRATION_ERRORS_CONSUMER)
     default SubscribableChannel integrationErrorsConsumer() {
         return MessageChannels.publishSubscribe(INTEGRATION_ERRORS_CONSUMER).getObject();
+    }
+
+    @InputBinding(CONNECTOR_INCIDENT_CONSUMER)
+    default SubscribableChannel connectorIncidentConsumer() {
+        return MessageChannels.publishSubscribe(CONNECTOR_INCIDENT_CONSUMER).getObject();
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.services.connectors.conf;
 
 import java.util.Set;
 import java.util.function.Consumer;
+import org.activiti.cloud.api.process.model.ConnectorIncidentEvent;
 import org.activiti.cloud.api.process.model.IntegrationError;
 import org.activiti.cloud.api.process.model.IntegrationResult;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration;
@@ -24,6 +25,7 @@ import org.activiti.cloud.common.messaging.functional.FunctionBinding;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
+import org.activiti.cloud.services.events.services.IncidentService;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
@@ -35,6 +37,7 @@ import org.activiti.runtime.api.connector.DefaultServiceTaskBehavior;
 import org.activiti.runtime.api.connector.IntegrationContextBuilder;
 import org.activiti.services.connectors.IntegrationRequestSender;
 import org.activiti.services.connectors.behavior.MQServiceTaskBehavior;
+import org.activiti.services.connectors.channel.ConnectorIncidentEventHandler;
 import org.activiti.services.connectors.channel.IntegrationRequestBuilder;
 import org.activiti.services.connectors.channel.IntegrationRequestReplayer;
 import org.activiti.services.connectors.channel.ProcessEngineIntegrationChannels;
@@ -129,6 +132,18 @@ public class CloudConnectorsAutoConfiguration {
         ServiceTaskIntegrationErrorEventHandler handler
     ) {
         return message -> handler.receive(message.getPayload());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConnectorIncidentEventHandler connectorIncidentEventHandler(IncidentService incidentService) {
+        return new ConnectorIncidentEventHandler(incidentService);
+    }
+
+    @FunctionBinding(input = ProcessEngineIntegrationChannels.CONNECTOR_INCIDENT_CONSUMER)
+    @Bean
+    public Consumer<ConnectorIncidentEvent> connectorIncidentEventConsumer(ConnectorIncidentEventHandler handler) {
+        return handler::accept;
     }
 
     @Bean

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/integration-result-stream.properties
@@ -7,3 +7,7 @@ spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:
 spring.cloud.stream.bindings.integrationErrorsConsumer.destination=integrationError
 spring.cloud.stream.bindings.integrationErrorsConsumer.contentType=application/json
 spring.cloud.stream.bindings.integrationErrorsConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}
+
+spring.cloud.stream.bindings.connectorIncidentConsumer.destination=connectorIncident
+spring.cloud.stream.bindings.connectorIncidentConsumer.contentType=application/json
+spring.cloud.stream.bindings.connectorIncidentConsumer.group=${ACT_RB_APP_NAME:${spring.application.name}}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandlerTest.java
@@ -16,7 +16,6 @@
 package org.activiti.services.connectors.channel;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.ConnectorIncidentEvent;
@@ -80,7 +79,6 @@ class ConnectorIncidentEventHandlerTest {
 
     @Test
     void should_logProcessInstanceId_when_integrationContextPresent() {
-        when(integrationContext.getProcessInstanceId()).thenReturn("process-123");
         Exception exception = new RuntimeException("test");
         ConnectorIncidentEvent event = new ConnectorIncidentEvent(
             integrationContext,

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandlerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/ConnectorIncidentEventHandlerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.services.connectors.channel;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.ConnectorIncidentEvent;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
+import org.activiti.cloud.services.events.services.IncidentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectorIncidentEventHandlerTest {
+
+    @Mock
+    private IncidentService incidentService;
+
+    @Mock
+    private IntegrationContext integrationContext;
+
+    @InjectMocks
+    private ConnectorIncidentEventHandler handler;
+
+    @Test
+    void should_delegateToIncidentService_when_eventReceived() {
+        Exception exception = new RuntimeException("Invalid email addresses");
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(
+            integrationContext,
+            exception,
+            IncidentSeverity.WARNING
+        );
+
+        handler.accept(event);
+
+        verify(incidentService).createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.WARNING);
+    }
+
+    @Test
+    void should_delegateWithErrorSeverity_when_eventHasErrorSeverity() {
+        Exception exception = new RuntimeException("Critical connector failure");
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(
+            integrationContext,
+            exception,
+            IncidentSeverity.ERROR
+        );
+
+        handler.accept(event);
+
+        verify(incidentService).createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void should_delegateWithNullSeverity_when_eventHasNoSeverity() {
+        Exception exception = new RuntimeException("Some error");
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(integrationContext, exception, null);
+
+        handler.accept(event);
+
+        verify(incidentService).createAndSendIncidentEvent(integrationContext, exception, null);
+    }
+
+    @Test
+    void should_logProcessInstanceId_when_integrationContextPresent() {
+        when(integrationContext.getProcessInstanceId()).thenReturn("process-123");
+        Exception exception = new RuntimeException("test");
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(
+            integrationContext,
+            exception,
+            IncidentSeverity.WARNING
+        );
+
+        handler.accept(event);
+
+        verify(incidentService).createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.WARNING);
+    }
+
+    @Test
+    void should_handleNullIntegrationContext() {
+        Exception exception = new RuntimeException("test");
+        ConnectorIncidentEvent event = new ConnectorIncidentEvent(null, exception, IncidentSeverity.WARNING);
+
+        handler.accept(event);
+
+        verify(incidentService)
+            .createAndSendIncidentEvent((IntegrationContext) null, exception, IncidentSeverity.WARNING);
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/IntegrationRequestBuilderTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/channel/IntegrationRequestBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.services.connectors.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.impl.IntegrationRequestImpl;
+import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration;
+import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationRequestBuilderTest {
+
+    @Mock
+    private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
+
+    @Mock
+    private FunctionBindingConfiguration.BindingResolver bindingResolver;
+
+    @Mock
+    private IntegrationContext integrationContext;
+
+    @InjectMocks
+    private IntegrationRequestBuilder builder;
+
+    @Test
+    void should_populateAllDestinations() {
+        when(bindingResolver.getBindingDestination("integrationErrorsConsumer")).thenReturn("integrationError_my-rb");
+        when(bindingResolver.getBindingDestination("integrationResultsConsumer")).thenReturn("integrationResult_my-rb");
+        when(bindingResolver.getBindingDestination("connectorIncidentConsumer")).thenReturn("connectorIncident_my-rb");
+
+        IntegrationRequestImpl request = builder.build(integrationContext);
+
+        assertThat(request.getErrorDestination()).isEqualTo("integrationError_my-rb");
+        assertThat(request.getResultDestination()).isEqualTo("integrationResult_my-rb");
+        assertThat(request.getIncidentDestination()).isEqualTo("connectorIncident_my-rb");
+    }
+
+    @Test
+    void should_appendRuntimeBundleInfo() {
+        IntegrationRequestImpl request = builder.build(integrationContext);
+
+        verify(runtimeBundleInfoAppender).appendRuntimeBundleInfoTo(request);
+    }
+
+    @Test
+    void should_setIntegrationContext() {
+        IntegrationRequestImpl request = builder.build(integrationContext);
+
+        assertThat(request.getIntegrationContext()).isSameAs(integrationContext);
+    }
+
+    @Test
+    void should_handleNullDestinations_whenBindingResolverReturnsNull() {
+        when(bindingResolver.getBindingDestination("integrationErrorsConsumer")).thenReturn(null);
+        when(bindingResolver.getBindingDestination("integrationResultsConsumer")).thenReturn(null);
+        when(bindingResolver.getBindingDestination("connectorIncidentConsumer")).thenReturn(null);
+
+        IntegrationRequestImpl request = builder.build(integrationContext);
+
+        assertThat(request.getErrorDestination()).isNull();
+        assertThat(request.getResultDestination()).isNull();
+        assertThat(request.getIncidentDestination()).isNull();
+    }
+}

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventCmd.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.events.services;
 
 import java.util.ArrayList;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.IncidentContextImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.events.converter.ExecutionContextInfoAppender;
@@ -29,13 +30,23 @@ abstract class CreateIncidentEventCmd implements Command<Message> {
 
     private final MessageBuilderChainFactory<ExecutionContext> messageBuilderIncidentsChainFactory;
     private final RuntimeBundleInfoAppender runtimeBundleInfoAppender;
+    private final IncidentSeverity severity;
 
     CreateIncidentEventCmd(
         MessageBuilderChainFactory<ExecutionContext> messageBuilderIncidentsChainFactory,
         RuntimeBundleInfoAppender runtimeBundleInfoAppender
     ) {
+        this(messageBuilderIncidentsChainFactory, runtimeBundleInfoAppender, IncidentSeverity.ERROR);
+    }
+
+    CreateIncidentEventCmd(
+        MessageBuilderChainFactory<ExecutionContext> messageBuilderIncidentsChainFactory,
+        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+        IncidentSeverity severity
+    ) {
         this.messageBuilderIncidentsChainFactory = messageBuilderIncidentsChainFactory;
         this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
+        this.severity = severity;
     }
 
     Message<ArrayList<Object>> createMessage(ExecutionContext rootExecutionContext, Exception exception) {
@@ -51,7 +62,7 @@ abstract class CreateIncidentEventCmd implements Command<Message> {
     ) {
         var incidentContext = getIncidentContext(rootExecutionContext);
 
-        var incident = new CloudIncidentCreatedEventImpl(exception, incidentContext);
+        var incident = new CloudIncidentCreatedEventImpl(exception, incidentContext, this.severity);
         getExecutionContextInfoAppender(rootExecutionContext).appendExecutionContextInfoTo(incident);
         this.runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(incident);
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromExecutionCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromExecutionCmd.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.events.services;
 
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderChainFactory;
 import org.activiti.engine.impl.context.ExecutionContext;
@@ -33,6 +34,18 @@ class CreateIncidentEventFromExecutionCmd extends CreateIncidentEventCmd {
         RuntimeBundleInfoAppender runtimeBundleInfoAppender
     ) {
         super(messageBuilderIncidentsChainFactory, runtimeBundleInfoAppender);
+        this.executionContext = executionContext;
+        this.exception = exception;
+    }
+
+    CreateIncidentEventFromExecutionCmd(
+        ExecutionContext executionContext,
+        Exception exception,
+        MessageBuilderChainFactory<ExecutionContext> messageBuilderIncidentsChainFactory,
+        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+        IncidentSeverity severity
+    ) {
+        super(messageBuilderIncidentsChainFactory, runtimeBundleInfoAppender, severity);
         this.executionContext = executionContext;
         this.exception = exception;
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmd.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmd.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.events.services;
 
 import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderChainFactory;
 import org.activiti.engine.RuntimeService;
@@ -38,6 +39,20 @@ class CreateIncidentEventFromIntegrationCmd extends CreateIncidentEventCmd {
         RuntimeBundleInfoAppender runtimeBundleInfoAppender
     ) {
         super(messageBuilderIncidentsChainFactory, runtimeBundleInfoAppender);
+        this.integrationContext = integrationContext;
+        this.exception = exception;
+        this.runtimeService = runtimeService;
+    }
+
+    CreateIncidentEventFromIntegrationCmd(
+        IntegrationContext integrationContext,
+        Exception exception,
+        RuntimeService runtimeService,
+        MessageBuilderChainFactory<ExecutionContext> messageBuilderIncidentsChainFactory,
+        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+        IncidentSeverity severity
+    ) {
+        super(messageBuilderIncidentsChainFactory, runtimeBundleInfoAppender, severity);
         this.integrationContext = integrationContext;
         this.exception = exception;
         this.runtimeService = runtimeService;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/IncidentService.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/services/IncidentService.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.events.services;
 
 import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
 import org.activiti.cloud.services.events.message.MessageBuilderChainFactory;
@@ -67,6 +68,43 @@ public class IncidentService {
                 exception,
                 this.messageBuilderIncidentsChainFactory,
                 this.runtimeBundleInfoAppender
+            )
+        );
+
+        sendIncident(incidentMessage);
+    }
+
+    public void createAndSendIncidentEvent(
+        IntegrationContext integrationContext,
+        Exception exception,
+        IncidentSeverity severity
+    ) {
+        var incidentMessage = createIncidentMessage(
+            new CreateIncidentEventFromIntegrationCmd(
+                integrationContext,
+                exception,
+                this.runtimeService,
+                this.messageBuilderIncidentsChainFactory,
+                this.runtimeBundleInfoAppender,
+                severity
+            )
+        );
+
+        sendIncident(incidentMessage);
+    }
+
+    public void createAndSendIncidentEvent(
+        ExecutionContext rootExecutionContext,
+        Exception exception,
+        IncidentSeverity severity
+    ) {
+        var incidentMessage = createIncidentMessage(
+            new CreateIncidentEventFromExecutionCmd(
+                rootExecutionContext,
+                exception,
+                this.messageBuilderIncidentsChainFactory,
+                this.runtimeBundleInfoAppender,
+                severity
             )
         );
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListenerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListenerTest.java
@@ -34,6 +34,7 @@ import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
 import org.activiti.cloud.api.process.model.IncidentContext;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -382,6 +383,7 @@ class MessageProducerCommandContextCloseListenerTest {
         assertThat(incident.getEntity().getProcessInstanceId()).isEqualTo(TestUtils.MOCK_PROCESS_INSTANCE_ID);
         assertThat(incident.getEntity().getProcessDefinitionId()).isEqualTo(TestUtils.MOCK_PROCESS_DEFINITION_ID);
         assertThat(incident.getEntity().getExecutionId()).isEqualTo(TestUtils.MOCK_PROCESS_INSTANCE_ID);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
     }
 
     private MessageProducerCommandContextCloseListener getMessageProducerCloseListenerWithDisabledChunker() {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromExecutionCmdTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromExecutionCmdTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.events.TestUtils;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
@@ -107,5 +108,34 @@ class CreateIncidentEventFromExecutionCmdTest {
                 entry("routingKey", "engineEvents.springAppName.appName"),
                 entry("messagePayloadType", "java.util.ArrayList")
             );
+    }
+
+    @Test
+    void shouldDefaultSeverityToError() {
+        Message<ArrayList<Object>> message = this.createIncidentEventFromExecutionCmd.execute(null);
+
+        var incident = (CloudIncidentCreatedEventImpl) ((List) message.getPayload()).get(0);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void shouldCreateIncidentEventWithWarningSeverity() {
+        var cmd = new CreateIncidentEventFromExecutionCmd(
+            this.executionContext,
+            testException,
+            this.messageBuilderChainIncidentFactory,
+            this.runtimeBundleInfoAppender,
+            IncidentSeverity.WARNING
+        );
+
+        Message<ArrayList<Object>> message = cmd.execute(null);
+
+        var payload = (List) message.getPayload();
+        assertThat(payload).hasSize(1);
+
+        var incident = (CloudIncidentCreatedEventImpl) payload.get(0);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
+        assertThat(incident.getErrorClassName()).isEqualTo("java.lang.IllegalArgumentException");
+        assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -92,7 +91,6 @@ class CreateIncidentEventFromIntegrationCmdTest {
     @BeforeEach
     void setUp() {
         var integrationContext = mock(IntegrationContext.class);
-        lenient().when(integrationContext.getExecutionId()).thenReturn(EXECUTION_ID);
 
         this.createIncidentEventFromIntegrationCmd =
             spy(
@@ -108,6 +106,20 @@ class CreateIncidentEventFromIntegrationCmdTest {
 
     @Test
     void shouldExecuteCreateIncidentEventFromIntegration() {
+        var integrationContext = mock(IntegrationContext.class);
+        when(integrationContext.getExecutionId()).thenReturn(EXECUTION_ID);
+
+        this.createIncidentEventFromIntegrationCmd =
+            spy(
+                new CreateIncidentEventFromIntegrationCmd(
+                    integrationContext,
+                    this.testException,
+                    this.runtimeService,
+                    this.messageBuilderChainIncidentFactory,
+                    this.runtimeBundleInfoAppender
+                )
+            );
+
         var executionEntity = mockExecutionEntity();
         mockExecutionQuery(executionEntity);
         doReturn(null)
@@ -173,7 +185,6 @@ class CreateIncidentEventFromIntegrationCmdTest {
     @Test
     void shouldCreateIncidentEventWithWarningSeverity() {
         var integrationContext = mock(IntegrationContext.class);
-        lenient().when(integrationContext.getExecutionId()).thenReturn(EXECUTION_ID);
 
         var cmd = spy(
             new CreateIncidentEventFromIntegrationCmd(
@@ -208,9 +219,9 @@ class CreateIncidentEventFromIntegrationCmdTest {
 
     private ExecutionEntityImpl mockExecutionEntity() {
         var executionEntity = mock(ExecutionEntityImpl.class);
-        lenient().when(executionEntity.getId()).thenReturn(EXECUTION_ID);
+        when(executionEntity.getId()).thenReturn(EXECUTION_ID);
         when(executionEntity.getProcessInstanceId()).thenReturn(TestUtils.MOCK_PROCESS_INSTANCE_ID);
-        lenient().when(executionEntity.getProcessDefinitionId()).thenReturn(TestUtils.MOCK_PROCESS_DEFINITION_ID);
+        when(executionEntity.getProcessDefinitionId()).thenReturn(TestUtils.MOCK_PROCESS_DEFINITION_ID);
         return executionEntity;
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
@@ -219,7 +219,6 @@ class CreateIncidentEventFromIntegrationCmdTest {
 
     private ExecutionEntityImpl mockExecutionEntity() {
         var executionEntity = mock(ExecutionEntityImpl.class);
-        when(executionEntity.getId()).thenReturn(EXECUTION_ID);
         when(executionEntity.getProcessInstanceId()).thenReturn(TestUtils.MOCK_PROCESS_INSTANCE_ID);
         when(executionEntity.getProcessDefinitionId()).thenReturn(TestUtils.MOCK_PROCESS_DEFINITION_ID);
         return executionEntity;

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/CreateIncidentEventFromIntegrationCmdTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.events.TestUtils;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
@@ -156,6 +157,46 @@ class CreateIncidentEventFromIntegrationCmdTest {
                 entry("routingKey", "engineEvents.springAppName.appName"),
                 entry("messagePayloadType", "java.util.ArrayList")
             );
+    }
+
+    @Test
+    void shouldDefaultSeverityToError() {
+        var executionContext = TestUtils.mockExecutionContext();
+
+        Message<ArrayList<Object>> message =
+            this.createIncidentEventFromIntegrationCmd.createMessage(executionContext, this.testException);
+
+        var incident = (CloudIncidentCreatedEventImpl) ((List) message.getPayload()).get(0);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.ERROR);
+    }
+
+    @Test
+    void shouldCreateIncidentEventWithWarningSeverity() {
+        var integrationContext = mock(IntegrationContext.class);
+        lenient().when(integrationContext.getExecutionId()).thenReturn(EXECUTION_ID);
+
+        var cmd = spy(
+            new CreateIncidentEventFromIntegrationCmd(
+                integrationContext,
+                this.testException,
+                this.runtimeService,
+                this.messageBuilderChainIncidentFactory,
+                this.runtimeBundleInfoAppender,
+                IncidentSeverity.WARNING
+            )
+        );
+
+        var executionContext = TestUtils.mockExecutionContext();
+
+        Message<ArrayList<Object>> message = cmd.createMessage(executionContext, this.testException);
+
+        var payload = (List) message.getPayload();
+        assertThat(payload).hasSize(1);
+
+        var incident = (CloudIncidentCreatedEventImpl) payload.get(0);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
+        assertThat(incident.getErrorClassName()).isEqualTo("java.lang.IllegalArgumentException");
+        assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
     }
 
     private void mockExecutionQuery(ExecutionEntityImpl executionEntity) {

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/IncidentServiceTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/IncidentServiceTest.java
@@ -218,7 +218,7 @@ class IncidentServiceTest {
         var incidentCreatedEvent = new CloudIncidentCreatedEventImpl(
             new IllegalArgumentException("Test exception"),
             incidentContext,
-            IncidentSeverity.FATAL
+            IncidentSeverity.WARNING
         );
 
         var message = MessageBuilder.withPayload(List.of(incidentCreatedEvent)).build();
@@ -226,7 +226,7 @@ class IncidentServiceTest {
             .thenReturn(message);
         var exception = new IllegalArgumentException("Test exception");
 
-        this.incidentService.createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.FATAL);
+        this.incidentService.createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.WARNING);
 
         verify(this.producer.auditProducerIncidents()).send(this.messageArgumentCaptor.capture());
 
@@ -237,7 +237,7 @@ class IncidentServiceTest {
         assertThat(payload.get(0)).isInstanceOf(CloudIncidentCreatedEventImpl.class);
 
         var incident = (CloudIncidentCreatedEventImpl) payload.get(0);
-        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.FATAL);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
         assertThat(incident.getErrorClassName()).isEqualTo("java.lang.IllegalArgumentException");
         assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
     }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/IncidentServiceTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/services/IncidentServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IncidentContext;
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.api.process.model.impl.events.CloudIncidentCreatedEventImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.TestUtils;
@@ -176,5 +177,68 @@ class IncidentServiceTest {
         assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
         assertThat(incident.getStackTraceElements()).isNotNull();
         assertThat(incident.getStackTraceElements()).isNotEmpty();
+    }
+
+    @Test
+    void shouldCreateAndSendExecutionContextIncidentEventWithSeverity() {
+        var executionContext = mock(ExecutionContext.class);
+        var incidentContext = mock(IncidentContext.class);
+        when(incidentContext.getExecutionId()).thenReturn(TestUtils.MOCK_PROCESS_INSTANCE_ID);
+        var incidentCreatedEvent = new CloudIncidentCreatedEventImpl(
+            new IllegalArgumentException("Test exception"),
+            incidentContext,
+            IncidentSeverity.WARNING
+        );
+
+        var message = MessageBuilder.withPayload(List.of(incidentCreatedEvent)).build();
+        when(this.managementService.executeCommand(any(CreateIncidentEventFromExecutionCmd.class))).thenReturn(message);
+        var exception = new IllegalArgumentException("Test exception");
+
+        this.incidentService.createAndSendIncidentEvent(executionContext, exception, IncidentSeverity.WARNING);
+
+        verify(this.producer.auditProducerIncidents()).send(this.messageArgumentCaptor.capture());
+
+        var capturedMessage = this.messageArgumentCaptor.getValue();
+
+        var payload = (List) capturedMessage.getPayload();
+        assertThat(payload).hasSize(1);
+        assertThat(payload.getFirst()).isInstanceOf(CloudIncidentCreatedEventImpl.class);
+
+        var incident = (CloudIncidentCreatedEventImpl) payload.getFirst();
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.WARNING);
+        assertThat(incident.getErrorClassName()).isEqualTo("java.lang.IllegalArgumentException");
+        assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
+    }
+
+    @Test
+    void shouldCreateAndSendIntegrationContextIncidentEventWithSeverity() {
+        var integrationContext = mock(IntegrationContext.class);
+        var incidentContext = mock(IncidentContext.class);
+        when(incidentContext.getExecutionId()).thenReturn(TestUtils.MOCK_PROCESS_INSTANCE_ID);
+        var incidentCreatedEvent = new CloudIncidentCreatedEventImpl(
+            new IllegalArgumentException("Test exception"),
+            incidentContext,
+            IncidentSeverity.FATAL
+        );
+
+        var message = MessageBuilder.withPayload(List.of(incidentCreatedEvent)).build();
+        when(this.managementService.executeCommand(any(CreateIncidentEventFromIntegrationCmd.class)))
+            .thenReturn(message);
+        var exception = new IllegalArgumentException("Test exception");
+
+        this.incidentService.createAndSendIncidentEvent(integrationContext, exception, IncidentSeverity.FATAL);
+
+        verify(this.producer.auditProducerIncidents()).send(this.messageArgumentCaptor.capture());
+
+        var capturedMessage = this.messageArgumentCaptor.getValue();
+
+        var payload = (List) capturedMessage.getPayload();
+        assertThat(payload).hasSize(1);
+        assertThat(payload.get(0)).isInstanceOf(CloudIncidentCreatedEventImpl.class);
+
+        var incident = (CloudIncidentCreatedEventImpl) payload.get(0);
+        assertThat(incident.getSeverity()).isEqualTo(IncidentSeverity.FATAL);
+        assertThat(incident.getErrorClassName()).isEqualTo("java.lang.IllegalArgumentException");
+        assertThat(incident.getErrorMessage()).isEqualTo("Test exception");
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -20,6 +20,7 @@ activiti.cloud.messaging.function-router.group=${spring.application.name}
 activiti.cloud.messaging.function-router.routes.commandConsumer.enabled=true
 activiti.cloud.messaging.function-router.routes.integrationErrorsConsumer.enabled=true
 activiti.cloud.messaging.function-router.routes.integrationResultsConsumer.enabled=true
+activiti.cloud.messaging.function-router.routes.connectorIncidentConsumer.enabled=true
 activiti.cloud.messaging.function-router.routes.myCmdResults.enabled=true
 activiti.cloud.messaging.function-router.routes.signalConsumer.enabled=true
 activiti.cloud.messaging.function-router.routes.messageConnectorInput.enabled=true

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerWithChunkSizeIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerWithChunkSizeIT.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
+import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener;
 import org.activiti.cloud.services.events.services.IncidentService;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
@@ -104,7 +105,12 @@ class MessageProducerCommandContextCloseListenerWithChunkSizeIT {
             () -> this.runtimeService.createProcessInstanceBuilder().processDefinitionKey(processDefinitionKey).start()
         );
 
-        verify(this.incidentService).createAndSendIncidentEvent(this.executionContextCaptor.capture(), any());
+        verify(this.incidentService)
+            .createAndSendIncidentEvent(
+                this.executionContextCaptor.capture(),
+                any(Exception.class),
+                any(IncidentSeverity.class)
+            );
 
         var executionContextCaptorValue = this.executionContextCaptor.getValue();
         assertThat(executionContextCaptorValue.getProcessInstance().getProcessInstanceId()).isNotEmpty();

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerWithChunkSizeIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageProducerCommandContextCloseListenerWithChunkSizeIT.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-import org.activiti.cloud.api.process.model.IncidentSeverity;
 import org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener;
 import org.activiti.cloud.services.events.services.IncidentService;
 import org.activiti.cloud.services.test.containers.KeycloakContainerApplicationInitializer;
@@ -106,11 +105,7 @@ class MessageProducerCommandContextCloseListenerWithChunkSizeIT {
         );
 
         verify(this.incidentService)
-            .createAndSendIncidentEvent(
-                this.executionContextCaptor.capture(),
-                any(Exception.class),
-                any(IncidentSeverity.class)
-            );
+            .createAndSendIncidentEvent(this.executionContextCaptor.capture(), any(Exception.class));
 
         var executionContextCaptorValue = this.executionContextCaptor.getValue();
         assertThat(executionContextCaptorValue.getProcessInstance().getProcessInstanceId()).isNotEmpty();


### PR DESCRIPTION
### Summary
Add a severity attribute (**ERROR**, **WARNING**) to **INCIDENT_CREATED** audit events, propagated end-to-end from the runtime bundle through messaging to the audit database and REST API. This lets consumers differentiate hard failures from non-critical warnings (e.g., invalid email). Defaults to ERROR for full backward compatibility.