### PR TITLE
AEE-47003 Fix supply chain security alerts in playwright-run GitHub Action

### DIFF
--- a/.github/actions/playwright-run/action.yml
+++ b/.github/actions/playwright-run/action.yml
@@ -56,8 +56,8 @@ runs:
       env:
         SCRIPT_COMMAND: ${{ inputs.script-command }}
       run: |
-        npm clean-install
-        npx playwright install chromium
+        npm ci --ignore-scripts
+        ./node_modules/.bin/playwright install chromium
         eval "${SCRIPT_COMMAND}"
       continue-on-error: true
 


### PR DESCRIPTION
Issue Link- https://hyland.atlassian.net/browse/AAE-47003

Fix two CodeQL supply chain security alerts in the playwright-run composite action:

  - Replace npm clean-install with npm ci --ignore-scripts to enforce the lock file and prevent
  install-time script execution
  - Replace npx playwright install chromium with ./node_modules/.bin/playwright install chromium to
  use the locally resolved binary instead of fetching via npx

  Changes

  - npm ci --ignore-scripts — strictly requires package-lock.json, ensuring reproducible dependency
  resolution and blocking lifecycle scripts that could execute arbitrary code during install
  - ./node_modules/.bin/playwright install chromium — invokes the Playwright binary already
  installed by npm ci, avoiding any runtime registry fetch via npx
