### PR TITLE
AAE-47532 Optimize Activiti Cloud GraphQl Notifications WebSockets data fetcher CPU overhead

### DIFF
--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.cloud.services.notifications.graphql.events;
 
 import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
@@ -10,16 +25,25 @@ public class EngineEventRoutingKeyResolver implements RoutingKeyResolver {
     public String resolveRoutingKey(Object object) {
         if (object instanceof EngineEvent engineEvent) {
             return "engineEvents.%s.%s.%s.%s.%s.%s.%s".formatted(
-                    engineEvent.getOrDefault("serviceName", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("appName", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("eventType", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("processDefinitionKey", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("processInstanceId", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("businessKey", DEFAULT_VALUE),
-                    engineEvent.getOrDefault("actor", DEFAULT_VALUE)
-                );
+                segment(engineEvent, "serviceName"),
+                segment(engineEvent, "appName"),
+                segment(engineEvent, "eventType"),
+                segment(engineEvent, "processDefinitionKey"),
+                segment(engineEvent, "processInstanceId"),
+                segment(engineEvent, "businessKey"),
+                segment(engineEvent, "actor")
+            );
         }
 
-        return null;
+        throw new IllegalArgumentException("Cannot resolve routing key for class: " + (object == null ? "null" : object.getClass()));
+    }
+
+    private static String segment(EngineEvent engineEvent, String key) {
+        Object value = engineEvent.get(key);
+        if (value == null) {
+            return DEFAULT_VALUE;
+        }
+        String asString = value.toString();
+        return asString.isBlank() ? DEFAULT_VALUE : asString;
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
@@ -1,0 +1,25 @@
+package org.activiti.cloud.services.notifications.graphql.events;
+
+import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
+
+public class EngineEventRoutingKeyResolver implements RoutingKeyResolver {
+
+    private static final String DEFAULT_VALUE = "_";
+
+    @Override
+    public String resolveRoutingKey(Object object) {
+        if (object instanceof EngineEvent engineEvent) {
+            return "engineEvents.%s.%s.%s.%s.%s.%s.%s".formatted(
+                    engineEvent.getOrDefault("serviceName", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("appName", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("eventType", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("processDefinitionKey", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("processInstanceId", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("businessKey", DEFAULT_VALUE),
+                    engineEvent.getOrDefault("actor", DEFAULT_VALUE)
+                );
+        }
+
+        return null;
+    }
+}

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/EngineEventRoutingKeyResolver.java
@@ -35,7 +35,9 @@ public class EngineEventRoutingKeyResolver implements RoutingKeyResolver {
             );
         }
 
-        throw new IllegalArgumentException("Cannot resolve routing key for class: " + (object == null ? "null" : object.getClass()));
+        throw new IllegalArgumentException(
+            "Cannot resolve routing key for class: " + (object == null ? "null" : object.getClass())
+        );
     }
 
     private static String segment(EngineEvent engineEvent, String key) {

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
@@ -42,12 +42,12 @@ public class SpELTemplateRoutingKeyResolver implements RoutingKeyResolver {
     }
 
     private Expression computeExpression(Class<?> clazz) {
-            Annotation annotation = AnnotationUtils.findAnnotation(clazz, SpELTemplateRoutingKey.class);
+        Annotation annotation = AnnotationUtils.findAnnotation(clazz, SpELTemplateRoutingKey.class);
 
-            if (annotation == null) throw new RuntimeException("Cannot resolve routing key for class: " + clazz);
+        if (annotation == null) throw new RuntimeException("Cannot resolve routing key for class: " + clazz);
 
-            String value = AnnotationUtils.getValue(annotation).toString();
+        String value = AnnotationUtils.getValue(annotation).toString();
 
-            return parser.parseExpression(value, parserContext);
+        return parser.parseExpression(value, parserContext);
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.services.notifications.graphql.events;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
@@ -32,18 +31,17 @@ public class SpELTemplateRoutingKeyResolver implements RoutingKeyResolver {
 
     private final ParserContext parserContext = new TemplateParserContext();
 
-    private final Map<String, Expression> expressionCacheByName = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Expression> expressionCacheByName = new ConcurrentHashMap<>();
 
     @Override
     public String resolveRoutingKey(Object object) {
         return expressionCacheByName
-            .computeIfAbsent(object.getClass().getName(), computeExpression(object.getClass()))
+            .computeIfAbsent(object.getClass(), this::computeExpression)
             .getValue(object)
             .toString();
     }
 
-    private Function<String, Expression> computeExpression(Class<?> clazz) {
-        return name -> {
+    private Expression computeExpression(Class<?> clazz) {
             Annotation annotation = AnnotationUtils.findAnnotation(clazz, SpELTemplateRoutingKey.class);
 
             if (annotation == null) throw new RuntimeException("Cannot resolve routing key for class: " + clazz);
@@ -51,6 +49,5 @@ public class SpELTemplateRoutingKeyResolver implements RoutingKeyResolver {
             String value = AnnotationUtils.getValue(annotation).toString();
 
             return parser.parseExpression(value, parserContext);
-        };
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/SpELTemplateRoutingKeyResolver.java
@@ -16,6 +16,9 @@
 package org.activiti.cloud.services.notifications.graphql.events;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
@@ -25,22 +28,29 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 public class SpELTemplateRoutingKeyResolver implements RoutingKeyResolver {
 
-    private ExpressionParser parser = new SpelExpressionParser();
+    private final ExpressionParser parser = new SpelExpressionParser();
 
-    private ParserContext parserContext = new TemplateParserContext();
+    private final ParserContext parserContext = new TemplateParserContext();
+
+    private final Map<String, Expression> expressionCacheByName = new ConcurrentHashMap<>();
 
     @Override
     public String resolveRoutingKey(Object object) {
-        Annotation annotation = AnnotationUtils.findAnnotation(object.getClass(), SpELTemplateRoutingKey.class);
+        return expressionCacheByName
+            .computeIfAbsent(object.getClass().getName(), computeExpression(object.getClass()))
+            .getValue(object)
+            .toString();
+    }
 
-        if (annotation == null) throw new RuntimeException(
-            "Cannot resolve routing key for class: " + object.getClass()
-        );
+    private Function<String, Expression> computeExpression(Class<?> clazz) {
+        return name -> {
+            Annotation annotation = AnnotationUtils.findAnnotation(clazz, SpELTemplateRoutingKey.class);
 
-        String value = AnnotationUtils.getValue(annotation).toString();
+            if (annotation == null) throw new RuntimeException("Cannot resolve routing key for class: " + clazz);
 
-        Expression expression = parser.parseExpression(value, parserContext);
+            String value = AnnotationUtils.getValue(annotation).toString();
 
-        return expression.getValue(object).toString();
+            return parser.parseExpression(value, parserContext);
+        };
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
+++ b/activiti-cloud-notifications-graphql-service/services/events/src/main/java/org/activiti/cloud/services/notifications/graphql/events/consumer/EngineEventsConsumerAutoConfiguration.java
@@ -19,8 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
+import org.activiti.cloud.services.notifications.graphql.events.EngineEventRoutingKeyResolver;
 import org.activiti.cloud.services.notifications.graphql.events.RoutingKeyResolver;
-import org.activiti.cloud.services.notifications.graphql.events.SpELTemplateRoutingKeyResolver;
 import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
 import org.activiti.cloud.services.notifications.graphql.events.transformer.EngineEventsTransformer;
 import org.activiti.cloud.services.notifications.graphql.events.transformer.Transformer;
@@ -81,7 +81,7 @@ public class EngineEventsConsumerAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         public RoutingKeyResolver routingKeyResolver() {
-            return new SpELTemplateRoutingKeyResolver();
+            return new EngineEventRoutingKeyResolver();
         }
 
         @Bean
@@ -138,9 +138,7 @@ public class EngineEventsConsumerAutoConfiguration {
                 .onErrorResume(e -> Mono.empty())
                 .publish()
                 .autoConnect()
-                .parallel()
-                .runOn(engineEventsScheduler)
-                .sequential()
+                .publishOn(engineEventsScheduler)
                 .onBackpressureLatest();
         }
 

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsDestinationsPredicateFactory.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsDestinationsPredicateFactory.java
@@ -47,7 +47,9 @@ public class EngineEventsDestinationsPredicateFactory implements EngineEventsPre
         return engineEvent -> {
             String routingKey = routingKeyResolver.resolveRoutingKey(engineEvent);
 
-            logger.debug("Resolved routing key {} for {}", routingKey, engineEvent);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Resolved routing key {} for {}", routingKey, engineEvent);
+            }
 
             return destinations.stream().anyMatch(pattern -> pathMatcher.match(pattern, routingKey));
         };

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
@@ -18,10 +18,10 @@ package org.activiti.cloud.services.notifications.graphql.subscriptions.datafetc
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
 import org.springframework.messaging.Message;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -45,14 +45,12 @@ public class EngineEventsFluxPublisherFactory implements EngineEventsPublisherFa
         Predicate<? super EngineEvent> predicate = predicateFactory.getPredicate(environment);
 
         return Flux.from(
-            engineEventsFlux
-                .log(logger, Level.CONFIG, true)
-                .flatMapSequential(message ->
-                    Flux.fromIterable(message.getPayload())
-                        .filter(predicate)
-                        .collectList()
-                        .filter(list -> !list.isEmpty())
-                )
+            engineEventsFlux.concatMap(message ->
+                Mono
+                    .just(message.getPayload())
+                    .map(engineEvents -> engineEvents.stream().filter(predicate).toList())
+                    .filter(Predicate.not(List::isEmpty))
+            )
         );
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
@@ -44,9 +44,10 @@ public class EngineEventsFluxPublisherFactory implements EngineEventsPublisherFa
         Predicate<? super EngineEvent> predicate = predicateFactory.getPredicate(environment);
 
         return Flux.from(
-            engineEventsFlux.map(Message::getPayload)
-                    .map(engineEvents -> engineEvents.stream().filter(predicate).toList())
-                    .filter(Predicate.not(List::isEmpty))
+            engineEventsFlux
+                .map(Message::getPayload)
+                .map(engineEvents -> engineEvents.stream().filter(predicate).toList())
+                .filter(Predicate.not(List::isEmpty))
         );
     }
 }

--- a/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
+++ b/activiti-cloud-notifications-graphql-service/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/datafetcher/EngineEventsFluxPublisherFactory.java
@@ -21,7 +21,6 @@ import java.util.function.Predicate;
 import org.activiti.cloud.services.notifications.graphql.events.model.EngineEvent;
 import org.springframework.messaging.Message;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -45,12 +44,9 @@ public class EngineEventsFluxPublisherFactory implements EngineEventsPublisherFa
         Predicate<? super EngineEvent> predicate = predicateFactory.getPredicate(environment);
 
         return Flux.from(
-            engineEventsFlux.concatMap(message ->
-                Mono
-                    .just(message.getPayload())
+            engineEventsFlux.map(Message::getPayload)
                     .map(engineEvents -> engineEvents.stream().filter(predicate).toList())
                     .filter(Predicate.not(List::isEmpty))
-            )
         );
     }
 }


### PR DESCRIPTION
## Pull request overview

Optimizes the Activiti Cloud Notifications GraphQL subscriptions/event-consumer path to reduce CPU overhead during WebSocket subscription event filtering and routing-key resolution.

**Changes:**
- Simplifies engine event filtering in the subscription publisher and reduces logging overhead in destination predicate evaluation.
- Introduces a dedicated `EngineEventRoutingKeyResolver` and switches the default `RoutingKeyResolver` bean away from SpEL evaluation.
- Adjusts the engine events Flux scheduling strategy (replacing `parallel()/runOn()/sequential()` with `publishOn()`).


https://hyland.atlassian.net/browse/AAE-47532