### PR TITLE
AAE-46388 Fix DependaBot config to ignore gh-aw-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,4 +34,4 @@ updates:
           - "patch"
     ignore:
       # Managed by gh aw add. Version-locked to the gh-aw compiler; do not bump.
-      - dependency-name: "github/gh-aw-actions/**"
+      - dependency-name: "github/gh-aw-actions"


### PR DESCRIPTION
Fixes the DependaBot configuration to properly ignore gh-aw-actions dependencies.

## Changes
- Updated `.github/dependabot.yml` exclusion pattern from `github/gh-aw-actions/**` to `github/gh-aw-actions`

## Reason
The wildcard pattern `/**` was overly specific. The simplified pattern `github/gh-aw-actions` correctly ignores all actions under this namespace while maintaining cleaner configuration.