### PR TITLE
AAE-46386 Set DependaBot cooldown for all ecosystems as 3d

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,6 @@ updates:
       - "/.github/actions/project-models-cleanup"
     schedule:
       interval: "weekly"
-      day: "sunday"
     cooldown:
       default-days: 3
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "org.activiti:*"
       - dependency-name: "org.assertj:assertj-core"
@@ -25,6 +27,8 @@ updates:
     - "/.github/actions/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,28 @@ updates:
     ignore:
       # Managed by gh aw add. Version-locked to the gh-aw compiler; do not bump.
       - dependency-name: "github/gh-aw-actions"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/.github/actions/force-full-model-cleanup"
+      - "/.github/actions/project-models-cleanup"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    cooldown:
+      default-days: 3
+    groups:
+      framework:
+        patterns:
+          - "@playwright/test"
+        update-types:
+          - "minor"
+          - "patch"
+      tools:
+        patterns:
+          - "dotenv*"
+          - "winston"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Configure DependaBot cooldown period for all package ecosystems.

## Changes
- Added `cooldown` with `default-days: 3` as a sibling to `schedule` in `.github/dependabot.yml`

## Rationale
Setting a 3-day cooldown period helps prevent DependaBot from proposing dependencies which would be vectors for supply chain attacks as soon as they are released.
