### PR TITLE
AAE-45411 Fix at-most-once delivery bug in FunctionRouterConfiguration

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -444,6 +444,8 @@ public class ActivitiCloudMessagingProperties {
 
         private Duration requestTimeout = Duration.ofSeconds(15);
 
+        private Duration processingTimeout = Duration.ofSeconds(120);
+
         @NestedConfigurationProperty
         private final FunctionRouterAnonymousProperties anonymous = new FunctionRouterAnonymousProperties();
 
@@ -556,6 +558,14 @@ public class ActivitiCloudMessagingProperties {
             this.retryInterval = retryInterval;
         }
 
+        public Duration getProcessingTimeout() {
+            return processingTimeout;
+        }
+
+        public void setProcessingTimeout(Duration processingTimeout) {
+            this.processingTimeout = processingTimeout;
+        }
+
         public void register(String bindingName, String functionBeanName) {
             destinations
                 .keySet()
@@ -609,6 +619,7 @@ public class ActivitiCloudMessagingProperties {
                 Objects.equals(registrations, that.registrations) &&
                 Objects.equals(group, that.group) &&
                 Objects.equals(retryInterval, that.retryInterval) &&
+                Objects.equals(processingTimeout, that.processingTimeout) &&
                 Objects.equals(consumer, that.consumer) &&
                 Objects.equals(anonymous, that.anonymous)
             );
@@ -624,6 +635,7 @@ public class ActivitiCloudMessagingProperties {
                 group,
                 maxRetries,
                 retryInterval,
+                processingTimeout,
                 consumer,
                 anonymous,
                 errorHandlerDefinition,
@@ -641,6 +653,7 @@ public class ActivitiCloudMessagingProperties {
                 .add("group='" + group + "'")
                 .add("maxRetries=" + maxRetries)
                 .add("retryInterval=" + retryInterval)
+                .add("processingTimeout=" + processingTimeout)
                 .add("consumer=" + consumer)
                 .add("anonymous=" + anonymous)
                 .add("errorHandlerDefinition=" + errorHandlerDefinition)

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -19,6 +19,7 @@ import static org.springframework.integration.handler.LoggingHandler.Level.DEBUG
 
 import java.lang.reflect.Type;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -286,8 +287,11 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             if (destination != null) {
                 int retryCount = getRetryCount(headers);
                 if (retryCount < maxRetry - 1) {
-                    safeSleep(retryDelay);
-                    getStreamBridge().send(destination, newMessage);
+                    final var streamBridge = getStreamBridge();
+                    CompletableFuture.runAsync(() -> {
+                        safeSleep(retryDelay);
+                        streamBridge.send(destination, newMessage);
+                    });
                 } else {
                     LOGGER.error("Cannot retry message because retry limited exceeded: {}", maxRetry);
                 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -235,13 +235,15 @@ public class FunctionRouterConfiguration {
                                 return supplyAsyncWithRetry(
                                         () -> {
                                             CompletableFuture<Object> cf = new CompletableFuture<>();
-                                            currentRawFuture.set(executor.submit(() -> {
-                                                try {
-                                                    cf.complete(routingFunction.apply(functionRequest));
-                                                } catch (Throwable t) {
-                                                    cf.completeExceptionally(t);
-                                                }
-                                            }));
+                                            currentRawFuture.set(
+                                                executor.submit(() -> {
+                                                    try {
+                                                        cf.complete(routingFunction.apply(functionRequest));
+                                                    } catch (Throwable t) {
+                                                        cf.completeExceptionally(t);
+                                                    }
+                                                })
+                                            );
                                             return cf;
                                         },
                                         functionRouter.getMaxRetries(),
@@ -279,7 +281,9 @@ public class FunctionRouterConfiguration {
                                 completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
-                            cancellableFutures.forEach(ref -> Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true)));
+                            cancellableFutures.forEach(ref ->
+                                Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true))
+                            );
                             throw new MessagingException(message, e);
                         } catch (ExecutionException e) {
                             Throwable cause = e.getCause();
@@ -290,7 +294,9 @@ public class FunctionRouterConfiguration {
                                 functionRouter.getProcessingTimeout(),
                                 message
                             );
-                            cancellableFutures.forEach(ref -> Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true)));
+                            cancellableFutures.forEach(ref ->
+                                Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true))
+                            );
                             throw new MessagingException(message, e);
                         }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -179,10 +178,56 @@ public class FunctionRouterConfiguration {
         MessageContentTypeNormalizer messageContentTypeNormalizer,
         BindingServiceProperties bindingServiceProperties
     ) {
-        final var functionRouter = messagingProperties.getFunctionRouter();
+        return new FunctionRouterHandler(
+            messagingProperties,
+            routingFunction,
+            functionCatalog,
+            functionExecutorSelector,
+            messageContentTypeNormalizer,
+            bindingServiceProperties
+        );
+    }
 
