### PR TITLE
AAE-45916 Common Zip Protection in all BE projects

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/SafeZipExtractor.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/SafeZipExtractor.java
@@ -83,7 +83,7 @@ public final class SafeZipExtractor {
                 validateExtension(name, limits);
 
                 byte[] entryBytes = readEntryWithLimits(zis, counting, name, totalDecompressedSize, limits);
-                if (entryBytes.length == 0) {
+                if (entryBytes.length == 0 && limits.rejectEmptyEntries()) {
                     throw new IOException(MessageFormat.format(FOLDERS_OR_EMPTY_ENTRIES_MESSAGE, name));
                 }
                 totalDecompressedSize += entryBytes.length;
@@ -329,7 +329,7 @@ public final class SafeZipExtractor {
                 }
                 out.write(buffer, 0, bytesRead);
             }
-            if (out.size() == 0) {
+            if (out.size() == 0 && limits.rejectEmptyEntries()) {
                 throw new IOException(MessageFormat.format(FOLDERS_OR_EMPTY_ENTRIES_MESSAGE, entry.getName()));
             }
             return out.toByteArray();

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/SafeZipLimits.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/main/java/org/activiti/cloud/services/common/zip/SafeZipLimits.java
@@ -28,6 +28,7 @@ public record SafeZipLimits(
     boolean allowDirectories,
     boolean flatEntryPaths,
     boolean rejectNestedZipEntries,
+    boolean rejectEmptyEntries,
     Set<String> allowedExtensions,
     Set<String> nestedZipAllowedExtensions,
     Predicate<byte[]> executableContentCheck
@@ -73,6 +74,7 @@ public record SafeZipLimits(
         private boolean allowDirectories = true;
         private boolean flatEntryPaths = false;
         private boolean rejectNestedZipEntries = false;
+        private boolean rejectEmptyEntries = false;
         private Set<String> allowedExtensions = Set.of();
         private Set<String> nestedZipAllowedExtensions = Set.of();
         private Predicate<byte[]> executableContentCheck = bytes -> false;
@@ -112,6 +114,11 @@ public record SafeZipLimits(
             return this;
         }
 
+        public Builder rejectEmptyEntries(boolean rejectEmptyEntries) {
+            this.rejectEmptyEntries = rejectEmptyEntries;
+            return this;
+        }
+
         public Builder allowedExtensions(Set<String> allowedExtensions) {
             this.allowedExtensions = allowedExtensions;
             return this;
@@ -136,6 +143,7 @@ public record SafeZipLimits(
                 allowDirectories,
                 flatEntryPaths,
                 rejectNestedZipEntries,
+                rejectEmptyEntries,
                 allowedExtensions,
                 nestedZipAllowedExtensions,
                 executableContentCheck

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorDiskTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorDiskTest.java
@@ -266,14 +266,44 @@ class SafeZipExtractorDiskTest {
     }
 
     @Test
-    void extractToDirectory_shouldThrow_whenFileEntryIsEmpty() throws IOException {
+    void extractToDirectory_shouldThrow_whenFileEntryIsEmptyAndEmptyEntriesRejected() throws IOException {
         Path zipPath = ZipTestFixtures.writeZipFile(tempDir, "empty.zip", ZipTestFixtures.entry("empty.txt", ""));
 
-        assertThatThrownBy(() ->
-                SafeZipExtractor.extractToDirectory(zipPath.toFile(), tempDir.resolve("out"), permissiveLimits())
-            )
+        SafeZipLimits limits = SafeZipLimits
+            .builder()
+            .maxEntries(10)
+            .maxEntryDecompressedBytes(1024 * KB)
+            .maxTotalDecompressedBytes(1024 * KB)
+            .rejectEmptyEntries(true)
+            .build();
+
+        assertThatThrownBy(() -> SafeZipExtractor.extractToDirectory(zipPath.toFile(), tempDir.resolve("out"), limits))
             .isInstanceOf(IOException.class)
             .hasMessageContaining("must not contain folders or empty entries");
+    }
+
+    @Test
+    void extractToDirectory_shouldCreateEmptyFile_whenEmptyEntriesNotRejected() throws IOException {
+        Path zipPath = ZipTestFixtures.writeZipFile(
+            tempDir,
+            "empty.zip",
+            ZipTestFixtures.entry("files/empty.bin", ""),
+            ZipTestFixtures.entry("files/data.txt", "content")
+        );
+        Path target = tempDir.resolve("out");
+
+        SafeZipLimits limits = SafeZipLimits
+            .builder()
+            .maxEntries(10)
+            .maxEntryDecompressedBytes(1024 * KB)
+            .maxTotalDecompressedBytes(1024 * KB)
+            .build();
+
+        SafeZipExtractor.extractToDirectory(zipPath.toFile(), target, limits);
+
+        assertThat(Files.isRegularFile(target.resolve("files/empty.bin"))).isTrue();
+        assertThat(Files.size(target.resolve("files/empty.bin"))).isZero();
+        assertThat(Files.readString(target.resolve("files/data.txt"))).isEqualTo("content");
     }
 
     @Test

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorTest.java
@@ -344,6 +344,28 @@ class SafeZipExtractorTest {
     }
 
     @Test
+    void extractEntries_shouldReturnEmptyEntry_whenEmptyEntriesNotRejected() throws IOException {
+        byte[] zip = ZipTestFixtures.zipBytes(
+            ZipTestFixtures.entry("empty.json", ""),
+            ZipTestFixtures.entry("data.json", "{}")
+        );
+
+        SafeZipLimits limits = SafeZipLimits
+            .builder()
+            .maxEntries(10)
+            .maxEntryDecompressedBytes(MB)
+            .maxTotalDecompressedBytes(MB)
+            .build();
+
+        var entries = SafeZipExtractor.extractEntries(new ByteArrayInputStream(zip), limits);
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries.getFirst().name()).isEqualTo("empty.json");
+        assertThat(entries.getFirst().content()).isEmpty();
+        assertThat(entries.getFirst().directory()).isFalse();
+    }
+
+    @Test
     void extractEntries_shouldThrow_when_totalDecompressedExceedsMaxSize() throws IOException {
         byte[] halfLimitPlusOne = ZipTestFixtures.incompressibleBytes(5 * 1024 * 1024 + 1);
         byte[] zip = ZipTestFixtures.zipBytes(
@@ -508,6 +530,7 @@ class SafeZipExtractorTest {
             .allowDirectories(false)
             .flatEntryPaths(true)
             .allowedExtensions(Set.of("json"))
+            .rejectEmptyEntries(true)
             .executableContentCheck(executableContentCheck)
             .build();
     }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipLimitsTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipLimitsTest.java
@@ -32,6 +32,7 @@ class SafeZipLimitsTest {
         assertThat(limits.allowDirectories()).isTrue();
         assertThat(limits.flatEntryPaths()).isFalse();
         assertThat(limits.rejectNestedZipEntries()).isFalse();
+        assertThat(limits.rejectEmptyEntries()).isFalse();
         assertThat(limits.allowedExtensions()).isEmpty();
         assertThat(limits.nestedZipAllowedExtensions()).isEmpty();
         assertThat(limits.executableContentCheck().test(new byte[0])).isFalse();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Other... Please describe:

## Description

- Issue Link: https://hyland.atlassian.net/browse/AAE-45916

Empty (zero-byte) zip entries are not a security concern, so `SafeZipExtractor` now allows them by default. Adds a `rejectEmptyEntries` option to `SafeZipLimits` (default `false`, consistent with `rejectNestedZipEntries`) for callers that want to keep rejecting empty entries (e.g. model import). Applies to both the streaming and on-disk extraction paths.

**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No