### PR TITLE
AAE-46759 Upgrade prettier-plugin-java to 2.8.1 in activiti-cloud, hxp-common-libraries and hxp-process-services

### DIFF
--- a/.github/instructions/acceptance-tests.instructions.md
+++ b/.github/instructions/acceptance-tests.instructions.md
@@ -108,9 +108,7 @@ Static BPMN/DMN and modeling project files belong in `resources/modeling-project
 const bpmn = `<?xml version="1.0" ...`;
 
 // ✅ APPROVE — use catalog processes via ProcessDefinitionRegistry
-const key = ProcessDefinitionRegistry.processDefinitionKeyMatcher(
-  "CONNECTOR_PROCESS_INSTANCE"
-);
+const key = ProcessDefinitionRegistry.processDefinitionKeyMatcher("CONNECTOR_PROCESS_INSTANCE");
 ```
 
 ### 5. No comments or JSDoc in generated code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
           - java
           - markdown
         additional_dependencies:
-          - prettier@2.7.1
-          - prettier-plugin-java@1.6.2
+          - prettier@3.8.1
+          - prettier-plugin-java@2.8.1
         exclude: ^\.github/workflows/.*\.(lock\.yml|md)$
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.31.2

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorDiskTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/SafeZipExtractorDiskTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -164,8 +165,8 @@ class SafeZipExtractorDiskTest {
         Path trap = target.resolve("trap");
         try {
             Files.createSymbolicLink(trap, outside);
-        } catch (UnsupportedOperationException | IOException ignored) {
-            org.junit.jupiter.api.Assumptions.abort("Symbolic links are not supported in this environment");
+        } catch (UnsupportedOperationException | IOException _) {
+            Assumptions.abort("Symbolic links are not supported in this environment");
         }
 
         Path zipPath = ZipTestFixtures.writeZipFile(
@@ -250,8 +251,8 @@ class SafeZipExtractorDiskTest {
         Path link = target.resolve("linked.txt");
         try {
             Files.createSymbolicLink(link, outside);
-        } catch (UnsupportedOperationException | IOException ignored) {
-            org.junit.jupiter.api.Assumptions.abort("Symbolic links are not supported in this environment");
+        } catch (UnsupportedOperationException | IOException _) {
+            Assumptions.abort("Symbolic links are not supported in this environment");
         }
 
         Path zipPath = ZipTestFixtures.writeZipFile(

--- a/scripts/INSTALL_GUIDE.md
+++ b/scripts/INSTALL_GUIDE.md
@@ -110,31 +110,26 @@ You need access to a Rancher-managed Kubernetes cluster. The script supports any
 The script performs these operations:
 
 1. **Cluster Configuration**
-
    - Connects to Rancher and switches kubectl context
    - Validates cluster access and permissions
    - Confirms namespace creation capabilities
 
 2. **Environment Setup**
-
    - Generates PREVIEW_NAME: `pr-123-rabbit-n-d`
    - Creates local-values.local.yaml with working Docker image tags (gitignored)
    - Sets up all required environment variables
 
 3. **Kubernetes Deployment**
-
    - Creates namespace with proper labels
    - Deploys Activiti Cloud using Helm with local-values.local.yaml
    - Patches all deployments with external Keycloak configuration
 
 4. **Local Access Configuration**
-
    - Automatically adds entries to /etc/hosts (requires sudo password)
    - Sets up port forwarding: localhost:8080 → traefik
    - Configures DNS resolution for `pr-123-rabbit-n-d.activiti-hackathon.envalfresco.com`
 
 5. **Authentication Setup**
-
    - Configures external Keycloak URL: `https://activiti-hackathon.envalfresco.com/auth`
    - Sets realm: `alfresco`
    - Patches all services with ACT_KEYCLOAK_URL and ACT_KEYCLOAK_REALM

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,31 +53,26 @@ KEYCLOAK_CLIENT_SECRET=<grab-from-keycloak> ./scripts/local-install.sh [options]
 The `local-install.sh` script provides a fully automated local development environment:
 
 1. **Cluster Configuration**
-
    - Validates kubectl connection and cluster access
    - Configures kubectl context using Rancher CLI integration
    - Verifies cluster connectivity and namespace permissions
 
 2. **Environment Preparation**
-
    - Generates PREVIEW_NAME in format: `pr-{number}-{broker}-{partition}-{destination}`
    - Creates local-values.local.yaml with working Docker image tags (gitignored)
    - Sets up environment variables for consistent deployment
 
 3. **Kubernetes Deployment**
-
    - Creates and configures namespace with proper labels
    - Deploys Activiti Cloud using Helm with local-values.local.yaml by default
    - Patches deployments with correct external Keycloak configuration
 
 4. **Local Access Configuration**
-
    - Automatically configures /etc/hosts entries for gateway routing
    - Sets up port forwarding: localhost:8080 → ingress-nginx-controller
    - Generates .env file for Playwright tests with proper SSO configuration
 
 5. **Keycloak Authentication Setup**
-
    - Configures external Keycloak URL: `https://{cluster}.envalfresco.com/auth`
    - Sets correct realm: `alfresco`
    - Patches all services with ACT_KEYCLOAK_URL and ACT_KEYCLOAK_REALM


### PR DESCRIPTION
**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Other... Please describe:

## Description

Upgrade the prettier pre-commit hook to `prettier@3.8.1` / `prettier-plugin-java@2.8.1` so it supports unnamed catch patterns (`catch (Exception _)`) and no longer fails on Sonar `java:S7467` fixes. `mirrors-prettier` rev kept at `v4.0.0-alpha.8`.

- Issue Link: https://hyland.atlassian.net/browse/AAE-46759

**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No