-        return (message, routingContext) -> {
-            Optional
+    private static class FunctionRouterHandler implements BiConsumer<Message<?>, String> {
+
+        private static final Logger log = LoggerFactory.getLogger(FunctionRouterHandler.class);
+
+        private final ActivitiCloudMessagingProperties messagingProperties;
+        private final RoutingFunction routingFunction;
+        private final FunctionCatalog functionCatalog;
+        private final Function<Message<?>, ExecutorService> functionExecutorSelector;
+        private final MessageContentTypeNormalizer messageContentTypeNormalizer;
+        private final BindingServiceProperties bindingServiceProperties;
+
+        FunctionRouterHandler(
+            ActivitiCloudMessagingProperties messagingProperties,
+            RoutingFunction routingFunction,
+            FunctionCatalog functionCatalog,
+            Function<Message<?>, ExecutorService> functionExecutorSelector,
+            MessageContentTypeNormalizer messageContentTypeNormalizer,
+            BindingServiceProperties bindingServiceProperties
+        ) {
+            this.messagingProperties = messagingProperties;
+            this.routingFunction = routingFunction;
+            this.functionCatalog = functionCatalog;
+            this.functionExecutorSelector = functionExecutorSelector;
+            this.messageContentTypeNormalizer = messageContentTypeNormalizer;
+            this.bindingServiceProperties = bindingServiceProperties;
+        }
+
+        @Override
+        public void accept(Message<?> message, String routingContext) {
+            resolveRoutingKey(message)
+                .map(messagingProperties.getFunctionRouter().registrations(routingContext)::get)
+                .filter(Predicate.not(Collection::isEmpty))
+                .ifPresentOrElse(
+                    registrations -> dispatchToRegistrations(message, registrations),
+                    () -> logUnroutableMessage(message, routingContext)
+                );
+        }
+
+        private Optional<String> resolveRoutingKey(Message<?> message) {
+            return Optional
                 .ofNullable(message.getHeaders().get(FUNCTION_DESTINATION, String.class))
                 .or(() -> Optional.ofNullable(message.getHeaders().get(CONNECTOR_TYPE, String.class)))
                 .or(() ->
@@ -196,169 +241,180 @@ public class FunctionRouterConfiguration {
                                 .map(exchange -> exchange.substring(prefix.length()))
                         )
                 )
-                .or(() -> Optional.ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class)))
-                .map(messagingProperties.getFunctionRouter().registrations(routingContext)::get)
-                .filter(Predicate.not(Collection::isEmpty))
-                .ifPresentOrElse(
-                    registrations -> {
-                        Function<Message<?>, String> resolveFunctionDefinition = functionMessage ->
-                            functionMessage.getHeaders().get(FunctionProperties.FUNCTION_DEFINITION, String.class);
-                        BiFunction<Message<?>, String, Message<?>> toFunctionRequest = (
-                            functionMessage,
-                            functionRegistration
-                        ) -> {
-                            String expectedContentType = functionRouter
-                                .bindingNameFor(functionRegistration)
-                                .map(bindingName -> bindingServiceProperties.getBindings().get(bindingName))
-                                .map(BindingProperties::getContentType)
-                                .orElse(null);
-                            return MessageBuilder
-                                .fromMessage(
-                                    messageContentTypeNormalizer.normalizeToExpected(
-                                        functionMessage,
-                                        expectedContentType
-                                    )
-                                )
-                                .setHeader(FunctionProperties.FUNCTION_DEFINITION, functionRegistration)
-                                .build();
-                        };
+                .or(() -> Optional.ofNullable(message.getHeaders().get(AmqpHeaders.RECEIVED_EXCHANGE, String.class)));
+        }
 
-                        List<AtomicReference<Future<?>>> cancellableFutures = new ArrayList<>();
+        private void dispatchToRegistrations(Message<?> message, Collection<String> registrations) {
+            List<AtomicReference<Future<?>>> cancellableFutures = new ArrayList<>();
+            CompletableFuture<List<?>> allCompleted = submitAll(message, registrations, cancellableFutures);
+            List<?> results = waitForCompletion(message, allCompleted, cancellableFutures);
+            handleErrors(message, results);
+        }
 
-                        var functions = registrations
-                            .stream()
-                            .map(functionRegistration -> toFunctionRequest.apply(message, functionRegistration))
-                            .map(functionRequest -> {
-                                AtomicReference<Future<?>> currentRawFuture = new AtomicReference<>();
-                                cancellableFutures.add(currentRawFuture);
-                                ExecutorService executor = functionExecutorSelector.apply(functionRequest);
-                                return supplyAsyncWithRetry(
-                                        () -> {
-                                            CompletableFuture<Object> cf = new CompletableFuture<>();
-                                            currentRawFuture.set(
-                                                executor.submit(() -> {
-                                                    try {
-                                                        cf.complete(routingFunction.apply(functionRequest));
-                                                    } catch (Throwable t) {
-                                                        cf.completeExceptionally(t);
-                                                    }
-                                                })
-                                            );
-                                            return cf;
-                                        },
-                                        functionRouter.getMaxRetries(),
-                                        functionRouter.getRetryInterval()
-                                    )
-                                    .thenApply(result -> {
-                                        var functionDefinition = resolveFunctionDefinition.apply(functionRequest);
-                                        log.debug(
-                                            "Function message request {} successfully routed to {}",
-                                            functionRequest,
-                                            functionDefinition
-                                        );
-                                        return Map.entry(functionDefinition, Optional.ofNullable(result));
-                                    })
-                                    .exceptionally(error -> {
-                                        var functionDefinition = resolveFunctionDefinition.apply(functionRequest);
-                                        log.error(
-                                            "Error routing message request {} to function registration {}",
-                                            functionRequest,
-                                            functionDefinition,
-                                            error
-                                        );
-                                        return Map.entry(functionDefinition, Optional.of(error));
-                                    });
-                            })
-                            .toArray(CompletableFuture[]::new);
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private CompletableFuture<List<?>> submitAll(
+            Message<?> message,
+            Collection<String> registrations,
+            List<AtomicReference<Future<?>>> cancellableFutures
+        ) {
+            CompletableFuture[] futures = registrations
+                .stream()
+                .map(functionRegistration -> buildFunctionRequest(message, functionRegistration))
+                .map(functionRequest -> submitFunctionWithRetry(functionRequest, cancellableFutures))
+                .toArray(CompletableFuture[]::new);
 
-                        var completed = CompletableFuture
-                            .allOf(functions)
-                            .thenApply(v -> Stream.of(functions).map(CompletableFuture::join).toList());
+            return CompletableFuture
+                .allOf(futures)
+                .thenApply(v -> Stream.of(futures).map(CompletableFuture::join).toList());
+        }
 
-                        List<?> results;
-                        try {
-                            results =
-                                completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            cancellableFutures.forEach(ref ->
-                                Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true))
-                            );
-                            throw new MessagingException(message, e);
-                        } catch (ExecutionException e) {
-                            Throwable cause = e.getCause();
-                            throw cause instanceof RuntimeException re ? re : new MessagingException(message, cause);
-                        } catch (TimeoutException e) {
-                            log.error(
-                                "Processing timeout ({}) exceeded waiting for function router to handle message {}",
-                                functionRouter.getProcessingTimeout(),
-                                message
-                            );
-                            cancellableFutures.forEach(ref ->
-                                Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true))
-                            );
-                            throw new MessagingException(message, e);
-                        }
+        private Message<?> buildFunctionRequest(Message<?> message, String functionRegistration) {
+            String expectedContentType = messagingProperties.getFunctionRouter()
+                .bindingNameFor(functionRegistration)
+                .map(bindingName -> bindingServiceProperties.getBindings().get(bindingName))
+                .map(BindingProperties::getContentType)
+                .orElse(null);
+            return MessageBuilder
+                .fromMessage(messageContentTypeNormalizer.normalizeToExpected(message, expectedContentType))
+                .setHeader(FunctionProperties.FUNCTION_DEFINITION, functionRegistration)
+                .build();
+        }
 
