### PR TITLE
AAE-45142 Handle fallback for connectors not setting content type

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -431,6 +431,8 @@ public class ActivitiCloudMessagingProperties {
 
         private final Map<String, Map<String, List<String>>> registrations = new LinkedCaseInsensitiveMap<>();
 
+        private final Map<String, String> registrationBindings = new LinkedCaseInsensitiveMap<>();
+
         @NotEmpty
         private String group = "function-router";
 
@@ -559,11 +561,12 @@ public class ActivitiCloudMessagingProperties {
                     Optional
                         .ofNullable(destinations.get(routingContext))
                         .map(it -> it.get(bindingName))
-                        .ifPresent(destination ->
+                        .ifPresent(destination -> {
                             registrations(routingContext)
                                 .computeIfAbsent(destination, key -> new ArrayList<>())
-                                .add(functionBeanName)
-                        )
+                                .add(functionBeanName);
+                            registrationBindings.put(functionBeanName, bindingName);
+                        })
                 );
         }
 
@@ -579,13 +582,18 @@ public class ActivitiCloudMessagingProperties {
                                 .of(destinations.split(","))
                                 .filter(connectorType::equals)
                                 .findFirst()
-                                .ifPresent(destination ->
+                                .ifPresent(destination -> {
                                     registrations(routingContext)
                                         .computeIfAbsent(destination, key -> new ArrayList<>())
-                                        .add(functionBeanName)
-                                )
+                                        .add(functionBeanName);
+                                    registrationBindings.put(functionBeanName, bindingName);
+                                })
                         )
                 );
+        }
+
+        public Optional<String> bindingNameFor(String functionBeanName) {
+            return Optional.ofNullable(registrationBindings.get(functionBeanName));
         }
 
         @Override

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
@@ -113,13 +113,18 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
             .get();
     }
 
