### PR TITLE
AAE-46487 Fix the order of producer audit events is not preserved for multi-instance parallel async tasks

### DIFF
--- a/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
+++ b/activiti-cloud-examples/example-runtime-bundle/starter/src/test/java/org/activiti/cloud/runtime/RuntimeBundleApplicationIT.java
@@ -190,4 +190,23 @@ public class RuntimeBundleApplicationIT {
         assertThat(environment.getProperty("spring.cloud.stream.rabbit.default.producer.prefix", String.class))
             .isNullOrEmpty();
     }
+
+    @Test
+    void transactedProducerBindings() {
+        assertThat(
+            environment.getProperty(
+                "spring.cloud.stream.rabbit.bindings.auditProducer.producer.transacted",
+                Boolean.class
+            )
+        )
+            .isTrue();
+
+        assertThat(
+            environment.getProperty(
+                "spring.cloud.stream.rabbit.bindings.asyncExecutorJobsOutput.producer.transacted",
+                Boolean.class
+            )
+        )
+            .isTrue();
+    }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -9,6 +9,7 @@ activiti.spring.cache-manager.caches.processDefinitions.caffeine.spec=maximumSiz
 
 #ensures that producer participates in the Spring transactions
 spring.cloud.stream.rabbit.bindings.auditProducer.producer.transacted=${ACT_AUDIT_PRODUCER_TRANSACTED:true}
+spring.cloud.stream.rabbit.bindings.asyncExecutorJobsOutput.producer.transacted=${ACT_AUDIT_PRODUCER_TRANSACTED:true}
 spring.cloud.stream.kafka.binder.transaction.transactionIdPrefix=${ACT_AUDIT_PRODUCER_TRANSACTION_ID_PREFIX:tx-}
 
 #disables zipkin reporting

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/ActivitiCloudMessagingProperties.java
@@ -442,6 +442,8 @@ public class ActivitiCloudMessagingProperties {
 
         private Duration retryInterval = Duration.ofMillis(10);
 
+        private Duration requestTimeout = Duration.ofSeconds(15);
+
         @NestedConfigurationProperty
         private final FunctionRouterAnonymousProperties anonymous = new FunctionRouterAnonymousProperties();
 
@@ -624,7 +626,8 @@ public class ActivitiCloudMessagingProperties {
                 retryInterval,
                 consumer,
                 anonymous,
-                errorHandlerDefinition
+                errorHandlerDefinition,
+                requestTimeout
             );
         }
 
@@ -641,6 +644,7 @@ public class ActivitiCloudMessagingProperties {
                 .add("consumer=" + consumer)
                 .add("anonymous=" + anonymous)
                 .add("errorHandlerDefinition=" + errorHandlerDefinition)
+                .add("requestTimeout=" + requestTimeout)
                 .toString();
         }
 