-                        var errors = results
-                            .stream()
-                            .map(Map.Entry.class::cast)
-                            .filter(entry ->
-                                Optional.class.cast(entry.getValue()).filter(Exception.class::isInstance).isPresent()
-                            )
-                            .map(entry -> Optional.class.cast(entry.getValue()).get())
-                            .toList();
+        private CompletableFuture<Map.Entry<String, Optional<Object>>> submitFunctionWithRetry(
+            Message<?> functionRequest,
+            List<AtomicReference<Future<?>>> cancellableFutures
+        ) {
+            final var functionRouter = messagingProperties.getFunctionRouter();
+            AtomicReference<Future<?>> currentRawFuture = new AtomicReference<>();
+            cancellableFutures.add(currentRawFuture);
+            ExecutorService executor = functionExecutorSelector.apply(functionRequest);
 
-                        if (!errors.isEmpty()) {
-                            log.debug("Errors handling function route message request {}", errors);
-
-                            Optional
-                                .ofNullable(messagingProperties.getFunctionRouter().getErrorHandlerDefinition())
-                                .filter(StringUtils::hasText)
-                                .map(functionCatalog::lookup)
-                                .map(SimpleFunctionRegistry.FunctionInvocationWrapper.class::cast)
-                                .ifPresent(errorHandlerDefinition -> {
-                                    errors
-                                        .stream()
-                                        .map(Throwable.class::cast)
-                                        .map(throwable ->
-                                            throwable instanceof CompletionException ce ? ce.getCause() : throwable
-                                        )
-                                        .map(exception -> {
-                                            if (exception instanceof MessagingException messagingException) {
-                                                return new ErrorMessage(messagingException, message);
-                                            } else {
-                                                return new ErrorMessage(
-                                                    new MessagingException(message, exception),
-                                                    message
-                                                );
-                                            }
-                                        })
-                                        .forEach(errorMessage -> {
-                                            errorHandlerDefinition.accept(errorMessage);
-                                        });
-                                });
-                        } else {
-                            log.debug("Successfully completed function route message request {}", message);
-                        }
-                    },
+            return supplyAsyncWithRetry(
                     () -> {
-                        final var destination = message.getHeaders().get(FUNCTION_DESTINATION, String.class);
-
-                        final var registration = Optional
-                            .ofNullable(destination)
-                            .map(it -> messagingProperties.getFunctionRouter().registrations(routingContext).get(it))
-                            .orElse(List.of());
-
-                        log.warn(
-                            "Unable to route message {} to destination '{}' for function registration '{}'",
-                            message,
-                            destination,
-                            registration
+                        CompletableFuture<Object> cf = new CompletableFuture<>();
+                        currentRawFuture.set(
+                            executor.submit(() -> {
+                                try {
+                                    cf.complete(routingFunction.apply(functionRequest));
+                                } catch (Exception t) {
+                                    cf.completeExceptionally(t);
+                                }
+                            })
                         );
-                    }
+                        return cf;
+                    },
+                    functionRouter.getMaxRetries(),
+                    functionRouter.getRetryInterval()
+                )
+                .thenApply(result -> {
+                    var functionDefinition = functionRequest
+                        .getHeaders()
+                        .get(FunctionProperties.FUNCTION_DEFINITION, String.class);
+                    log.debug(
+                        "Function message request {} successfully routed to {}",
+                        functionRequest,
+                        functionDefinition
+                    );
+                    return Map.entry(functionDefinition, Optional.ofNullable(result));
+                })
+                .exceptionally(error -> {
+                    var functionDefinition = functionRequest
+                        .getHeaders()
+                        .get(FunctionProperties.FUNCTION_DEFINITION, String.class);
+                    log.error(
+                        "Error routing message request {} to function registration {}",
+                        functionRequest,
+                        functionDefinition,
+                        error
+                    );
+                    return Map.entry(functionDefinition, Optional.of(error));
+                });
+        }
+
+        private List<?> waitForCompletion(
+            Message<?> message,
+            CompletableFuture<List<?>> completed,
+            List<AtomicReference<Future<?>>> cancellableFutures
+        ) {
+            final var functionRouter = messagingProperties.getFunctionRouter();
+            try {
+                return completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                cancelAll(cancellableFutures);
+                throw new MessagingException(message, e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                throw cause instanceof RuntimeException re ? re : new MessagingException(message, cause);
+            } catch (TimeoutException e) {
+                log.error(
+                    "Processing timeout ({}) exceeded waiting for function router to handle message {}",
+                    functionRouter.getProcessingTimeout(),
+                    message
                 );
-        };
+                cancelAll(cancellableFutures);
+                throw new MessagingException(message, e);
+            }
+        }
+
+        private void cancelAll(List<AtomicReference<Future<?>>> cancellableFutures) {
+            cancellableFutures.forEach(ref -> Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true)));
+        }
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private void handleErrors(Message<?> message, List<?> results) {
+            var errors = results
+                .stream()
+                .map(Map.Entry.class::cast)
+                .filter(entry ->
+                    Optional.class.cast(entry.getValue()).filter(Exception.class::isInstance).isPresent()
+                )
+                .map(entry -> Optional.class.cast(entry.getValue()).get())
+                .toList();
+
+            if (errors.isEmpty()) {
+                log.debug("Successfully completed function route message request {}", message);
+                return;
+            }
+
+            log.debug("Errors handling function route message request {}", errors);
+
+            Optional
+                .ofNullable(messagingProperties.getFunctionRouter().getErrorHandlerDefinition())
+                .filter(StringUtils::hasText)
+                .map(functionCatalog::lookup)
+                .map(SimpleFunctionRegistry.FunctionInvocationWrapper.class::cast)
+                .ifPresent(errorHandlerDefinition ->
+                    errors
+                        .stream()
+                        .map(Throwable.class::cast)
+                        .map(throwable ->
+                            throwable instanceof CompletionException ce ? ce.getCause() : throwable
+                        )
+                        .map(exception -> {
+                            if (exception instanceof MessagingException messagingException) {
+                                return new ErrorMessage(messagingException, message);
+                            } else {
+                                return new ErrorMessage(new MessagingException(message, exception), message);
+                            }
+                        })
+                        .forEach(errorHandlerDefinition::accept)
+                );
+        }
+
+        private void logUnroutableMessage(Message<?> message, String routingContext) {
+            final var destination = message.getHeaders().get(FUNCTION_DESTINATION, String.class);
+            final var registration = Optional
+                .ofNullable(destination)
+                .map(it -> messagingProperties.getFunctionRouter().registrations(routingContext).get(it))
+                .orElse(List.of());
+            log.warn(
+                "Unable to route message {} to destination '{}' for function registration '{}'",
+                message,
+                destination,
+                registration
+            );
+        }
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -269,7 +269,8 @@ public class FunctionRouterConfiguration {
         }
 
         private Message<?> buildFunctionRequest(Message<?> message, String functionRegistration) {
-            String expectedContentType = messagingProperties.getFunctionRouter()
+            String expectedContentType = messagingProperties
+                .getFunctionRouter()
                 .bindingNameFor(functionRegistration)
                 .map(bindingName -> bindingServiceProperties.getBindings().get(bindingName))
                 .map(BindingProperties::getContentType)
@@ -366,9 +367,7 @@ public class FunctionRouterConfiguration {
             var errors = results
                 .stream()
                 .map(Map.Entry.class::cast)
-                .filter(entry ->
-                    Optional.class.cast(entry.getValue()).filter(Exception.class::isInstance).isPresent()
-                )
+                .filter(entry -> Optional.class.cast(entry.getValue()).filter(Exception.class::isInstance).isPresent())
                 .map(entry -> Optional.class.cast(entry.getValue()).get())
                 .toList();
 
@@ -388,9 +387,7 @@ public class FunctionRouterConfiguration {
                     errors
                         .stream()
                         .map(Throwable.class::cast)
-                        .map(throwable ->
-                            throwable instanceof CompletionException ce ? ce.getCause() : throwable
-                        )
+                        .map(throwable -> throwable instanceof CompletionException ce ? ce.getCause() : throwable)
                         .map(exception -> {
                             if (exception instanceof MessagingException messagingException) {
                                 return new ErrorMessage(messagingException, message);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -259,13 +261,21 @@ public class FunctionRouterConfiguration {
 
                         List<?> results;
                         try {
-                            results = completed.get();
+                            results =
+                                completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             throw new MessagingException(message, e);
                         } catch (ExecutionException e) {
                             Throwable cause = e.getCause();
                             throw cause instanceof RuntimeException re ? re : new MessagingException(message, cause);
+                        } catch (TimeoutException e) {
+                            log.error(
+                                "Processing timeout ({}) exceeded waiting for function router to handle message {}",
+                                functionRouter.getProcessingTimeout(),
+                                message
+                            );
+                            throw new MessagingException(message, e);
                         }
 
                         var errors = results

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.common.messaging.config;
 
 import static org.activiti.cloud.common.messaging.config.CompletableFutureRetry.supplyAsyncWithRetry;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -25,8 +26,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -220,16 +223,27 @@ public class FunctionRouterConfiguration {
                                 .build();
                         };
 
+                        List<AtomicReference<Future<?>>> cancellableFutures = new ArrayList<>();
+
                         var functions = registrations
                             .stream()
                             .map(functionRegistration -> toFunctionRequest.apply(message, functionRegistration))
-                            .map(functionRequest ->
-                                supplyAsyncWithRetry(
-                                        () ->
-                                            CompletableFuture.supplyAsync(
-                                                () -> routingFunction.apply(functionRequest),
-                                                functionExecutorSelector.apply(functionRequest)
-                                            ),
+                            .map(functionRequest -> {
+                                AtomicReference<Future<?>> currentRawFuture = new AtomicReference<>();
+                                cancellableFutures.add(currentRawFuture);
+                                ExecutorService executor = functionExecutorSelector.apply(functionRequest);
+                                return supplyAsyncWithRetry(
+                                        () -> {
+                                            CompletableFuture<Object> cf = new CompletableFuture<>();
+                                            currentRawFuture.set(executor.submit(() -> {
+                                                try {
+                                                    cf.complete(routingFunction.apply(functionRequest));
+                                                } catch (Throwable t) {
+                                                    cf.completeExceptionally(t);
+                                                }
+                                            }));
+                                            return cf;
+                                        },
                                         functionRouter.getMaxRetries(),
                                         functionRouter.getRetryInterval()
                                     )
@@ -251,8 +265,8 @@ public class FunctionRouterConfiguration {
                                             error
                                         );
                                         return Map.entry(functionDefinition, Optional.of(error));
-                                    })
-                            )
+                                    });
+                            })
                             .toArray(CompletableFuture[]::new);
 
                         var completed = CompletableFuture
@@ -265,6 +279,7 @@ public class FunctionRouterConfiguration {
                                 completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
+                            cancellableFutures.forEach(ref -> Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true)));
                             throw new MessagingException(message, e);
                         } catch (ExecutionException e) {
                             Throwable cause = e.getCause();
@@ -275,6 +290,7 @@ public class FunctionRouterConfiguration {
                                 functionRouter.getProcessingTimeout(),
                                 message
                             );
+                            cancellableFutures.forEach(ref -> Optional.ofNullable(ref.get()).ifPresent(f -> f.cancel(true)));
                             throw new MessagingException(message, e);
                         }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -256,49 +257,58 @@ public class FunctionRouterConfiguration {
                             .allOf(functions)
                             .thenApply(v -> Stream.of(functions).map(CompletableFuture::join).toList());
 
-                        completed.thenAccept(results -> {
-                            var errors = results
-                                .stream()
-                                .map(Map.Entry.class::cast)
-                                .filter(entry ->
-                                    Optional.class.cast(entry.getValue())
-                                        .filter(Exception.class::isInstance)
-                                        .isPresent()
-                                )
-                                .map(entry -> Optional.class.cast(entry.getValue()).get())
-                                .toList();
+                        List<?> results;
+                        try {
+                            results = completed.get();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new MessagingException(message, e);
+                        } catch (ExecutionException e) {
+                            Throwable cause = e.getCause();
+                            throw cause instanceof RuntimeException re ? re : new MessagingException(message, cause);
+                        }
 
-                            if (!errors.isEmpty()) {
-                                log.debug("Errors handling function route message request {}", errors);
+                        var errors = results
+                            .stream()
+                            .map(Map.Entry.class::cast)
+                            .filter(entry ->
+                                Optional.class.cast(entry.getValue()).filter(Exception.class::isInstance).isPresent()
+                            )
+                            .map(entry -> Optional.class.cast(entry.getValue()).get())
+                            .toList();
 
-                                Optional
-                                    .ofNullable(messagingProperties.getFunctionRouter().getErrorHandlerDefinition())
-                                    .filter(StringUtils::hasText)
-                                    .map(functionCatalog::lookup)
-                                    .map(SimpleFunctionRegistry.FunctionInvocationWrapper.class::cast)
-                                    .ifPresent(errorHandlerDefinition -> {
-                                        errors
-                                            .stream()
-                                            .map(CompletionException.class::cast)
-                                            .map(CompletionException::getCause)
-                                            .map(exception -> {
-                                                if (exception instanceof MessagingException messagingException) {
-                                                    return new ErrorMessage(messagingException, message);
-                                                } else {
-                                                    return new ErrorMessage(
-                                                        new MessagingException(message, exception),
-                                                        message
-                                                    );
-                                                }
-                                            })
-                                            .forEach(errorMessage -> {
-                                                errorHandlerDefinition.accept(errorMessage);
-                                            });
-                                    });
-                            } else {
-                                log.debug("Successfully completed function route message request {}", message);
-                            }
-                        });
+                        if (!errors.isEmpty()) {
+                            log.debug("Errors handling function route message request {}", errors);
+
+                            Optional
+                                .ofNullable(messagingProperties.getFunctionRouter().getErrorHandlerDefinition())
+                                .filter(StringUtils::hasText)
+                                .map(functionCatalog::lookup)
+                                .map(SimpleFunctionRegistry.FunctionInvocationWrapper.class::cast)
+                                .ifPresent(errorHandlerDefinition -> {
+                                    errors
+                                        .stream()
+                                        .map(Throwable.class::cast)
+                                        .map(throwable ->
+                                            throwable instanceof CompletionException ce ? ce.getCause() : throwable
+                                        )
+                                        .map(exception -> {
+                                            if (exception instanceof MessagingException messagingException) {
+                                                return new ErrorMessage(messagingException, message);
+                                            } else {
+                                                return new ErrorMessage(
+                                                    new MessagingException(message, exception),
+                                                    message
+                                                );
+                                            }
+                                        })
+                                        .forEach(errorMessage -> {
+                                            errorHandlerDefinition.accept(errorMessage);
+                                        });
+                                });
+                        } else {
+                            log.debug("Successfully completed function route message request {}", message);
+                        }
                     },
                     () -> {
                         final var destination = message.getHeaders().get(FUNCTION_DESTINATION, String.class);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -45,3 +45,4 @@ spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.ra
 
 activiti.cloud.messaging.function-router.error-handler-definition=${spring.cloud.stream.default.error-handler-definition:}
 activiti.cloud.messaging.function-router.request-timeout=15s
+activiti.cloud.messaging.function-router.processing-timeout=${ACT_FUNCTION_ROUTER_PROCESSING_TIMEOUT:120s}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/FunctionRouterPropertiesTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/FunctionRouterPropertiesTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties.FunctionRouterProperties;
+import org.junit.jupiter.api.Test;
+
+class FunctionRouterPropertiesTest {
+
+    @Test
+    void should_be_equal_to_itself() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+
+        assertThat(a.equals(a)).isTrue();
+    }
+
+    @Test
+    void should_not_be_equal_to_null() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+
+        assertThat(a.equals(null)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_to_different_type() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+
+        assertThat(a.equals("not-a-FunctionRouterProperties")).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_enabled_differs() {
+        FunctionRouterProperties enabled = new FunctionRouterProperties();
+        FunctionRouterProperties disabled = new FunctionRouterProperties();
+
+        enabled.setEnabled(true);
+        disabled.setEnabled(false);
+
+        assertThat(enabled.equals(disabled)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_maxRetries_differs() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+        FunctionRouterProperties b = new FunctionRouterProperties();
+
+        a.setMaxRetries(5);
+        b.setMaxRetries(10);
+
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_group_differs() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+        FunctionRouterProperties b = new FunctionRouterProperties();
+
+        a.setGroup("group-a");
+        b.setGroup("group-b");
+
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_retryInterval_differs() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+        FunctionRouterProperties b = new FunctionRouterProperties();
+
+        a.setRetryInterval(Duration.ofMillis(100));
+        b.setRetryInterval(Duration.ofMillis(200));
+
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_processingTimeout_differs() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+        FunctionRouterProperties b = new FunctionRouterProperties();
+
+        a.setProcessingTimeout(Duration.ofSeconds(30));
+        b.setProcessingTimeout(Duration.ofSeconds(60));
+
+        assertThat(a.equals(b)).isFalse();
+    }
+
+    @Test
+    void should_not_be_equal_when_routes_differ() {
+        FunctionRouterProperties a = new FunctionRouterProperties();
+        FunctionRouterProperties b = new FunctionRouterProperties();
+
+        a.getRoutes().put("route-a", new ActivitiCloudMessagingProperties.BindingFunctionRouterProperties());
+
+        assertThat(a.equals(b)).isFalse();
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -150,6 +150,8 @@ public class FunctionRouterBindingConfigurationIT {
     private static final AtomicReference<Message<?>> engineEventsMessage = new AtomicReference<>();
     private static final AtomicReference<Integer> auditRetries = new AtomicReference<>();
     private static final AtomicReference<String> connectorPayload = new AtomicReference<>();
+    private static final AtomicReference<Long> connectorProcessingEndNanos = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> connectorBlockingLatch = new AtomicReference<>();
     private static final AtomicReference<String> getPayload = new AtomicReference<>();
     private static final AtomicReference<String> postPayload = new AtomicReference<>();
     private static final AtomicReference<TypedPayload> receivedTypedPayload = new AtomicReference<>();
@@ -238,6 +240,22 @@ public class FunctionRouterBindingConfigurationIT {
         public ConsumerConnector<String> scriptRuntimeExecutor() {
             return message -> {
                 connectorPayload.set(message);
+                CountDownLatch latch = connectorBlockingLatch.get();
+                if (latch != null) {
+                    try {
+                        boolean released = latch.await(
+                            Duration.ofSeconds(5).toMillis(),
+                            java.util.concurrent.TimeUnit.MILLISECONDS
+                        );
+                        assertThat(released)
+                            .as("Timed out waiting for scriptRuntimeExecutor latch to be released")
+                            .isTrue();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        Assertions.fail("Interrupted while waiting for scriptRuntimeExecutor latch", e);
+                    }
+                }
+                connectorProcessingEndNanos.set(System.nanoTime());
             };
         }
 
@@ -310,6 +328,8 @@ public class FunctionRouterBindingConfigurationIT {
         queryMessage.set(null);
         auditMessage.set(null);
         connectorPayload.set(null);
+        connectorProcessingEndNanos.set(null);
+        connectorBlockingLatch.set(null);
         getPayload.set(null);
         postPayload.set(null);
         receivedTypedPayload.set(null);
@@ -954,6 +974,49 @@ public class FunctionRouterBindingConfigurationIT {
     @Test
     void functionRouterExecutorFactoryTimeout() {
         assertThat(functionRouterExecutorFactory.getTimeout()).isEqualTo(Duration.ofSeconds(1));
+    }
+
+    @Test
+    void callerThreadShouldBlockUntilFunctionRouterCompletesProcessing() {
+        final CountDownLatch processingLatch = new CountDownLatch(1);
+        connectorBlockingLatch.set(processingLatch);
+
+        final AtomicReference<Long> callerReturnTime = new AtomicReference<>();
+
+        Message<String> message = MessageBuilder
+            .withPayload("run_test();")
+            .setHeader(FUNCTION_DESTINATION, "script.EXECUTE")
+            .build();
+
+        CompletableFuture<Void> senderFuture = CompletableFuture.runAsync(() -> {
+            input.send(message, "script.EXECUTE");
+            callerReturnTime.set(System.nanoTime());
+        });
+
+        try {
+            await().atMost(Duration.ofSeconds(5)).until(() -> connectorPayload.get() != null);
+
+            assertThat(senderFuture)
+                .as("sender future must not complete before the connector latch is released")
+                .isNotDone();
+            assertThat(callerReturnTime.get())
+                .as("caller thread must not return before the connector latch is released")
+                .isNull();
+        } finally {
+            processingLatch.countDown();
+        }
+
+        await()
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(() -> {
+                assertThat(callerReturnTime.get()).isNotNull();
+                assertThat(connectorProcessingEndNanos.get()).isNotNull();
+                assertThat(callerReturnTime.get())
+                    .as("caller thread must not return before processing completes")
+                    .isGreaterThanOrEqualTo(connectorProcessingEndNanos.get());
+            });
+
+        assertThat(senderFuture).succeedsWithin(Duration.ofSeconds(5));
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
+import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootTest(
+    properties = {
+        "activiti.cloud.application.name=foo",
+        "spring.application.name=bar",
+        "spring.cloud.stream.bindings.restConsumer.destination=rest.GET",
+        "spring.cloud.stream.bindings.restConsumer.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.enabled=true",
+        "activiti.cloud.messaging.function-router.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.routes.restConsumer.enabled=true",
+        "activiti.cloud.messaging.function-router.max-retries=0",
+        "activiti.cloud.messaging.function-router.error-handler-definition=functionRouterErrorHandler",
+    }
+)
+@EnableTestBinder
+@Import({ TestBindingsChannelsConfiguration.class })
+class FunctionRouterErrorHandlerIT {
+
+    private static final AtomicReference<Supplier<RuntimeException>> exceptionSupplier = new AtomicReference<>();
+    private static final List<ErrorMessage> capturedErrorMessages = new CopyOnWriteArrayList<>();
+
+    @Autowired
+    private BiConsumer<Message<?>, String> functionRouterMessageHandler;
+
+    @TestConfiguration
+    static class ApplicationConfig {
+
+        @Bean
+        @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
+        ConsumerConnector<String> throwingRestConsumer() {
+            return payload -> {
+                Supplier<RuntimeException> supplier = exceptionSupplier.get();
+                if (supplier != null) {
+                    throw supplier.get();
+                }
+            };
+        }
+
+        @Bean
+        Consumer<ErrorMessage> functionRouterErrorHandler() {
+            return capturedErrorMessages::add;
+        }
+    }
+
+    @AfterEach
+    void reset() {
+        exceptionSupplier.set(null);
+        capturedErrorMessages.clear();
+    }
+
+    @Test
+    void shouldCallErrorHandlerWithWrappedMessagingExceptionWhenFunctionThrowsRuntimeException() {
+        exceptionSupplier.set(() -> new RuntimeException("test error"));
+
+        Message<String> message = MessageBuilder
+            .withPayload("test payload")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
+
+        assertThat(capturedErrorMessages).hasSize(1);
+        Throwable payload = capturedErrorMessages.get(0).getPayload();
+        assertThat(payload).isInstanceOf(MessagingException.class);
+        assertThat(payload.getCause()).isInstanceOf(RuntimeException.class).hasMessage("test error");
+    }
+
+    @Test
+    void shouldCallErrorHandlerWithOriginalMessagingExceptionWhenFunctionThrowsMessagingException() {
+        Message<String> dummyMessage = MessageBuilder.withPayload("dummy").build();
+        MessagingException originalException = new MessagingException(dummyMessage, new RuntimeException("inner error"));
+        exceptionSupplier.set(() -> originalException);
+
+        Message<String> message = MessageBuilder
+            .withPayload("test payload")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
+
+        assertThat(capturedErrorMessages).hasSize(1);
+        assertThat(capturedErrorMessages.get(0).getPayload()).isSameAs(originalException);
+    }
+
+    @Test
+    void shouldCallErrorHandlerAndPreserveCompletionExceptionCauseChainWhenFunctionThrowsCompletionException() {
+        RuntimeException innerCause = new RuntimeException("inner cause");
+        exceptionSupplier.set(() -> new CompletionException(innerCause));
+
+        Message<String> message = MessageBuilder
+            .withPayload("test payload")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
+
+        assertThat(capturedErrorMessages).hasSize(1);
+        Throwable payload = capturedErrorMessages.get(0).getPayload();
+        assertThat(payload).isInstanceOf(MessagingException.class);
+        assertThat(payload.getCause()).isInstanceOf(CompletionException.class);
+        assertThat(payload.getCause().getCause()).isSameAs(innerCause);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerIT.java
@@ -109,7 +109,10 @@ class FunctionRouterErrorHandlerIT {
     @Test
     void shouldCallErrorHandlerWithOriginalMessagingExceptionWhenFunctionThrowsMessagingException() {
         Message<String> dummyMessage = MessageBuilder.withPayload("dummy").build();
-        MessagingException originalException = new MessagingException(dummyMessage, new RuntimeException("inner error"));
+        MessagingException originalException = new MessagingException(
+            dummyMessage,
+            new RuntimeException("inner error")
+        );
         exceptionSupplier.set(() -> originalException);
 
         Message<String> message = MessageBuilder

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerNotConfiguredIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerNotConfiguredIT.java
@@ -85,7 +85,8 @@ class FunctionRouterErrorHandlerNotConfiguredIT {
             .build();
 
         assertThatCode(() ->
-            functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT)
-        ).doesNotThrowAnyException();
+                functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT)
+            )
+            .doesNotThrowAnyException();
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerNotConfiguredIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterErrorHandlerNotConfiguredIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config.test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
+import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootTest(
+    properties = {
+        "activiti.cloud.application.name=foo",
+        "spring.application.name=bar",
+        "spring.cloud.stream.bindings.restConsumer.destination=rest.GET",
+        "spring.cloud.stream.bindings.restConsumer.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.enabled=true",
+        "activiti.cloud.messaging.function-router.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.routes.restConsumer.enabled=true",
+        "activiti.cloud.messaging.function-router.max-retries=0",
+    }
+)
+@EnableTestBinder
+@Import({ TestBindingsChannelsConfiguration.class })
+class FunctionRouterErrorHandlerNotConfiguredIT {
+
+    private static final AtomicReference<Supplier<RuntimeException>> exceptionSupplier = new AtomicReference<>();
+
+    @Autowired
+    private BiConsumer<Message<?>, String> functionRouterMessageHandler;
+
+    @TestConfiguration
+    static class ApplicationConfig {
+
+        @Bean
+        @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
+        ConsumerConnector<String> throwingRestConsumer() {
+            return payload -> {
+                Supplier<RuntimeException> supplier = exceptionSupplier.get();
+                if (supplier != null) {
+                    throw supplier.get();
+                }
+            };
+        }
+    }
+
+    @AfterEach
+    void reset() {
+        exceptionSupplier.set(null);
+    }
+
+    @Test
+    void shouldNotThrowWhenFunctionFailsAndNoErrorHandlerIsConfigured() {
+        exceptionSupplier.set(() -> new RuntimeException("unhandled error"));
+
+        Message<String> message = MessageBuilder
+            .withPayload("test payload")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        assertThatCode(() ->
+            functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT)
+        ).doesNotThrowAnyException();
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterExecutorFactoryIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterExecutorFactoryIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config.test;
+
+import static org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration.CONNECTOR_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
+
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootTest(
+    properties = {
+        "activiti.cloud.application.name=foo",
+        "spring.application.name=bar",
+        "spring.cloud.stream.bindings.restConsumer.destination=rest.GET",
+        "spring.cloud.stream.bindings.restConsumer.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.enabled=true",
+        "activiti.cloud.messaging.function-router.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.routes.restConsumer.enabled=true",
+    }
+)
+@EnableTestBinder
+@Import({ TestBindingsChannelsConfiguration.class })
+public class FunctionRouterExecutorFactoryIT {
+
+    private static final String REST_GET_HANDLER = "restGetHandler";
+    private static final String EXPECTED_REGISTRATION_KEY = REST_GET_HANDLER + REGISTRATION_NAME_SUFFIX;
+
+    private static final AtomicReference<String> lastFactoryKey = new AtomicReference<>();
+    private static final AtomicInteger executorTaskCount = new AtomicInteger();
+    private static final AtomicReference<String> receivedPayload = new AtomicReference<>();
+
+    @Autowired
+    private InputDestination input;
+
+    @TestConfiguration
+    static class ApplicationConfig {
+
+        private final List<ExecutorService> createdExecutors = new ArrayList<>();
+
+        @Bean(REST_GET_HANDLER)
+        @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
+        ConsumerConnector<String> restGetHandler() {
+            return payload -> receivedPayload.set(payload);
+        }
+
+        @Bean
+        Function<String, ExecutorService> functionRouterExecutorFactory() {
+            return registrationKey -> {
+                lastFactoryKey.set(registrationKey);
+                ThreadFactory daemonThreadFactory = runnable -> {
+                    Thread thread = new Thread(runnable);
+                    thread.setDaemon(true);
+                    return thread;
+                };
+                ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                    1,
+                    1,
+                    0L,
+                    TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>(),
+                    daemonThreadFactory
+                ) {
+                    @Override
+                    public void execute(Runnable command) {
+                        executorTaskCount.incrementAndGet();
+                        super.execute(command);
+                    }
+                };
+                createdExecutors.add(executor);
+                return executor;
+            };
+        }
+
+        @PreDestroy
+        void shutdownExecutors() {
+            createdExecutors.forEach(ExecutorService::shutdown);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        lastFactoryKey.set(null);
+        executorTaskCount.set(0);
+        receivedPayload.set(null);
+    }
+
+    @Test
+    void shouldUseCustomExecutorWhenFunctionRouterExecutorFactoryPresent() {
+        Message<String> message = MessageBuilder
+            .withPayload("GET http://localhost:8080")
+            .setHeader(CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        input.send(message, "rest.GET");
+
+        await()
+            .untilAsserted(() -> {
+                assertThat(receivedPayload.get()).isEqualTo("GET http://localhost:8080");
+                assertThat(lastFactoryKey.get()).isEqualTo(EXPECTED_REGISTRATION_KEY);
+                assertThat(executorTaskCount.get()).isGreaterThan(0);
+            });
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterExecutorFactoryIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterExecutorFactoryIT.java
@@ -58,7 +58,7 @@ import org.springframework.messaging.support.MessageBuilder;
 )
 @EnableTestBinder
 @Import({ TestBindingsChannelsConfiguration.class })
-public class FunctionRouterExecutorFactoryIT {
+class FunctionRouterExecutorFactoryIT {
 
     private static final String REST_GET_HANDLER = "restGetHandler";
     private static final String EXPECTED_REGISTRATION_KEY = REST_GET_HANDLER + REGISTRATION_NAME_SUFFIX;
@@ -78,7 +78,7 @@ public class FunctionRouterExecutorFactoryIT {
         @Bean(REST_GET_HANDLER)
         @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
         ConsumerConnector<String> restGetHandler() {
-            return payload -> receivedPayload.set(payload);
+            return receivedPayload::set;
         }
 
         @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
+import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+@SpringBootTest(
+    properties = {
+        "activiti.cloud.application.name=foo",
+        "spring.application.name=bar",
+        "spring.cloud.stream.bindings.restConsumer.destination=rest.GET",
+        "spring.cloud.stream.bindings.restConsumer.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.enabled=true",
+        "activiti.cloud.messaging.function-router.group=${spring.application.name}",
+        "activiti.cloud.messaging.function-router.routes.restConsumer.enabled=true",
+        "activiti.cloud.messaging.function-router.processing-timeout=1s",
+    }
+)
+@EnableTestBinder
+@Import({ TestBindingsChannelsConfiguration.class })
+class FunctionRouterProcessingTimeoutIT {
+
+    private static final AtomicReference<CountDownLatch> blockingLatch = new AtomicReference<>();
+
+    @Autowired
+    private InputDestination input;
+
+    @TestConfiguration
+    static class ApplicationConfig {
+
+        @Bean
+        @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
+        ConsumerConnector<String> restGetHandler() {
+            return payload -> {
+                CountDownLatch latch = blockingLatch.get();
+                if (latch != null) {
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        CountDownLatch latch = blockingLatch.getAndSet(null);
+        if (latch != null) {
+            while (latch.getCount() > 0) {
+                latch.countDown();
+            }
+        }
+    }
+
+    @Test
+    void shouldUnblockCallerAfterProcessingTimeoutExpires() {
+        final CountDownLatch neverReleasedLatch = new CountDownLatch(1);
+        blockingLatch.set(neverReleasedLatch);
+
+        Message<String> message = MessageBuilder
+            .withPayload("GET http://localhost:8080")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        CompletableFuture<Void> senderFuture = CompletableFuture.runAsync(() -> {
+            try {
+                input.send(message, "rest.GET");
+            } catch (Exception ignored) {}
+        });
+
+        assertThat(senderFuture).succeedsWithin(Duration.ofSeconds(10));
+        assertThat(neverReleasedLatch.getCount())
+            .as("latch must not have been released by the router — unblocking was caused by the timeout")
+            .isEqualTo(1);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -151,9 +151,7 @@ class FunctionRouterProcessingTimeoutIT {
         });
         callerThread.start();
 
-        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS))
-            .as("handler must start within 5s")
-            .isTrue();
+        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS)).as("handler must start within 5s").isTrue();
         callerThread.interrupt();
         callerThread.join(5_000);
 
@@ -183,9 +181,7 @@ class FunctionRouterProcessingTimeoutIT {
             } catch (Exception ignored) {}
         });
 
-        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS))
-            .as("handler must start within 5s")
-            .isTrue();
+        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS)).as("handler must start within 5s").isTrue();
 
         assertThat(interruptSignalLatch.get().await(10, TimeUnit.SECONDS))
             .as("handler thread must be interrupted after processing timeout expires")

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -57,6 +57,7 @@ class FunctionRouterProcessingTimeoutIT {
 
     private static final AtomicReference<CountDownLatch> handlerStartedLatch = new AtomicReference<>();
     private static final AtomicReference<CountDownLatch> blockingLatch = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> interruptSignalLatch = new AtomicReference<>();
 
     @Autowired
     private BiConsumer<Message<?>, String> functionRouterMessageHandler;
@@ -78,6 +79,10 @@ class FunctionRouterProcessingTimeoutIT {
                         latch.await();
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
+                        CountDownLatch signal = interruptSignalLatch.get();
+                        if (signal != null) {
+                            signal.countDown();
+                        }
                     }
                 }
             };
@@ -98,6 +103,7 @@ class FunctionRouterProcessingTimeoutIT {
                 latch.countDown();
             }
         }
+        interruptSignalLatch.set(null);
     }
 
     @Test
@@ -157,6 +163,32 @@ class FunctionRouterProcessingTimeoutIT {
             .isInstanceOf(InterruptedException.class);
         assertThat(interruptFlagPreserved)
             .as("interrupt flag must be re-set on the caller thread after InterruptedException is caught")
+            .isTrue();
+    }
+
+    @Test
+    void shouldInterruptHandlerThreadAfterProcessingTimeout() throws InterruptedException {
+        handlerStartedLatch.set(new CountDownLatch(1));
+        interruptSignalLatch.set(new CountDownLatch(1));
+        blockingLatch.set(new CountDownLatch(1));
+
+        Message<String> message = MessageBuilder
+            .withPayload("GET http://localhost:8080")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
+            } catch (Exception ignored) {}
+        });
+
+        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS))
+            .as("handler must start within 5s")
+            .isTrue();
+
+        assertThat(interruptSignalLatch.get().await(10, TimeUnit.SECONDS))
+            .as("handler thread must be interrupted after processing timeout expires")
             .isTrue();
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -77,7 +77,7 @@ class FunctionRouterProcessingTimeoutIT {
                 if (latch != null) {
                     try {
                         latch.await();
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException ignored) {
                         Thread.currentThread().interrupt();
                         CountDownLatch signal = interruptSignalLatch.get();
                         if (signal != null) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
 import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
@@ -30,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.stream.binder.test.EnableTestBinder;
-import org.springframework.cloud.stream.binder.test.InputDestination;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
@@ -55,7 +55,7 @@ class FunctionRouterProcessingTimeoutIT {
     private static final AtomicReference<CountDownLatch> blockingLatch = new AtomicReference<>();
 
     @Autowired
-    private InputDestination input;
+    private BiConsumer<Message<?>, String> functionRouterMessageHandler;
 
     @TestConfiguration
     static class ApplicationConfig {
@@ -98,7 +98,7 @@ class FunctionRouterProcessingTimeoutIT {
 
         CompletableFuture<Void> senderFuture = CompletableFuture.runAsync(() -> {
             try {
-                input.send(message, "rest.GET");
+                functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
             } catch (Exception ignored) {}
         });
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterProcessingTimeoutIT.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import org.activiti.cloud.common.messaging.config.FunctionRouterConfiguration;
@@ -34,6 +36,7 @@ import org.springframework.cloud.stream.binder.test.EnableTestBinder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 
 @SpringBootTest(
@@ -52,6 +55,7 @@ import org.springframework.messaging.support.MessageBuilder;
 @Import({ TestBindingsChannelsConfiguration.class })
 class FunctionRouterProcessingTimeoutIT {
 
+    private static final AtomicReference<CountDownLatch> handlerStartedLatch = new AtomicReference<>();
     private static final AtomicReference<CountDownLatch> blockingLatch = new AtomicReference<>();
 
     @Autowired
@@ -64,6 +68,10 @@ class FunctionRouterProcessingTimeoutIT {
         @ConnectorBinding(input = TestBindingsChannels.REST_CONSUMER, connectorType = "rest.GET", condition = "true")
         ConsumerConnector<String> restGetHandler() {
             return payload -> {
+                CountDownLatch started = handlerStartedLatch.get();
+                if (started != null) {
+                    started.countDown();
+                }
                 CountDownLatch latch = blockingLatch.get();
                 if (latch != null) {
                     try {
@@ -78,6 +86,12 @@ class FunctionRouterProcessingTimeoutIT {
 
     @AfterEach
     void tearDown() {
+        CountDownLatch started = handlerStartedLatch.getAndSet(null);
+        if (started != null) {
+            while (started.getCount() > 0) {
+                started.countDown();
+            }
+        }
         CountDownLatch latch = blockingLatch.getAndSet(null);
         if (latch != null) {
             while (latch.getCount() > 0) {
@@ -106,5 +120,43 @@ class FunctionRouterProcessingTimeoutIT {
         assertThat(neverReleasedLatch.getCount())
             .as("latch must not have been released by the router — unblocking was caused by the timeout")
             .isEqualTo(1);
+    }
+
+    @Test
+    void shouldThrowMessagingExceptionAndPreserveInterruptFlagWhenCallerIsInterrupted() throws InterruptedException {
+        handlerStartedLatch.set(new CountDownLatch(1));
+        blockingLatch.set(new CountDownLatch(1));
+
+        Message<String> message = MessageBuilder
+            .withPayload("test")
+            .setHeader(FunctionRouterConfiguration.CONNECTOR_TYPE, "rest.GET")
+            .build();
+
+        AtomicReference<Throwable> thrownException = new AtomicReference<>();
+        AtomicBoolean interruptFlagPreserved = new AtomicBoolean(false);
+
+        Thread callerThread = new Thread(() -> {
+            try {
+                functionRouterMessageHandler.accept(message, FunctionRouterConfiguration.FUNCTION_ROUTER_INPUT);
+            } catch (MessagingException e) {
+                thrownException.set(e);
+                interruptFlagPreserved.set(Thread.currentThread().isInterrupted());
+            }
+        });
+        callerThread.start();
+
+        assertThat(handlerStartedLatch.get().await(5, TimeUnit.SECONDS))
+            .as("handler must start within 5s")
+            .isTrue();
+        callerThread.interrupt();
+        callerThread.join(5_000);
+
+        assertThat(thrownException.get())
+            .isInstanceOf(MessagingException.class)
+            .extracting(Throwable::getCause)
+            .isInstanceOf(InterruptedException.class);
+        assertThat(interruptFlagPreserved)
+            .as("interrupt flag must be re-set on the caller thread after InterruptedException is caught")
+            .isTrue();
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other... Please describe:

## Description

Fixes an at-most-once delivery bug in `FunctionRouterConfiguration` where RabbitMQ messages were acknowledged **before** the connector finished processing them. This made `prefetch` ineffective and caused messages to be permanently lost on pod crashes.

## Root Cause

`functionRouterMessageHandler()` dispatches work to an executor via `CompletableFuture.supplyAsync()` and then attaches a result callback via `completed.thenAccept(results -> { ... })`. Because `thenAccept()` is non-blocking, the AMQP listener thread returns immediately — before the executor thread has even started processing — and Spring Cloud Stream ACKs the RabbitMQ message. Consequently:

- `prefetch=1` has no effect: the ACK is sent before processing begins, so RabbitMQ delivers the next message without waiting
- Any message held in the executor queue or actively being processed is permanently lost if the pod crashes mid-flight
- All other connectors (Lambda, Content, Slack, etc.) use at-least-once delivery because they process messages synchronously on the AMQP thread; FunctionRouter connectors (Rest, OpenAPI) were the only ones affected

## Fix

Replace `completed.thenAccept(results -> { ... })` with `completed.get(timeout, MILLISECONDS)` plus explicit exception handling:

```java
// Before — non-blocking, ACK before processing completes
completed.thenAccept(results -> {
    // handle errors and log
});

// After — blocks AMQP thread until executor finishes or timeout is exceeded
List<?> results;
try {
    results = completed.get(functionRouter.getProcessingTimeout().toMillis(), TimeUnit.MILLISECONDS);
} catch (InterruptedException e) {
    Thread.currentThread().interrupt();
    throw new MessagingException(message, e);
} catch (ExecutionException e) {
    Throwable cause = e.getCause();
    throw cause instanceof RuntimeException re ? re : new MessagingException(message, cause);
} catch (TimeoutException e) {
    log.error("Processing timeout ({}) exceeded waiting for function router to handle message {}",
        functionRouter.getProcessingTimeout(), message);
    throw new MessagingException(message, e);
}
// handle errors and log (same logic, now on the AMQP thread)
```

`completed.get(timeout, ...)` blocks the AMQP listener thread until all executor threads complete or the configurable `processingTimeout` (default: 120 seconds) is exceeded. The timeout guard prevents the AMQP connection from being silently killed by the broker's `consumer_timeout` due to an indefinitely hanging HTTP endpoint.

## Advantages

- **At-least-once delivery**: ACK is only sent after the executor thread completes the HTTP/processing call, consistent with all other connectors in the codebase
- **`prefetch` now works**: blocking the AMQP thread means RabbitMQ respects the prefetch limit and withholds further messages until the current one is fully processed
- **Correct interrupt handling**: `InterruptedException` re-interrupts the thread instead of being silently swallowed (improvement over `join()`)
- **Bounded blocking**: the `processingTimeout` guard ensures the AMQP thread is never blocked indefinitely, preventing silent connection loss due to broker `consumer_timeout`
- **Consistent behaviour**: FunctionRouter connectors now match the delivery semantics of Lambda, Content, Slack and all other connectors

## Trade-offs / Considerations

- **At-least-once (not exactly-once)**: there is a narrow window between `get()` returning and the physical ACK being sent (microseconds, no user code runs in between). A pod crash in that window would cause the message to be redelivered. This is identical to the risk in all other connectors and is inherent to AMQP without transactions.
- **AMQP thread is blocked**: the listener thread now waits for the executor thread. Throughput scales horizontally via `FUNCTIONROUTER_CONSUMER_CONCURRENCY` and the executor thread pool size — set both to the same value for optimal resource utilisation.
- **On `TimeoutException`**: the AMQP thread throws `MessagingException` which triggers Spring Cloud Stream's error handling (dead-letter queue or requeue, depending on configuration). The message is **not** silently lost.

## Configuration

| Property | Default | Description |
|---|---|---|
| `activiti.cloud.messaging.function-router.processing-timeout` | `120s` | Maximum time the AMQP thread will block waiting for the executor to complete. Should be set above the maximum expected HTTP response time. |

## Changes

- **`FunctionRouterConfiguration`**: replaced `completed.thenAccept(results -> { ... })` with `completed.get(processingTimeout, MILLISECONDS)` and explicit `InterruptedException` / `ExecutionException` / `TimeoutException` handling; inlined the result-handling logic; updated error unwrapping to handle both `CompletionException` and plain `Throwable`.
- **`ActivitiCloudMessagingProperties`**: added `processingTimeout` field (default `Duration.ofSeconds(120)`) to `FunctionRouter` inner class.

## Test

- **`FunctionRouterBindingConfigurationIT`**: added regression test `callerThreadShouldBlockUntilFunctionRouterCompletesProcessing()` — sends a message on a background thread, records `callerReturnTime` when `input.send()` returns, then asserts that `callerReturnTime >= processingEndTime` (i.e. the caller cannot return before the connector has finished processing the message)

## Related PRs

- `hxp-process-services` #5142 — Rest Connector cleanup (removes now-obsolete `CallerRunsPolicy` / bounded queue): https://github.com/Alfresco/hxp-process-services/pull/5142
- `hxp-studio-services` #7098 — DeploymentService cleanup (removes `REST_CONNECTOR_EXECUTOR_QUEUE_CAPACITY` from ConfigMap): https://github.com/Alfresco/hxp-studio-services/pull/7098

## Issue

https://hyland.atlassian.net/browse/AAE-45411

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

**Does this PR need propagation to upstream?** (check one with "x")

- [ ] Yes
- [X] No
