### PR TITLE
AAE-46906 Enhance partitioned Query Consumer performance

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.springframework.integration</groupId>
+          <artifactId>spring-integration-test</artifactId>
+          <scope>test</scope>
+      </dependency>
 
   </dependencies>
   <build>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
 
 @AutoConfiguration
 @Import(QueryConsumerChannelsConfiguration.class)
@@ -41,6 +42,7 @@ public class QueryConsumerAutoConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryConsumerAutoConfiguration.class);
     public static final String PARTITIONED_QUERY_CONSUMER_INTEGRATION_FLOW_INPUT =
         "partitionedQueryConsumerIntegrationFlowInput";
+    public static final String PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL = "partitionedQueryConsumerErrorChannel";
 
     @Bean
     InitializingBean queryConsumerAutoConfigurationInfo(
@@ -74,6 +76,24 @@ public class QueryConsumerAutoConfiguration {
     }
 
     @Bean
+    public IntegrationFlow partitionedQueryConsumerErrorIntegrationFlow() {
+        return IntegrationFlow
+            .from(PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL)
+            .handle(message -> {
+                final var errorMessage = ErrorMessage.class.cast(message);
+                final var exception = errorMessage.getPayload();
+
+                LOGGER.error(
+                    "Error {} handling message {} in partition {}",
+                    exception.getMessage(),
+                    errorMessage.getOriginalMessage(),
+                    Thread.currentThread().getName()
+                );
+            })
+            .get();
+    }
+
+    @Bean
     public IntegrationFlow partitionedQueryConsumerIntegrationFlow(
         QueryConsumerPartitionedChannelCountProvider queryConsumerPartitionedChannelCountProvider,
         QueryConsumerPartitionedChannelKeySelector queryConsumerPartitionedChannelKeySelector,
@@ -82,13 +102,14 @@ public class QueryConsumerAutoConfiguration {
     ) {
         return IntegrationFlow
             .from(PARTITIONED_QUERY_CONSUMER_INTEGRATION_FLOW_INPUT)
+            .enrichHeaders(headers -> headers.errorChannel(PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL))
             .channel(
                 MessageChannels
                     .partitioned(queryConsumerPartitionedChannelCountProvider.get())
                     .partitionKey(queryConsumerPartitionedChannelKeySelector)
                     .workerQueueSize(workerQueueSize)
             )
-            .handle(genericQueryConsumerChannelHandlerAdapter)
+            .handle(genericQueryConsumerChannelHandlerAdapter, endpoint -> endpoint.requiresReply(false))
             .get();
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.conf;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
@@ -80,15 +81,23 @@ public class QueryConsumerAutoConfiguration {
         return IntegrationFlow
             .from(PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL)
             .handle(message -> {
-                final var errorMessage = ErrorMessage.class.cast(message);
-                final var exception = errorMessage.getPayload();
+                if (message instanceof ErrorMessage errorMessage) {
+                    final var exception = errorMessage.getPayload();
 
-                LOGGER.error(
-                    "Error {} handling message {} in partition {}",
-                    exception.getMessage(),
-                    errorMessage.getOriginalMessage(),
-                    Thread.currentThread().getName()
-                );
+                    LOGGER.error(
+                        "Error {} handling message {} in partition {}",
+                        exception.getMessage(),
+                        errorMessage.getOriginalMessage(),
+                        Thread.currentThread().getName(),
+                        Optional.ofNullable(exception.getCause()).orElse(exception)
+                    );
+                } else {
+                    LOGGER.error(
+                        "Unexpected message type on {}: {}",
+                        PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL,
+                        message
+                    );
+                }
             })
             .get();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
@@ -85,7 +85,7 @@ public class QueryConsumerAutoConfiguration {
                     final var exception = errorMessage.getPayload();
 
                     LOGGER.error(
-                        "Error {} handling message {} in partition {}",
+                        "{} while handling {} for partition thread {}",
                         exception.getMessage(),
                         errorMessage.getOriginalMessage(),
                         Thread.currentThread().getName(),
@@ -93,7 +93,8 @@ public class QueryConsumerAutoConfiguration {
                     );
                 } else {
                     LOGGER.error(
-                        "Unexpected message type on {}: {}",
+                        "Unexpected message type {} on {}: {}",
+                        message.getClass(),
                         PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL,
                         message
                     );
@@ -128,7 +129,7 @@ public class QueryConsumerAutoConfiguration {
     ) {
         return (events, headers) -> {
             LOGGER.debug(
-                "Handling {} events with root process instance id {} on thread: {}",
+                "Handling {} events with root process instance id {} on partition thread: {}",
                 events.size(),
                 headers.get(QueryConsumerPartitionedChannelKeySelector.ROOT_PROCESS_INSTANCE_ID),
                 Thread.currentThread().getName()

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/QueryConsumerAutoConfigurationTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/QueryConsumerAutoConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.conf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.test.context.SpringIntegrationTest;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringIntegrationTest
+@SpringJUnitConfig(QueryConsumerAutoConfigurationTest.TestConfiguration.class)
+@ExtendWith(OutputCaptureExtension.class)
+class QueryConsumerAutoConfigurationTest {
+
+    @Autowired
+    private MessageChannel partitionedQueryConsumerErrorChannel;
+
+    @Test
+    void shouldHandleErrorMessageInPartitionedQueryConsumerErrorIntegrationFlow(CapturedOutput output) {
+        ErrorMessage errorMessage = new ErrorMessage(
+            new MessagingException("Error message"),
+            MessageBuilder.withPayload("payload").build()
+        );
+
+        assertThat(partitionedQueryConsumerErrorChannel).isNotNull();
+        assertThatCode(() -> partitionedQueryConsumerErrorChannel.send(errorMessage)).doesNotThrowAnyException();
+        assertThat(output).contains("Error message while handling GenericMessage [payload=payload");
+    }
+
+    @Test
+    void shouldHandleUnexpectedMessageTypeInPartitionedQueryConsumerErrorIntegrationFlow(CapturedOutput output) {
+        assertThatCode(() -> partitionedQueryConsumerErrorChannel.send(MessageBuilder.withPayload("unexpected").build())
+            )
+            .doesNotThrowAnyException();
+        assertThat(output)
+            .contains(" Unexpected message type class org.springframework.messaging.support.GenericMessage");
+    }
+
+    @Configuration
+    @EnableIntegration
+    static class TestConfiguration {
+
+        @Bean
+        IntegrationFlow partitionedQueryConsumerErrorIntegrationFlow() {
+            return new QueryConsumerAutoConfiguration().partitionedQueryConsumerErrorIntegrationFlow();
+        }
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/resources/logback-test.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <include resource="org/springframework/boot/logging/logback/base.xml" />
-  <root level="OFF" />
+  <root level="ERROR" />
 </configuration>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/app/QueryConsumerChannelHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/app/QueryConsumerChannelHandler.java
@@ -42,7 +42,7 @@ public class QueryConsumerChannelHandler {
         this.entityManager = entityManager;
     }
 
-    public synchronized void receive(List<CloudRuntimeEvent<?, ?>> events) {
+    public void receive(List<CloudRuntimeEvent<?, ?>> events) {
         afterCompletion(entityManager::clear);
         eventHandlerContext.handle(optimizer.optimize(events).toArray(new CloudRuntimeEvent[] {}));
     }


### PR DESCRIPTION
Improves throughput of the partitioned Query Consumer by removing unnecessary serialization in event handling and by routing handler exceptions to a dedicated Spring Integration error channel for logging.

**Changes:**
- Removed `synchronized` from `QueryConsumerChannelHandler.receive(...)` to allow concurrent processing across partitions.
- Added a dedicated `partitionedQueryConsumerErrorChannel` and an `IntegrationFlow` to consume/log errors from partition workers.
- Configured the partitioned integration flow to use the new error channel and to not require replies from the handler endpoint.
- Added AssertJ-based test coverage in `QueryConsumerAutoConfigurationTest` for `partitionedQueryConsumerErrorIntegrationFlow`, including both `ErrorMessage` handling and unexpected message-type handling.

https://hyland.atlassian.net/browse/AAE-46906