### PR TITLE
AAE-46649 Fix flaky runtime acceptance tests

### DIFF
--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/process-instance-subprocess-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/process-instance-subprocess-actions.spec.ts
@@ -34,8 +34,13 @@ async function expectProcessCompleted(
 ): Promise<void> {
     await expect
         .poll(async () => {
-            const instance = await queryService.getProcessInstance(processInstanceId);
-            return instance.status;
+            try {
+                const instance = await queryService.getProcessInstance(processInstanceId);
+                return instance.status;
+            } catch {
+                // Query DB may not have ingested the instance yet — keep polling.
+                return undefined;
+            }
         }, pollOptions('querySync'))
         .toBe(ProcessInstanceStatus.COMPLETED);
 }

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/process-instance-subprocess-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/process-instance-subprocess-actions.spec.ts
@@ -37,9 +37,12 @@ async function expectProcessCompleted(
             try {
                 const instance = await queryService.getProcessInstance(processInstanceId);
                 return instance.status;
-            } catch {
+            } catch (error) {
                 // Query DB may not have ingested the instance yet — keep polling.
-                return undefined;
+                if (error instanceof Error && /Unable to find process instance/.test(error.message)) {
+                    return undefined;
+                }
+                throw error;
             }
         }, pollOptions('querySync'))
         .toBe(ProcessInstanceStatus.COMPLETED);

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-actions.spec.ts
@@ -91,8 +91,12 @@ activiti.describe('Runtime — Task Actions', { tag: '@slow' }, () => {
                     try {
                         await queryServiceTestUser.getProcessInstance(processInstanceId);
                         return true;
-                    } catch {
-                        return false;
+                    } catch (error) {
+                        // Query DB may not have ingested the instance yet — keep polling.
+                        if (error instanceof Error && /Unable to find process instance/.test(error.message)) {
+                            return false;
+                        }
+                        throw error;
                     }
                 }, pollOptions('querySync'))
                 .toBe(true);

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-actions.spec.ts
@@ -85,6 +85,18 @@ activiti.describe('Runtime — Task Actions', { tag: '@slow' }, () => {
         });
 
         await activiti.step('Then the task has the formKey field and correct processInstance fields', async () => {
+            // Wait for the query DB to ingest the freshly-started process instance.
+            await expect
+                .poll(async () => {
+                    try {
+                        await queryServiceTestUser.getProcessInstance(processInstanceId);
+                        return true;
+                    } catch {
+                        return false;
+                    }
+                }, pollOptions('querySync'))
+                .toBe(true);
+
             const processFromQuery = await queryServiceTestUser.getProcessInstance(processInstanceId);
             expect(processFromQuery).toBeTruthy();
 
@@ -237,6 +249,11 @@ activiti.describe('Runtime — Task Actions', { tag: '@slow' }, () => {
             expect(rbTask.dueDate).toBeTruthy();
             expect(rbTask.formKey).toBe('new-task-form-key');
 
+            // Audit event for TASK_UPDATED may arrive before the query DB projection is refreshed.
+            await expect
+                .poll(async () => (await queryServiceTestUser.getTaskById(taskId))?.name, pollOptions('querySync'))
+                .toBe('new-task-name');
+
             const queryTask = await queryServiceTestUser.getTaskById(taskId);
             expect(queryTask?.name).toBe('new-task-name');
             expect(queryTask?.priority).toBe(3);
@@ -351,6 +368,11 @@ activiti.describe('Runtime — Task Actions', { tag: '@slow' }, () => {
             expect(rbTask.priority).toBe(3);
             expect(rbTask.dueDate).toBeTruthy();
             expect(rbTask.formKey).toBe('new-task-form-key');
+
+            // Audit event for TASK_UPDATED may arrive before the query DB projection is refreshed.
+            await expect
+                .poll(async () => (await queryServiceTestUser.getTaskById(taskId))?.name, pollOptions('querySync'))
+                .toBe('new-task-name');
 
             const queryTask = await queryServiceTestUser.getTaskById(taskId);
             expect(queryTask?.name).toBe('new-task-name');

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-extended.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-extended.spec.ts
@@ -225,8 +225,12 @@ activiti.describe('Runtime — Task Actions (wave 2)', () => {
                     try {
                         const instance = await queryServiceTestUser.getProcessInstance(processInstanceId);
                         return instance.status;
-                    } catch {
-                        return undefined;
+                    } catch (error) {
+                        // Query DB may not have ingested the instance yet — keep polling.
+                        if (error instanceof Error && /Unable to find process instance/.test(error.message)) {
+                            return undefined;
+                        }
+                        throw error;
                     }
                 }, pollOptions('querySync'))
                 .toBe(ProcessInstanceStatus.COMPLETED);

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-extended.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/task-extended.spec.ts
@@ -20,6 +20,7 @@ import { startCatalogProcessWithFirstTask } from '../../flows/start-process-with
 import { ProcessInstanceStatus } from '../../models/runtime-bundle.models';
 import { TaskStatus } from '../../models/task.models';
 import { scopedName } from '../../helpers/test-isolation';
+import { pollOptions } from '../../config/runtime/timeouts';
 import {
     expectClientError,
     expectProcessAndTaskCompleted,
@@ -221,9 +222,13 @@ activiti.describe('Runtime — Task Actions (wave 2)', () => {
         await activiti.step('Then the process is completed', async () => {
             await expect
                 .poll(async () => {
-                    const instance = await queryServiceTestUser.getProcessInstance(processInstanceId);
-                    return instance.status;
-                })
+                    try {
+                        const instance = await queryServiceTestUser.getProcessInstance(processInstanceId);
+                        return instance.status;
+                    } catch {
+                        return undefined;
+                    }
+                }, pollOptions('querySync'))
                 .toBe(ProcessInstanceStatus.COMPLETED);
         });
     });


### PR DESCRIPTION
Problem: Several Playwright tests intermittently failed with Unable to find process instance for the given id:'…' or undefined task-field reads. Root cause: tests called QueryService.getProcessInstance(...) / getTaskById(...) immediately after a runtime-bundle write, before the messaging pipeline (RabbitMQ/Kafka) had propagated the event into the query-service projection.

Fix applied: Wrap the affected reads in expect.poll(..., pollOptions('querySync')) callbacks that tolerate the transient "not found" / undefined state, matching the proven pattern already used in signal-actions / timer-actions / service-tasks-actions.