+    @Bean
+    public MessageContentTypeNormalizer messageContentTypeNormalizer() {
+        return new MessageContentTypeNormalizer();
+    }
+
     @Bean(name = "functionBindingBeanPostProcessor")
     public BeanPostProcessor functionBindingBeanPostProcessor(
         FunctionAnnotationService functionAnnotationService,
         IntegrationFlowContext integrationFlowContext,
         Function<String, String> resolveExpression,
         ActivitiCloudMessagingProperties messagingProperties,
-        GenericApplicationContext applicationContext
+        MessageContentTypeNormalizer messageContentTypeNormalizer
     ) {
         return new BeanPostProcessor() {
             @Override
@@ -171,8 +176,9 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                 GenericHandler<Message> handler = (message, headers) -> {
                                     FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                                     function.setSkipOutputConversion(false);
-                                    Message<?> messageToProcess = message;
-                                    Object result = function.apply(messageToProcess);
+                                    Object result = function.apply(
+                                        messageContentTypeNormalizer.normalizeToJsonFallback(message)
+                                    );
                                     if (result instanceof Message<?> msg) {
                                         return msg;
                                     }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
@@ -39,7 +39,6 @@ import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.function.FunctionConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.dsl.IntegrationFlow;
@@ -124,7 +123,8 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
         IntegrationFlowContext integrationFlowContext,
         Function<String, String> resolveExpression,
         ActivitiCloudMessagingProperties messagingProperties,
-        MessageContentTypeNormalizer messageContentTypeNormalizer
+        MessageContentTypeNormalizer messageContentTypeNormalizer,
+        BindingServiceProperties bindingServiceProperties
     ) {
         return new BeanPostProcessor() {
             @Override
@@ -173,11 +173,15 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                     .channel(functionBinding.output());
                                 integrationFlowContext.registration(supplierFlowBuilder.get()).register();
                             } else {
+                                String expectedContentType = Optional
+                                    .ofNullable(bindingServiceProperties.getBindings().get(functionBinding.input()))
+                                    .map(BindingProperties::getContentType)
+                                    .orElse(null);
                                 GenericHandler<Message> handler = (message, headers) -> {
                                     FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                                     function.setSkipOutputConversion(false);
                                     Object result = function.apply(
-                                        messageContentTypeNormalizer.normalizeToJsonFallback(message)
+                                        messageContentTypeNormalizer.normalizeToExpected(message, expectedContentType)
                                     );
                                     if (result instanceof Message<?> msg) {
                                         return msg;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionBindingConfiguration.java
@@ -180,13 +180,9 @@ public class FunctionBindingConfiguration extends AbstractFunctionalBindingConfi
                                 GenericHandler<Message> handler = (message, headers) -> {
                                     FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                                     function.setSkipOutputConversion(false);
-                                    Object result = function.apply(
+                                    return function.apply(
                                         messageContentTypeNormalizer.normalizeToExpected(message, expectedContentType)
                                     );
-                                    if (result instanceof Message<?> msg) {
-                                        return msg;
-                                    }
-                                    return result;
                                 };
 
                                 IntegrationFlowBuilder functionFlowBuilder = IntegrationFlow

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -166,7 +166,8 @@ public class FunctionRouterConfiguration {
         RoutingFunction routingFunction,
         ActivitiCloudMessagingProperties messagingProperties,
         FunctionCatalog functionCatalog,
-        Function<Message<?>, ExecutorService> functionExecutorSelector
+        Function<Message<?>, ExecutorService> functionExecutorSelector,
+        MessageContentTypeNormalizer messageContentTypeNormalizer
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
 
@@ -197,7 +198,7 @@ public class FunctionRouterConfiguration {
                                 functionRegistration
                             ) ->
                             MessageBuilder
-                                .fromMessage(functionMessage)
+                                .fromMessage(messageContentTypeNormalizer.normalizeToJsonFallback(functionMessage))
                                 .setHeader(FunctionProperties.FUNCTION_DEFINITION, functionRegistration)
                                 .build();
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.cloud.function.context.MessageRoutingCallback;
 import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry;
 import org.springframework.cloud.function.context.config.RoutingFunction;
 import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
+import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -167,7 +168,8 @@ public class FunctionRouterConfiguration {
         ActivitiCloudMessagingProperties messagingProperties,
         FunctionCatalog functionCatalog,
         Function<Message<?>, ExecutorService> functionExecutorSelector,
-        MessageContentTypeNormalizer messageContentTypeNormalizer
+        MessageContentTypeNormalizer messageContentTypeNormalizer,
+        BindingServiceProperties bindingServiceProperties
     ) {
         final var functionRouter = messagingProperties.getFunctionRouter();
 
@@ -194,13 +196,24 @@ public class FunctionRouterConfiguration {
                         Function<Message<?>, String> resolveFunctionDefinition = functionMessage ->
                             functionMessage.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class);
                         BiFunction<Message<?>, String, Message<?>> toFunctionRequest = (
-                                functionMessage,
-                                functionRegistration
-                            ) ->
-                            MessageBuilder
-                                .fromMessage(messageContentTypeNormalizer.normalizeToJsonFallback(functionMessage))
+                            functionMessage,
+                            functionRegistration
+                        ) -> {
+                            String expectedContentType = functionRouter
+                                .bindingNameFor(functionRegistration)
+                                .map(bindingName -> bindingServiceProperties.getBindings().get(bindingName))
+                                .map(BindingProperties::getContentType)
+                                .orElse(null);
+                            return MessageBuilder
+                                .fromMessage(
+                                    messageContentTypeNormalizer.normalizeToExpected(
+                                        functionMessage,
+                                        expectedContentType
+                                    )
+                                )
                                 .setHeader(FunctionProperties.FUNCTION_DEFINITION, functionRegistration)
                                 .build();
+                        };
 
                         var functions = registrations
                             .stream()

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+public class MessageContentTypeNormalizer {
+
+    public Message<?> normalizeToJsonFallback(Message<?> message) {
+        if (!requiresJsonFallback(message.getHeaders().get(MessageHeaders.CONTENT_TYPE))) {
+            return message;
+        }
+        return MessageBuilder
+            .fromMessage(message)
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    private boolean requiresJsonFallback(Object currentContentType) {
+        if (currentContentType == null) {
+            return true;
+        }
+        return MimeTypeUtils.APPLICATION_OCTET_STREAM.equalsTypeAndSubtype(
+            MimeType.valueOf(currentContentType.toString())
+        );
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
@@ -23,22 +23,15 @@ import org.springframework.util.MimeTypeUtils;
 
 public class MessageContentTypeNormalizer {
 
-    public Message<?> normalizeToJsonFallback(Message<?> message) {
-        if (!requiresJsonFallback(message.getHeaders().get(MessageHeaders.CONTENT_TYPE))) {
+    public Message<?> normalizeToExpected(Message<?> message, String expectedContentType) {
+        String effectiveExpected = (expectedContentType == null || expectedContentType.isBlank())
+            ? MimeTypeUtils.APPLICATION_JSON_VALUE
+            : expectedContentType;
+        MimeType expected = MimeType.valueOf(effectiveExpected);
+        Object current = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
+        if (current != null && expected.isCompatibleWith(MimeType.valueOf(current.toString()))) {
             return message;
         }
-        return MessageBuilder
-            .fromMessage(message)
-            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)
-            .build();
-    }
-
-    private boolean requiresJsonFallback(Object currentContentType) {
-        if (currentContentType == null) {
-            return true;
-        }
-        return MimeTypeUtils.APPLICATION_OCTET_STREAM.equalsTypeAndSubtype(
-            MimeType.valueOf(currentContentType.toString())
-        );
+        return MessageBuilder.fromMessage(message).setHeader(MessageHeaders.CONTENT_TYPE, effectiveExpected).build();
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizer.java
@@ -23,7 +23,7 @@ import org.springframework.util.MimeTypeUtils;
 
 public class MessageContentTypeNormalizer {
 
-    public Message<?> normalizeToExpected(Message<?> message, String expectedContentType) {
+    public <T> Message<T> normalizeToExpected(Message<T> message, String expectedContentType) {
         String effectiveExpected = (expectedContentType == null || expectedContentType.isBlank())
             ? MimeTypeUtils.APPLICATION_JSON_VALUE
             : expectedContentType;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizerTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizerTest.java
@@ -29,51 +29,85 @@ class MessageContentTypeNormalizerTest {
     private final MessageContentTypeNormalizer normalizer = new MessageContentTypeNormalizer();
 
     @Test
-    void shouldSetJsonWhenContentTypeHeaderIsMissing() {
+    void shouldSetExpectedWhenContentTypeHeaderIsMissing() {
         Message<byte[]> message = new GenericMessage<>("payload".getBytes());
 
-        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+        Message<?> normalized = normalizer.normalizeToExpected(message, MimeTypeUtils.APPLICATION_JSON_VALUE);
 
         assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
             .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
     }
 
     @Test
-    void shouldOverrideOctetStreamWithJson() {
+    void shouldOverrideOctetStreamWithExpected() {
         Message<byte[]> message = MessageBuilder
             .withPayload("payload".getBytes())
             .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)
             .build();
 
-        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+        Message<?> normalized = normalizer.normalizeToExpected(message, MimeTypeUtils.APPLICATION_JSON_VALUE);
 
         assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
             .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
     }
 
     @Test
-    void shouldReturnSameInstanceWhenContentTypeIsJson() {
-        Message<byte[]> message = MessageBuilder
-            .withPayload("payload".getBytes())
-            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)
-            .build();
-
-        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
-
-        assertThat(normalized).isSameAs(message);
-    }
-
-    @Test
-    void shouldPreserveNonJsonContentType() {
+    void shouldOverrideMismatchedContentTypeWithExpected() {
         Message<byte[]> message = MessageBuilder
             .withPayload("payload".getBytes())
             .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
             .build();
 
-        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+        Message<?> normalized = normalizer.normalizeToExpected(message, MimeTypeUtils.APPLICATION_JSON_VALUE);
+
+        assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+            .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenContentTypeMatchesExpected() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToExpected(message, MimeTypeUtils.APPLICATION_JSON_VALUE);
 
         assertThat(normalized).isSameAs(message);
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenContentTypeIsCompatibleWithExpected() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, "application/json;charset=UTF-8")
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToExpected(message, MimeTypeUtils.APPLICATION_JSON_VALUE);
+
+        assertThat(normalized).isSameAs(message);
+    }
+
+    @Test
+    void shouldDefaultToJsonWhenExpectedIsNull() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToExpected(message, null);
+
         assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
-            .hasToString(MimeTypeUtils.TEXT_PLAIN_VALUE);
+            .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    void shouldDefaultToJsonWhenExpectedIsBlank() {
+        Message<byte[]> message = new GenericMessage<>("payload".getBytes());
+
+        Message<?> normalized = normalizer.normalizeToExpected(message, "   ");
+
+        assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+            .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizerTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/MessageContentTypeNormalizerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeTypeUtils;
+
+class MessageContentTypeNormalizerTest {
+
+    private final MessageContentTypeNormalizer normalizer = new MessageContentTypeNormalizer();
+
+    @Test
+    void shouldSetJsonWhenContentTypeHeaderIsMissing() {
+        Message<byte[]> message = new GenericMessage<>("payload".getBytes());
+
+        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+
+        assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+            .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    void shouldOverrideOctetStreamWithJson() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+
+        assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+            .hasToString(MimeTypeUtils.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenContentTypeIsJson() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON_VALUE)
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+
+        assertThat(normalized).isSameAs(message);
+    }
+
+    @Test
+    void shouldPreserveNonJsonContentType() {
+        Message<byte[]> message = MessageBuilder
+            .withPayload("payload".getBytes())
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN_VALUE)
+            .build();
+
+        Message<?> normalized = normalizer.normalizeToJsonFallback(message);
+
+        assertThat(normalized).isSameAs(message);
+        assertThat(normalized.getHeaders().get(MessageHeaders.CONTENT_TYPE))
+            .hasToString(MimeTypeUtils.TEXT_PLAIN_VALUE);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -26,6 +26,7 @@ import static org.activiti.cloud.common.messaging.config.test.TestBindingsChanne
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.ENGINE_EVENTS_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_REQUESTS;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_RESULT_TYPED_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.QUERY_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.REST_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.SCRIPT_RUNTIME_CONSUMER;
@@ -81,7 +82,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeTypeUtils;
+import tools.jackson.databind.ObjectMapper;
 
 @SpringBootTest(
     properties = {
@@ -105,6 +109,9 @@ import org.springframework.messaging.support.MessageBuilder;
         "spring.cloud.stream.bindings.scriptRuntimeConsumer.group=${spring.application.name}",
         "spring.cloud.stream.bindings.restConsumer.destination=rest.GET,rest.POST",
         "spring.cloud.stream.bindings.restConsumer.group=${spring.application.name}",
+        "spring.cloud.stream.bindings.integrationResultTypedConsumer.destination=integration-result-typed",
+        "spring.cloud.stream.bindings.integrationResultTypedConsumer.group=${spring.application.name}",
+        "spring.cloud.stream.bindings.integrationResultTypedConsumer.contentType=application/json",
         "activiti.cloud.messaging.function-router.enabled=true",
         "activiti.cloud.messaging.function-router.max-retries=4",
         "activiti.cloud.messaging.function-router.retry-interval=100ms",
@@ -117,6 +124,7 @@ import org.springframework.messaging.support.MessageBuilder;
         "activiti.cloud.messaging.function-router.routes.scriptRuntimeConsumer.enabled=true",
         "activiti.cloud.messaging.function-router.routes.engineEventsConsumer.enabled=true",
         "activiti.cloud.messaging.function-router.routes.restConsumer.enabled=true",
+        "activiti.cloud.messaging.function-router.routes.integrationResultTypedConsumer.enabled=true",
         "activiti.cloud.messaging.function-router.routes.auditProducer.override-required-producer-groups=consumer",
         "activiti.cloud.messaging.function-router.routes.auditProducerIncidents.override-required-producer-groups=consumer",
         "activiti.cloud.messaging.function-router.anonymous.consumer.concurrency=2",
@@ -143,6 +151,7 @@ public class FunctionRouterBindingConfigurationIT {
     private static final AtomicReference<String> connectorPayload = new AtomicReference<>();
     private static final AtomicReference<String> getPayload = new AtomicReference<>();
     private static final AtomicReference<String> postPayload = new AtomicReference<>();
+    private static final AtomicReference<TypedPayload> receivedTypedPayload = new AtomicReference<>();
 
     @Autowired
     private TestBindingsChannels channels;
@@ -258,6 +267,41 @@ public class FunctionRouterBindingConfigurationIT {
                 postPayload.set(message);
             };
         }
+
+        @Bean
+        @FunctionBinding(input = INTEGRATION_RESULT_TYPED_CONSUMER)
+        public Consumer<Message<TypedPayload>> integrationResultTypedConsumerHandler() {
+            return message -> receivedTypedPayload.set(message.getPayload());
+        }
+    }
+
+    public static class TypedPayload {
+
+        private String name;
+        private int value;
+
+        public TypedPayload() {}
+
+        public TypedPayload(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
     }
 
     @BeforeEach
@@ -267,6 +311,7 @@ public class FunctionRouterBindingConfigurationIT {
         connectorPayload.set(null);
         getPayload.set(null);
         postPayload.set(null);
+        receivedTypedPayload.set(null);
         auditRetries.set(0);
         output.clear();
     }
@@ -317,7 +362,8 @@ public class FunctionRouterBindingConfigurationIT {
                         "integration-requests",
                         "script.EXECUTE",
                         "rest.GET",
-                        "rest.POST"
+                        "rest.POST",
+                        "integration-result-typed"
                     )
             );
 
@@ -461,6 +507,34 @@ public class FunctionRouterBindingConfigurationIT {
             .matches(bindings -> bindings == null || bindings.isEmpty());
         assertThat(streamFunctionProperties.getOutputBindings(FUNCTION_AUDIT_SUPPLIER_INCIDENTS_NAME))
             .matches(bindings -> bindings.size() == 1 && bindings.contains(AUDIT_PRODUCER_INCIDENTS));
+    }
+
+    @Test
+    void serializedPayloadWithOctetStreamContentTypeShouldBeDeserialized() throws Exception {
+        // given
+        TypedPayload expected = new TypedPayload("foo", 42);
+        byte[] jsonBytes = new ObjectMapper().writeValueAsBytes(expected);
+
+        Message<byte[]> message = MessageBuilder
+            .withPayload(jsonBytes)
+            .setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)
+            .setHeader(FUNCTION_DESTINATION, "integration-result-typed")
+            .build();
+
+        // when
+        input.send(message, "integration-result-typed");
+
+        // then
+        await()
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(() -> {
+                assertThat(receivedTypedPayload.get())
+                    .isNotNull()
+                    .satisfies(p -> {
+                        assertThat(p.getName()).isEqualTo("foo");
+                        assertThat(p.getValue()).isEqualTo(42);
+                    });
+            });
     }
 
     @Test
@@ -647,7 +721,8 @@ public class FunctionRouterBindingConfigurationIT {
                 "integrationRequests",
                 "scriptRuntimeConsumer",
                 "engineEventsConsumer",
-                "restConsumer"
+                "restConsumer",
+                "integrationResultTypedConsumer"
             );
     }
 
@@ -667,7 +742,8 @@ public class FunctionRouterBindingConfigurationIT {
                 ),
                 Map.entry("script.EXECUTE", List.of("scriptRuntimeExecutor_registration")),
                 Map.entry("rest.POST", List.of("restConsumerPostHandler_registration")),
-                Map.entry("rest.GET", List.of("restConsumerGetHandler_registration"))
+                Map.entry("rest.GET", List.of("restConsumerGetHandler_registration")),
+                Map.entry("integration-result-typed", List.of("integrationResultTypedConsumerHandler_registration"))
             );
     }
 
@@ -683,7 +759,8 @@ public class FunctionRouterBindingConfigurationIT {
                 ),
                 Map.entry("script.EXECUTE", List.of("scriptRuntimeExecutor_registration")),
                 Map.entry("rest.GET", List.of("restConsumerGetHandler_registration")),
-                Map.entry("rest.POST", List.of("restConsumerPostHandler_registration"))
+                Map.entry("rest.POST", List.of("restConsumerPostHandler_registration")),
+                Map.entry("integration-result-typed", List.of("integrationResultTypedConsumerHandler_registration"))
             );
     }
 
@@ -693,7 +770,13 @@ public class FunctionRouterBindingConfigurationIT {
             .assertThat(bindingServiceProperties.getBindingDestination(FUNCTION_ROUTER_INPUT))
             .satisfies(destination ->
                 assertThat(destination.split(","))
-                    .containsOnlyOnce("command-consumer", "script.EXECUTE", "engine-events", "integration-requests")
+                    .containsOnlyOnce(
+                        "command-consumer",
+                        "script.EXECUTE",
+                        "engine-events",
+                        "integration-requests",
+                        "integration-result-typed"
+                    )
             );
     }
 
@@ -715,7 +798,8 @@ public class FunctionRouterBindingConfigurationIT {
                 Map.entry("queryConsumer", "engine-events"),
                 Map.entry("scriptRuntimeConsumer", "script.EXECUTE"),
                 Map.entry("engineEventsConsumer", "engine-events"),
-                Map.entry("restConsumer", "rest.GET,rest.POST")
+                Map.entry("restConsumer", "rest.GET,rest.POST"),
+                Map.entry("integrationResultTypedConsumer", "integration-result-typed")
             );
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/TestBindingsChannels.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/TestBindingsChannels.java
@@ -44,6 +44,8 @@ public interface TestBindingsChannels {
 
     String REST_CONSUMER = "restConsumer";
 
+    String INTEGRATION_RESULT_TYPED_CONSUMER = "integrationResultTypedConsumer";
+
     @InputBinding(value = COMMAND_CONSUMER)
     default SubscribableChannel commandConsumer() {
         return MessageChannels.publishSubscribe(COMMAND_CONSUMER).getObject();
@@ -97,5 +99,10 @@ public interface TestBindingsChannels {
     @InputBinding(value = REST_CONSUMER)
     default SubscribableChannel restConsumer() {
         return MessageChannels.publishSubscribe(REST_CONSUMER).getObject();
+    }
+
+    @InputBinding(value = INTEGRATION_RESULT_TYPED_CONSUMER)
+    default SubscribableChannel integrationResultTypedConsumer() {
+        return MessageChannels.publishSubscribe(INTEGRATION_RESULT_TYPED_CONSUMER).getObject();
     }
 }


### PR DESCRIPTION
  Spring Cloud Function 5 / Stream 5 (Spring Boot 4) no longer re-applies the binding-level contentType on the router-mediated invocation path; the inbound `MessageHeaders.CONTENT_TYPE` is now authoritative. Messages arriving via RabbitMQ
  with `contentType=application/octet-stream` bypass JsonMessageConverter, get claimed by `ByteArrayMessageConverter`, and surface to `Consumer<Message<T>>` beans as raw `byte[]`, triggering a `ClassCastException`.

  Introduce `MessageContentTypeNormalizer` and apply it on both the router (`FunctionRouterConfiguration`) and direct binding (`FunctionBindingConfiguration`) paths. When the inbound contentType header is missing or is not compatible with the expected content type, it  is overridden with expected content type (defaulted to `application/json` if missing), before the function is invoked; other content types are preserved.