@@ -654,6 +658,14 @@ public class ActivitiCloudMessagingProperties {
 
         public void setErrorHandlerDefinition(String errorHandlerDefinition) {
             this.errorHandlerDefinition = errorHandlerDefinition;
+        }
+
+        public Duration getRequestTimeout() {
+            return requestTimeout;
+        }
+
+        public void setRequestTimeout(Duration requestTimeout) {
+            this.requestTimeout = requestTimeout;
         }
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterConfiguration.java
@@ -137,8 +137,10 @@ public class FunctionRouterConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    Function<String, ExecutorService> functionRouterExecutorFactory() {
-        return new FunctionRouterExecutorFactory();
+    Function<String, ExecutorService> functionRouterExecutorFactory(
+        ActivitiCloudMessagingProperties messagingProperties
+    ) {
+        return new FunctionRouterExecutorFactory(messagingProperties.getFunctionRouter().getRequestTimeout());
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -35,7 +35,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
     private static final int SINGLE_THREAD_POOL_SIZE = 1;
 
     private final RejectedExecutionHandler taskExecutionHandler = (runnable, executor) -> {
-        if (executor.isShutdown()) {
+        if (executor.isShutdown() || executor.isTerminating()) {
             throw new RejectedExecutionException("Executor has been shutdown");
         }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -42,8 +42,10 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         try {
             // This forces the submitting thread to block and wait
             // until the queue can accept the task.
-            if (!executor.getQueue().offer(runnable, timeout.getSeconds(), TimeUnit.SECONDS)) {
-                throw new RejectedExecutionException("Timeout after %s because queue is full".formatted(timeout));
+            if (!executor.getQueue().offer(runnable, timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new RejectedExecutionException(
+                    "Timeout after %s duration because the queue is full".formatted(timeout)
+                );
             }
         } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -34,6 +34,12 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
     private Duration timeout = Duration.ofSeconds(5);
     private static final int SINGLE_THREAD_POOL_SIZE = 1;
 
+    public FunctionRouterExecutorFactory() {}
+
+    public FunctionRouterExecutorFactory(Duration timeout) {
+        this.timeout = timeout;
+    }
+
     private final RejectedExecutionHandler taskExecutionHandler = (runnable, executor) -> {
         if (executor.isShutdown() || executor.isTerminating()) {
             throw new RejectedExecutionException("Executor has been shutdown");
@@ -115,6 +121,10 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
             .allOf(cfs.toArray(CompletableFuture[]::new))
             .thenApply(v -> cfs.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals))
             .join();
+    }
+
+    public Duration getTimeout() {
+        return this.timeout;
     }
 
     public void setTimeout(Duration timeout) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -21,7 +21,10 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -30,13 +33,32 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
     private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
     private Duration timeout = Duration.ofSeconds(5);
 
-    private final Function<String, ExecutorService> executorServiceFactory = registration ->
-        Executors.newSingleThreadScheduledExecutor(runnable -> {
-            final var thread = new Thread(runnable);
-            thread.setName(registration);
+    private final RejectedExecutionHandler taskExecutionHandler = (runnable, executor) -> {
+        if (executor.isShutdown()) {
+            throw new RejectedExecutionException("Executor has been shutdown");
+        }
 
-            return thread;
-        });
+        try {
+            // This forces the submitting thread to block and wait
+            // until the queue can accept the task.
+            if (!executor.getQueue().offer(runnable, 15, TimeUnit.SECONDS)) {
+                throw new RejectedExecutionException("Queue is full");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    };
+
+    private final Function<String, ExecutorService> executorServiceFactory = registration ->
+        new ThreadPoolExecutor(
+            1,
+            1,
+            0L,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(1),
+            Thread.ofPlatform().name(registration).factory(),
+            taskExecutionHandler
+        );
 
     @Override
     public ExecutorService apply(String key) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -32,7 +32,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
 
     private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
     private Duration timeout = Duration.ofSeconds(5);
-    private final int concurrency = 1;
+    private static final int SINGLE_THREAD_POOL_SIZE = 1;
 
     private final RejectedExecutionHandler taskExecutionHandler = (runnable, executor) -> {
         if (executor.isShutdown()) {
@@ -47,15 +47,17 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
                     "Timeout after %s duration because the queue is full".formatted(timeout)
                 );
             }
-        } catch (InterruptedException ignored) {
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+
+            throw new RejectedExecutionException("Interrupted while waiting for queue capacity", e);
         }
     };
 
     private final Function<String, ExecutorService> executorServiceFactory = registration ->
         new ThreadPoolExecutor(
-            concurrency,
-            concurrency,
+            SINGLE_THREAD_POOL_SIZE,
+            SINGLE_THREAD_POOL_SIZE,
             0L,
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(1),

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -18,10 +18,10 @@ package org.activiti.cloud.common.messaging.config;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -60,7 +60,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
             SINGLE_THREAD_POOL_SIZE,
             0L,
             TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(1),
+            new ArrayBlockingQueue<>(1, true),
             Thread.ofPlatform().name(registration).factory(),
             taskExecutionHandler
         );

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactory.java
@@ -32,6 +32,7 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
 
     private final Map<String, ExecutorService> executors = new ConcurrentHashMap<>();
     private Duration timeout = Duration.ofSeconds(5);
+    private final int concurrency = 1;
 
     private final RejectedExecutionHandler taskExecutionHandler = (runnable, executor) -> {
         if (executor.isShutdown()) {
@@ -41,18 +42,18 @@ public class FunctionRouterExecutorFactory implements Function<String, ExecutorS
         try {
             // This forces the submitting thread to block and wait
             // until the queue can accept the task.
-            if (!executor.getQueue().offer(runnable, 15, TimeUnit.SECONDS)) {
-                throw new RejectedExecutionException("Queue is full");
+            if (!executor.getQueue().offer(runnable, timeout.getSeconds(), TimeUnit.SECONDS)) {
+                throw new RejectedExecutionException("Timeout after %s because queue is full".formatted(timeout));
             }
-        } catch (InterruptedException e) {
+        } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();
         }
     };
 
     private final Function<String, ExecutorService> executorServiceFactory = registration ->
         new ThreadPoolExecutor(
-            1,
-            1,
+            concurrency,
+            concurrency,
             0L,
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(1),

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/resources/config/activiti-cloud-messaging.properties
@@ -44,3 +44,4 @@ spring.cloud.stream.rabbit.default.producer.prefix=${activiti.cloud.messaging.ra
 spring.cloud.stream.rabbit.default.consumer.prefix=${activiti.cloud.messaging.rabbitmq.prefix:}
 
 activiti.cloud.messaging.function-router.error-handler-definition=${spring.cloud.stream.default.error-handler-definition:}
+activiti.cloud.messaging.function-router.request-timeout=15s

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
@@ -103,15 +103,17 @@ class FunctionRouterExecutorFactoryTest {
 
         executor.submit(() -> {});
 
-        final var submitter = Thread.ofPlatform().start(() -> {
-            try {
-                Thread.currentThread().interrupt();
-                executor.submit(() -> {});
-                interrupted.set(Thread.currentThread().isInterrupted());
-            } catch (Throwable throwable) {
-                thrown.set(throwable);
-            }
-        });
+        final var submitter = Thread
+            .ofPlatform()
+            .start(() -> {
+                try {
+                    Thread.currentThread().interrupt();
+                    executor.submit(() -> {});
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                } catch (Throwable throwable) {
+                    thrown.set(throwable);
+                }
+            });
 
         submitter.join(TimeUnit.SECONDS.toMillis(5));
         releaseTask.countDown();

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class FunctionRouterExecutorFactoryTest {
+
+    private final FunctionRouterExecutorFactory factory = new FunctionRouterExecutorFactory();
+
+    @AfterEach
+    void tearDown() {
+        factory.destroy();
+    }
+
+    @Test
+    void shouldReuseExecutorsPerRegistration() {
+        final var firstExecutor = factory.apply("foo-registration");
+        final var sameRegistrationExecutor = factory.apply("foo-registration");
+        final var differentRegistrationExecutor = factory.apply("bar-registration");
+
+        assertThat(firstExecutor).isSameAs(sameRegistrationExecutor);
+        assertThat(differentRegistrationExecutor).isNotSameAs(firstExecutor);
+    }
+
+    @Test
+    void shouldRejectTasksAfterShutdown() {
+        final var executor = factory.apply("foo-registration");
+
+        executor.shutdown();
+
+        assertThatThrownBy(() -> executor.submit(() -> {}))
+            .isInstanceOf(RejectedExecutionException.class)
+            .hasMessage("Executor has been shutdown");
+    }
+
+    @Test
+    void shouldRejectTasksWhenQueueRemainsFullUntilTimeout() throws InterruptedException {
+        factory.setTimeout(Duration.ofMillis(20));
+
+        final var executor = factory.apply("foo-registration");
+        final var taskStarted = new CountDownLatch(1);
+        final var releaseTask = new CountDownLatch(1);
+        final var queuedTaskExecuted = new CountDownLatch(1);
+
+        executor.submit(() -> {
+            taskStarted.countDown();
+            await(releaseTask);
+        });
+
+        assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        executor.submit(queuedTaskExecuted::countDown);
+
+        assertThatThrownBy(() -> executor.submit(() -> {}))
+            .isInstanceOf(RejectedExecutionException.class)
+            .hasMessageContaining("queue is full");
+
+        releaseTask.countDown();
+
+        assertThat(queuedTaskExecuted.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void shouldRestoreInterruptStatusWhenInterruptedWhileWaitingForQueueCapacity() throws InterruptedException {
+        factory.setTimeout(Duration.ofSeconds(1));
+
+        final var executor = factory.apply("foo-registration");
+        final var taskStarted = new CountDownLatch(1);
+        final var releaseTask = new CountDownLatch(1);
+        final var interrupted = new AtomicBoolean();
+        final var thrown = new AtomicReference<Throwable>();
+
+        executor.submit(() -> {
+            taskStarted.countDown();
+            await(releaseTask);
+        });
+
+        assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        executor.submit(() -> {});
+
+        final var submitter = Thread.ofPlatform().start(() -> {
+            try {
+                Thread.currentThread().interrupt();
+                executor.submit(() -> {});
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable throwable) {
+                thrown.set(throwable);
+            }
+        });
+
+        submitter.join(TimeUnit.SECONDS.toMillis(5));
+        releaseTask.countDown();
+
+        assertThat(submitter.isAlive()).isFalse();
+        assertThat(thrown.get()).isNull();
+        assertThat(interrupted.get()).isTrue();
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
@@ -117,8 +117,9 @@ class FunctionRouterExecutorFactoryTest {
                 }
             });
 
-        submitter.join(TimeUnit.MILLISECONDS.toMillis(200));
+        submitter.join(TimeUnit.MILLISECONDS.toMillis(2));
         releaseTask.countDown();
+        submitter.join(TimeUnit.MILLISECONDS.toMillis(2));
 
         assertThat(submitter.isAlive()).isFalse();
         assertThat(thrown.get()).isInstanceOf(RejectedExecutionException.class);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
@@ -71,7 +71,7 @@ class FunctionRouterExecutorFactoryTest {
             await(releaseTask);
         });
 
-        assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskStarted.await(200, TimeUnit.MILLISECONDS)).isTrue();
 
         executor.submit(queuedTaskExecuted::countDown);
 
@@ -81,12 +81,12 @@ class FunctionRouterExecutorFactoryTest {
 
         releaseTask.countDown();
 
-        assertThat(queuedTaskExecuted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(queuedTaskExecuted.await(200, TimeUnit.MILLISECONDS)).isTrue();
     }
 
     @Test
     void shouldRestoreInterruptStatusWhenInterruptedWhileWaitingForQueueCapacity() throws InterruptedException {
-        factory.setTimeout(Duration.ofSeconds(1));
+        factory.setTimeout(Duration.ofMillis(200));
 
         final var executor = factory.apply("foo-registration");
         final var taskStarted = new CountDownLatch(1);
@@ -99,7 +99,7 @@ class FunctionRouterExecutorFactoryTest {
             await(releaseTask);
         });
 
-        assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskStarted.await(200, TimeUnit.MILLISECONDS)).isTrue();
 
         executor.submit(() -> {});
 
@@ -115,7 +115,7 @@ class FunctionRouterExecutorFactoryTest {
                 }
             });
 
-        submitter.join(TimeUnit.SECONDS.toMillis(5));
+        submitter.join(TimeUnit.MILLISECONDS.toMillis(200));
         releaseTask.countDown();
 
         assertThat(submitter.isAlive()).isFalse();

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/FunctionRouterExecutorFactoryTest.java
@@ -112,6 +112,8 @@ class FunctionRouterExecutorFactoryTest {
                     interrupted.set(Thread.currentThread().isInterrupted());
                 } catch (Throwable throwable) {
                     thrown.set(throwable);
+                } finally {
+                    interrupted.set(Thread.currentThread().isInterrupted());
                 }
             });
 
@@ -119,7 +121,7 @@ class FunctionRouterExecutorFactoryTest {
         releaseTask.countDown();
 
         assertThat(submitter.isAlive()).isFalse();
-        assertThat(thrown.get()).isNull();
+        assertThat(thrown.get()).isInstanceOf(RejectedExecutionException.class);
         assertThat(interrupted.get()).isTrue();
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -128,6 +128,7 @@ import tools.jackson.databind.ObjectMapper;
         "activiti.cloud.messaging.function-router.routes.auditProducer.override-required-producer-groups=consumer",
         "activiti.cloud.messaging.function-router.routes.auditProducerIncidents.override-required-producer-groups=consumer",
         "activiti.cloud.messaging.function-router.anonymous.consumer.concurrency=2",
+        "activiti.cloud.messaging.function-router.request-timeout=1s",
     }
 )
 @EnableTestBinder
@@ -708,6 +709,7 @@ public class FunctionRouterBindingConfigurationIT {
     void messagingProperties() {
         assertThat(messagingProperties.getFunctionRouter().getMaxRetries()).isEqualTo(4);
         assertThat(messagingProperties.getFunctionRouter().getRetryInterval()).isEqualTo(Duration.ofMillis(100));
+        assertThat(messagingProperties.getFunctionRouter().getRequestTimeout()).isEqualTo(Duration.ofSeconds(1));
     }
 
     @Test
@@ -920,7 +922,6 @@ public class FunctionRouterBindingConfigurationIT {
     @Test
     void functionExecutorShouldAwaitTerminatingTasksOnDestroy() throws InterruptedException, ExecutionException {
         //given
-        functionRouterExecutorFactory.setTimeout(Duration.ofMillis(1000));
         final Message<String> message = MessageBuilder
             .withPayload("foo")
             .setHeader(FUNCTION_DEFINITION, "foo_registration")
@@ -948,6 +949,11 @@ public class FunctionRouterBindingConfigurationIT {
         //then
         assertThat(futureResult.get()).isNull();
         assertThatThrownBy(() -> functionExecutor.submit(() -> {})).isInstanceOf(RejectedExecutionException.class);
+    }
+
+    @Test
+    void functionRouterExecutorFactoryTimeout() {
+        assertThat(functionRouterExecutorFactory.getTimeout()).isEqualTo(Duration.ofSeconds(1));
     }
 
     void withRabbitMqPrefix(String prefix, Consumer<String> runnable) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/FunctionRouterBindingConfigurationIT.java
@@ -914,7 +914,7 @@ public class FunctionRouterBindingConfigurationIT {
 
         //then
         assertThat(executionThreadMap.values().stream().distinct().count()).isEqualTo(1);
-        assertThat(IntStream.range(0, 100).boxed().toList()).isEqualTo(executionOrder);
+        assertThat(executionOrder).isEqualTo(IntStream.range(0, 100).boxed().toList());
     }
 
     @Test


### PR DESCRIPTION
This PR makes two functional changes and adds coverage around them:

- it enables transactions for the `asyncExecutorJobsOutput` Rabbit producer in the runtime bundle starter, aligning it with `auditProducer` so related events are published consistently
- it refactors `FunctionRouterExecutorFactory` to use a single-thread `ThreadPoolExecutor` with bounded-queue backpressure, so routed messages are processed strictly in submission order instead of being reordered under load
- it makes `FunctionRouterExecutorFactory` request timeout configurable via configuration properties
- it adds/updates integration tests to verify the transactional producer properties and to assert the sequential execution/order guarantee

https://hyland.atlassian.net/browse/AAE-46487