### PR TITLE
AAE-47604 Graceful shutdown for partitioned REST connector

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorGracefulShutdownLifecycle.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorGracefulShutdownLifecycle.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.context.SmartLifecycle;
+
+public class ConnectorGracefulShutdownLifecycle implements SmartLifecycle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorGracefulShutdownLifecycle.class);
+
+    private static final long POLL_INTERVAL_MILLIS = 100;
+
+    private final InFlightMessageTracker inFlightTracker;
+    private final InputBindingLifecycle inputBindingLifecycle;
+    private final Duration shutdownTimeout;
+
+    private volatile boolean running;
+
+    public ConnectorGracefulShutdownLifecycle(
+        InFlightMessageTracker inFlightTracker,
+        InputBindingLifecycle inputBindingLifecycle,
+        Duration shutdownTimeout
+    ) {
+        this.inFlightTracker = inFlightTracker;
+        this.inputBindingLifecycle = inputBindingLifecycle;
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
+    @Override
+    public void start() {
+        running = true;
+    }
+
+    @Override
+    public void stop() {
+        if (!running) {
+            return;
+        }
+        running = false;
+        stopConsumption();
+        drainInFlightRequests();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+
+    private void stopConsumption() {
+        LOGGER.info("Graceful shutdown started: stopping connector message consumption");
+        inputBindingLifecycle.stop();
+    }
+
+    private void drainInFlightRequests() {
+        final long deadline = System.nanoTime() + shutdownTimeout.toNanos();
+        int remaining = inFlightTracker.inFlight();
+        while (remaining > 0 && System.nanoTime() < deadline) {
+            LOGGER.debug("Graceful shutdown: waiting for {} in-flight connector request(s) to finish", remaining);
+            try {
+                Thread.sleep(POLL_INTERVAL_MILLIS);
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            remaining = inFlightTracker.inFlight();
+        }
+
+        if (remaining > 0) {
+            LOGGER.warn(
+                "Graceful shutdown timeout ({}) exceeded; {} in-flight connector request(s) did not finish",
+                shutdownTimeout,
+                remaining
+            );
+        } else {
+            LOGGER.info("Graceful shutdown: all in-flight connector requests finished");
+        }
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/InFlightMessageTracker.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/InFlightMessageTracker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jspecify.annotations.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
+
+public class InFlightMessageTracker implements ExecutorChannelInterceptor {
+
+    private final AtomicInteger inFlight = new AtomicInteger();
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        inFlight.incrementAndGet();
+        return message;
+    }
+
+    @Override
+    public void afterSendCompletion(Message<?> message, MessageChannel channel, boolean sent, @Nullable Exception ex) {
+        if (!sent) {
+            inFlight.decrementAndGet();
+        }
+    }
+
+    @Override
+    public void afterMessageHandled(
+        Message<?> message,
+        MessageChannel channel,
+        MessageHandler handler,
+        @Nullable Exception ex
+    ) {
+        inFlight.decrementAndGet();
+    }
+
+    public int inFlight() {
+        return inFlight.get();
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/PartitionedChannelGracefulShutdown.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/PartitionedChannelGracefulShutdown.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import java.time.Duration;
+import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.messaging.support.ChannelInterceptor;
+
+public class PartitionedChannelGracefulShutdown implements SmartLifecycle {
+
+    private final InFlightMessageTracker inFlightTracker;
+    private final ConnectorGracefulShutdownLifecycle lifecycle;
+
+    public PartitionedChannelGracefulShutdown(InputBindingLifecycle inputBindingLifecycle, Duration shutdownTimeout) {
+        this.inFlightTracker = new InFlightMessageTracker();
+        this.lifecycle = new ConnectorGracefulShutdownLifecycle(
+            inFlightTracker,
+            inputBindingLifecycle,
+            shutdownTimeout
+        );
+    }
+
+    public ChannelInterceptor channelInterceptor() {
+        return inFlightTracker;
+    }
+
+    public int inFlight() {
+        return inFlightTracker.inFlight();
+    }
+
+    @Override
+    public void start() {
+        lifecycle.start();
+    }
+
+    @Override
+    public void stop() {
+        lifecycle.stop();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return lifecycle.isRunning();
+    }
+
+    @Override
+    public int getPhase() {
+        return lifecycle.getPhase();
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/ConnectorGracefulShutdownLifecycleTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/ConnectorGracefulShutdownLifecycleTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectorGracefulShutdownLifecycleTest {
+
+    @Mock
+    private InFlightMessageTracker inFlightTracker;
+
+    @Mock
+    private InputBindingLifecycle inputBindingLifecycle;
+
+    private ConnectorGracefulShutdownLifecycle gracefulShutdown;
+
+    @BeforeEach
+    void setUp() {
+        gracefulShutdown = new ConnectorGracefulShutdownLifecycle(
+            inFlightTracker,
+            inputBindingLifecycle,
+            Duration.ofSeconds(5)
+        );
+        gracefulShutdown.start();
+    }
+
+    @Test
+    void shouldBeRunningAfterStart() {
+        assertThat(gracefulShutdown.isRunning()).isTrue();
+    }
+
+    @Test
+    void shouldStopConsumptionWhenShutdownStarts() {
+        when(inFlightTracker.inFlight()).thenReturn(0);
+
+        gracefulShutdown.stop();
+
+        verify(inputBindingLifecycle).stop();
+        assertThat(gracefulShutdown.isRunning()).isFalse();
+    }
+
+    @Test
+    void shouldWaitForInFlightRequestsToFinishBeforeCompleting() {
+        when(inFlightTracker.inFlight()).thenReturn(2, 1, 0);
+
+        gracefulShutdown.stop();
+
+        verify(inputBindingLifecycle).stop();
+        verify(inFlightTracker, times(3)).inFlight();
+    }
+
+    @Test
+    void shouldForceShutdownWhenTimeoutExceeded() {
+        gracefulShutdown = new ConnectorGracefulShutdownLifecycle(
+            inFlightTracker,
+            inputBindingLifecycle,
+            Duration.ofMillis(200)
+        );
+        gracefulShutdown.start();
+        when(inFlightTracker.inFlight()).thenReturn(5);
+
+        final long start = System.nanoTime();
+        gracefulShutdown.stop();
+        final Duration elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+        verify(inputBindingLifecycle).stop();
+        assertThat(elapsed).isLessThan(Duration.ofSeconds(2));
+        assertThat(gracefulShutdown.isRunning()).isFalse();
+    }
+
+    @Test
+    void shouldDoNothingWhenAlreadyStopped() {
+        gracefulShutdown.stop();
+
+        gracefulShutdown.stop();
+
+        verify(inputBindingLifecycle, times(1)).stop();
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/InFlightMessageTrackerTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/InFlightMessageTrackerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+
+class InFlightMessageTrackerTest {
+
+    private final InFlightMessageTracker tracker = new InFlightMessageTracker();
+
+    private final Message<String> message = new GenericMessage<>("payload");
+
+    @Test
+    void shouldIncrementOnPreSendAndDecrementOnAfterMessageHandled() {
+        tracker.preSend(message, null);
+        assertThat(tracker.inFlight()).isEqualTo(1);
+
+        tracker.afterMessageHandled(message, null, null, null);
+        assertThat(tracker.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldDecrementOnAfterMessageHandledWhenHandlingFailed() {
+        tracker.preSend(message, null);
+
+        tracker.afterMessageHandled(message, null, null, new RuntimeException("boom"));
+
+        assertThat(tracker.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldDecrementOnAfterSendCompletionWhenMessageWasNotSent() {
+        tracker.preSend(message, null);
+
+        tracker.afterSendCompletion(message, null, false, null);
+
+        assertThat(tracker.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldDecrementOnAfterSendCompletionWhenSendThrew() {
+        tracker.preSend(message, null);
+
+        tracker.afterSendCompletion(message, null, false, new RuntimeException("boom"));
+
+        assertThat(tracker.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldNotDecrementOnAfterSendCompletionWhenMessageWasSentSuccessfully() {
+        tracker.preSend(message, null);
+
+        tracker.afterSendCompletion(message, null, true, null);
+
+        assertThat(tracker.inFlight()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCountMultipleConcurrentRequests() {
+        tracker.preSend(message, null);
+        tracker.preSend(message, null);
+        tracker.preSend(message, null);
+        assertThat(tracker.inFlight()).isEqualTo(3);
+
+        tracker.afterMessageHandled(message, null, null, null);
+        assertThat(tracker.inFlight()).isEqualTo(2);
+    }
+}

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/PartitionedChannelGracefulShutdownTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/PartitionedChannelGracefulShutdownTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.common.messaging.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
+import org.springframework.messaging.support.GenericMessage;
+
+@ExtendWith(MockitoExtension.class)
+class PartitionedChannelGracefulShutdownTest {
+
+    @Mock
+    private InputBindingLifecycle inputBindingLifecycle;
+
+    private PartitionedChannelGracefulShutdown gracefulShutdown;
+
+    @BeforeEach
+    void setUp() {
+        gracefulShutdown = new PartitionedChannelGracefulShutdown(inputBindingLifecycle, Duration.ofSeconds(5));
+        gracefulShutdown.start();
+    }
+
+    @Test
+    void shouldExposeChannelInterceptorThatTracksInFlight() {
+        final Message<String> message = new GenericMessage<>("payload");
+        final ExecutorChannelInterceptor interceptor =
+            (ExecutorChannelInterceptor) gracefulShutdown.channelInterceptor();
+
+        interceptor.preSend(message, null);
+        assertThat(gracefulShutdown.inFlight()).isEqualTo(1);
+
+        interceptor.afterMessageHandled(message, null, null, null);
+        assertThat(gracefulShutdown.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldStopConsumptionAndCompleteWhenNothingInFlight() {
+        gracefulShutdown.stop();
+
+        verify(inputBindingLifecycle).stop();
+        assertThat(gracefulShutdown.isRunning()).isFalse();
+        assertThat(gracefulShutdown.inFlight()).isZero();
+    }
+
+    @Test
+    void shouldHaveMaxPhaseSoItStopsFirst() {
+        assertThat(gracefulShutdown.getPhase()).isEqualTo(Integer.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Other... Please describe:

## Description

- Issue Link: https://hyland.atlassian.net/browse/AAE-47604

Reusable graceful-shutdown building blocks for executor-backed partitioned message channels (`InFlightMessageTracker`, `ConnectorGracefulShutdownLifecycle`, and the one-step `PartitionedChannelGracefulShutdown` helper) in `activiti-cloud-service-messaging-config`. Consumed by the hxp partitioned REST connector; also reusable by the partitioned query consumer.

**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No