### PR TITLE
AAE-47636 Add connector binding integration result configuration timeout error handler

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -140,6 +140,10 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
 
                         registerFunctionRegistration(functionDefinition, functionRegistration);
 
+                        final var integrationResultTimeout = Optional.of(connectorBinding.integrationResultTimeout())
+                            .filter(Predicate.not(String::isBlank))
+                            .map(resolveExpression);
+
                         GenericHandler<Message> handler = (message, headers) -> {
                             FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                             function.setSkipOutputConversion(true);
@@ -154,8 +158,8 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 final var resultTimeout = Optional.ofNullable(
                                     headers.get("integrationResultTimeout", String.class)
                                 )
-                                    .or(() -> Optional.of(connectorBinding.integrationResultTimeout()))
-                                    .filter(Predicate.not(String::isEmpty))
+                                    .filter(Predicate.not(String::isBlank))
+                                    .or(() -> integrationResultTimeout)
                                     .map(Duration::parse)
                                     .orElse(defaultResultTimeout);
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
@@ -106,7 +107,8 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
         > connectorErrorHandlerDefinitionResolver,
         AsyncTaskExecutor connectorAsyncTaskExecutor,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
-        @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
+        @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay,
+        @Value("${activiti.connector.integration.resultTimeout:25m}") Duration defaultResultTimeout
     ) {
         return new BeanPostProcessor() {
             @Override
@@ -147,8 +149,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                     headers.get("integrationResultTimeout", String.class)
                                 )
                                     .or(() -> Optional.of(connectorBinding.integrationResultTimeout()))
+                                    .filter(Predicate.not(String::isEmpty))
                                     .map(Duration::parse)
-                                    .get();
+                                    .orElse(defaultResultTimeout);
 
                                 try {
                                     Object result = future.get(resultTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
@@ -85,16 +84,14 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    Supplier<AsyncTaskExecutor> connectorTaskExecutorProvider() {
-        final var executor = new SimpleAsyncTaskExecutorBuilder()
+    @ConditionalOnMissingBean(name = "connectorTaskAsyncExecutor")
+    AsyncTaskExecutor connectorTaskAsyncExecutor() {
+        return new SimpleAsyncTaskExecutorBuilder()
             .concurrencyLimit(Runtime.getRuntime().availableProcessors())
             .cancelRemainingTasksOnClose(true)
             .threadNamePrefix("connector-executor-")
             .virtualThreads(true)
             .build();
-
-        return () -> executor;
     }
 
     @Bean(name = "connectorBindingPostProcessor")
@@ -107,7 +104,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             ConnectorBinding,
             Optional<SimpleFunctionRegistry.FunctionInvocationWrapper>
         > connectorErrorHandlerDefinitionResolver,
-        Supplier<AsyncTaskExecutor> connectorTaskExecutorProvider,
+        AsyncTaskExecutor connectorTaskAsyncExecutor,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
         @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
     ) {
@@ -151,9 +148,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         .toString()
                                 );
 
-                                Future<Object> future = connectorTaskExecutorProvider
-                                    .get()
-                                    .submit(() -> function.apply(message));
+                                Future<Object> future = connectorTaskAsyncExecutor.submit(() ->
+                                    function.apply(message)
+                                );
 
                                 Object result;
 
@@ -172,7 +169,10 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         timeoutException
                                     );
                                 } catch (ExecutionException executionException) {
-                                    throw new RuntimeException(executionException.getMessage(), executionException);
+                                    throw new RuntimeException(
+                                        executionException.getMessage(),
+                                        executionException.getCause()
+                                    );
                                 }
 
                                 if (result != null) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -18,8 +18,12 @@ package org.activiti.cloud.common.messaging.config;
 import static org.springframework.integration.handler.LoggingHandler.Level.DEBUG;
 
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
@@ -32,6 +36,8 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionRegistration;
 import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry;
@@ -42,6 +48,7 @@ import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.function.FunctionConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.dsl.IntegrationFlow;
@@ -76,6 +83,17 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             .get();
     }
 
+    @Bean
+    @ConditionalOnMissingBean
+    AsyncTaskExecutor connectorTaskExecutor() {
+        return new SimpleAsyncTaskExecutorBuilder()
+            .concurrencyLimit(Runtime.getRuntime().availableProcessors())
+            .cancelRemainingTasksOnClose(true)
+            .threadNamePrefix("connector-executor-")
+            .virtualThreads(true)
+            .build();
+    }
+
     @Bean(name = "connectorBindingPostProcessor")
     public BeanPostProcessor connectorBindingPostProcessor(
         FunctionAnnotationService functionAnnotationService,
@@ -86,6 +104,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             ConnectorBinding,
             Optional<SimpleFunctionRegistry.FunctionInvocationWrapper>
         > connectorErrorHandlerDefinitionResolver,
+        AsyncTaskExecutor connectorTaskExecutor,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
         @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
     ) {
@@ -120,7 +139,36 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                             Message<?> response = null;
 
                             try {
-                                Object result = function.apply(message);
+                                final var timeout = Duration.parse(
+                                    headers
+                                        .getOrDefault(
+                                            "integrationResultTimeout",
+                                            connectorBinding.integrationResultTimeout()
+                                        )
+                                        .toString()
+                                );
+
+                                Future<Object> future = connectorTaskExecutor.submit(() -> function.apply(message));
+
+                                Object result;
+
+                                try {
+                                    result = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                                } catch (InterruptedException interruptedException) {
+                                    Thread.currentThread().interrupt();
+                                    throw new RuntimeException(
+                                        "Interrupted while waiting for result",
+                                        interruptedException
+                                    );
+                                } catch (TimeoutException timeoutException) {
+                                    future.cancel(true);
+                                    throw new RuntimeException(
+                                        "Timeout after " + timeout + " while waiting for result",
+                                        timeoutException
+                                    );
+                                } catch (ExecutionException executionException) {
+                                    throw new RuntimeException("Failed to execute connector task", executionException);
+                                }
 
                                 if (result != null) {
                                     if (result instanceof Message<?> msg) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
@@ -70,6 +71,7 @@ import org.springframework.util.StringUtils;
 public class ConnectorConfiguration extends AbstractFunctionalBindingConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorConfiguration.class);
+    private static final Pattern ISO8601DurationPattern = Pattern.compile("^PT(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$");
 
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_FLOW = "connectorBindingSelectorDiscardFlow";
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_CHANNEL = "connectorBindingSelectorDiscardChannel";
@@ -142,7 +144,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
 
                         final var integrationResultTimeout = Optional.of(connectorBinding.integrationResultTimeout())
                             .filter(Predicate.not(String::isBlank))
-                            .map(resolveExpression);
+                            .map(resolveExpression)
+                            .filter(it -> ISO8601DurationPattern.matcher(it).matches())
+                            .map(Duration::parse);
 
                         GenericHandler<Message> handler = (message, headers) -> {
                             FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
@@ -159,8 +163,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                     headers.get("integrationResultTimeout", String.class)
                                 )
                                     .filter(Predicate.not(String::isBlank))
-                                    .or(() -> integrationResultTimeout)
+                                    .filter(it -> ISO8601DurationPattern.matcher(it).matches())
                                     .map(Duration::parse)
+                                    .or(() -> integrationResultTimeout)
                                     .orElse(defaultResultTimeout);
 
                                 try {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.activiti.cloud.common.messaging.ActivitiCloudMessagingProperties;
 import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
@@ -85,13 +86,15 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
 
     @Bean
     @ConditionalOnMissingBean
-    AsyncTaskExecutor connectorTaskExecutor() {
-        return new SimpleAsyncTaskExecutorBuilder()
+    Supplier<AsyncTaskExecutor> connectorTaskExecutorProvider() {
+        final var executor = new SimpleAsyncTaskExecutorBuilder()
             .concurrencyLimit(Runtime.getRuntime().availableProcessors())
             .cancelRemainingTasksOnClose(true)
             .threadNamePrefix("connector-executor-")
             .virtualThreads(true)
             .build();
+
+        return () -> executor;
     }
 
     @Bean(name = "connectorBindingPostProcessor")
@@ -104,7 +107,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             ConnectorBinding,
             Optional<SimpleFunctionRegistry.FunctionInvocationWrapper>
         > connectorErrorHandlerDefinitionResolver,
-        AsyncTaskExecutor connectorTaskExecutor,
+        Supplier<AsyncTaskExecutor> connectorTaskExecutorProvider,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
         @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
     ) {
@@ -148,7 +151,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         .toString()
                                 );
 
-                                Future<Object> future = connectorTaskExecutor.submit(() -> function.apply(message));
+                                Future<Object> future = connectorTaskExecutorProvider
+                                    .get()
+                                    .submit(() -> function.apply(message));
 
                                 Object result;
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -323,8 +323,8 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                 .orElse(null);
 
         return (message, connectorBinding) ->
-            Optional.ofNullable(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT, String.class))
-                .map(toDuration)
+            Optional.ofNullable(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT))
+                .map(it -> (it instanceof Duration) ? (Duration) it : toDuration.apply(it.toString()))
                 .or(() -> Optional.of(connectorBinding.integrationResultTimeout()).map(toDuration))
                 .filter(it -> it.compareTo(defaultResultTimeout) <= 0)
                 .orElse(defaultResultTimeout);

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -72,12 +73,12 @@ import org.springframework.util.StringUtils;
 public class ConnectorConfiguration extends AbstractFunctionalBindingConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorConfiguration.class);
-    private static final Pattern ISO8601DurationPattern = Pattern.compile("^PT(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$");
 
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_FLOW = "connectorBindingSelectorDiscardFlow";
     public static final String CONNECTOR_BINDING_SELECTOR_DISCARD_CHANNEL = "connectorBindingSelectorDiscardChannel";
     public static final String NULL_CHANNEL = "nullChannel";
     public static final String RETRY_COUNT = "x-retry-count";
+    public static final String INTEGRATION_RESULT_TIMEOUT = "integrationResultTimeout";
 
     @Bean(name = CONNECTOR_BINDING_SELECTOR_DISCARD_FLOW)
     IntegrationFlow functionBindingSelectorDiscardFlow() {
@@ -115,9 +116,9 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             Optional<SimpleFunctionRegistry.FunctionInvocationWrapper>
         > connectorErrorHandlerDefinitionResolver,
         AsyncTaskExecutor connectorAsyncTaskExecutor,
+        BiFunction<Message<?>, ConnectorBinding, Duration> connectorIntegrationResultTimeoutResolver,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
-        @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay,
-        @Value("${activiti.connector.integration-result-timeout:25m}") Duration defaultResultTimeout
+        @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
     ) {
         return new BeanPostProcessor() {
             @Override
@@ -143,34 +144,31 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
 
                         registerFunctionRegistration(functionDefinition, functionRegistration);
 
-                        final var integrationResultTimeout = Optional.of(connectorBinding.integrationResultTimeout())
-                            .filter(Predicate.not(String::isBlank))
-                            .map(resolveExpression)
-                            .filter(it -> ISO8601DurationPattern.matcher(it).matches())
-                            .map(Duration::parse);
-
                         GenericHandler<Message> handler = (message, headers) -> {
                             FunctionInvocationWrapper function = functionFromDefinition(functionDefinition);
                             function.setSkipOutputConversion(true);
 
                             Message<?> response = null;
 
+                            final var integrationResultTimeout = connectorIntegrationResultTimeoutResolver.apply(
+                                message,
+                                connectorBinding
+                            );
+
                             try {
                                 Future<Object> future = connectorAsyncTaskExecutor.submit(() ->
-                                    function.apply(message)
+                                    function.apply(
+                                        MessageBuilder.fromMessage(message)
+                                            .setHeader(INTEGRATION_RESULT_TIMEOUT, integrationResultTimeout.toString())
+                                            .build()
+                                    )
                                 );
 
-                                final var resultTimeout = Optional.ofNullable(
-                                    headers.get("integrationResultTimeout", String.class)
-                                )
-                                    .filter(Predicate.not(String::isBlank))
-                                    .filter(it -> ISO8601DurationPattern.matcher(it).matches())
-                                    .map(Duration::parse)
-                                    .or(() -> integrationResultTimeout)
-                                    .orElse(defaultResultTimeout);
-
                                 try {
-                                    Object result = future.get(resultTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                                    Object result = future.get(
+                                        integrationResultTimeout.toMillis(),
+                                        TimeUnit.MILLISECONDS
+                                    );
 
                                     if (result != null) {
                                         if (result instanceof Message<?> msg) {
@@ -195,7 +193,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 } catch (TimeoutException timeoutException) {
                                     future.cancel(true);
                                     throw new RuntimeException(
-                                        "Timeout after " + resultTimeout + " while waiting for result",
+                                        "Timeout after " + integrationResultTimeout + " while waiting for result",
                                         timeoutException
                                     );
                                 } catch (ExecutionException executionException) {
@@ -308,6 +306,28 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                 return bean;
             }
         };
+    }
+
+    @Bean
+    BiFunction<Message<?>, ConnectorBinding, Duration> connectorIntegrationResultTimeoutResolver(
+        @Value("${activiti.connector.integration-result-timeout:PT25M}") Duration defaultResultTimeout,
+        Function<String, String> resolveExpression
+    ) {
+        final var ISO8601DurationPattern = Pattern.compile("^PT(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$");
+        final Function<String, Duration> toDuration = value ->
+            Optional.of(value)
+                .filter(Predicate.not(String::isBlank))
+                .map(resolveExpression)
+                .filter(it -> ISO8601DurationPattern.matcher(it).matches())
+                .map(Duration::parse)
+                .orElse(null);
+
+        return (message, connectorBinding) ->
+            Optional.ofNullable(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT, String.class))
+                .map(toDuration)
+                .or(() -> Optional.of(connectorBinding.integrationResultTimeout()).map(toDuration))
+                .filter(it -> it.compareTo(defaultResultTimeout) <= 0)
+                .orElse(defaultResultTimeout);
     }
 
     @Bean

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -84,8 +84,8 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "connectorTaskAsyncExecutor")
-    AsyncTaskExecutor connectorTaskAsyncExecutor() {
+    @ConditionalOnMissingBean(name = "connectorAsyncTaskExecutor")
+    AsyncTaskExecutor connectorAsyncTaskExecutor() {
         return new SimpleAsyncTaskExecutorBuilder()
             .concurrencyLimit(Runtime.getRuntime().availableProcessors())
             .cancelRemainingTasksOnClose(true)
@@ -104,7 +104,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
             ConnectorBinding,
             Optional<SimpleFunctionRegistry.FunctionInvocationWrapper>
         > connectorErrorHandlerDefinitionResolver,
-        AsyncTaskExecutor connectorTaskAsyncExecutor,
+        AsyncTaskExecutor connectorAsyncTaskExecutor,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
         @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay
     ) {
@@ -148,7 +148,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         .toString()
                                 );
 
-                                Future<Object> future = connectorTaskAsyncExecutor.submit(() ->
+                                Future<Object> future = connectorAsyncTaskExecutor.submit(() ->
                                     function.apply(message)
                                 );
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -172,7 +172,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         timeoutException
                                     );
                                 } catch (ExecutionException executionException) {
-                                    throw new RuntimeException("Failed to execute connector task", executionException);
+                                    throw new RuntimeException(executionException.getMessage(), executionException);
                                 }
 
                                 if (result != null) {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -159,7 +159,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 Future<Object> future = connectorAsyncTaskExecutor.submit(() ->
                                     function.apply(
                                         MessageBuilder.fromMessage(message)
-                                            .setHeader(INTEGRATION_RESULT_TIMEOUT, integrationResultTimeout.toString())
+                                            .setHeader(INTEGRATION_RESULT_TIMEOUT, integrationResultTimeout)
                                             .build()
                                     )
                                 );

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -139,23 +139,34 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                             Message<?> response = null;
 
                             try {
-                                final var timeout = Duration.parse(
-                                    headers
-                                        .getOrDefault(
-                                            "integrationResultTimeout",
-                                            connectorBinding.integrationResultTimeout()
-                                        )
-                                        .toString()
-                                );
-
                                 Future<Object> future = connectorAsyncTaskExecutor.submit(() ->
                                     function.apply(message)
                                 );
 
-                                Object result;
+                                final var resultTimeout = Optional.ofNullable(
+                                    headers.get("integrationResultTimeout", String.class)
+                                )
+                                    .or(() -> Optional.of(connectorBinding.integrationResultTimeout()))
+                                    .map(Duration::parse)
+                                    .get();
 
                                 try {
-                                    result = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                                    Object result = future.get(resultTimeout.toMillis(), TimeUnit.MILLISECONDS);
+
+                                    if (result != null) {
+                                        if (result instanceof Message<?> msg) {
+                                            result = msg.getPayload();
+                                        }
+
+                                        response = MessageBuilder.withPayload(result).build();
+
+                                        String destination = headers.get(connectorBinding.outputHeader(), String.class);
+
+                                        if (StringUtils.hasText(destination)) {
+                                            getStreamBridge().send(destination, response);
+                                            return null;
+                                        }
+                                    }
                                 } catch (InterruptedException interruptedException) {
                                     Thread.currentThread().interrupt();
                                     throw new RuntimeException(
@@ -165,7 +176,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                 } catch (TimeoutException timeoutException) {
                                     future.cancel(true);
                                     throw new RuntimeException(
-                                        "Timeout after " + timeout + " while waiting for result",
+                                        "Timeout after " + resultTimeout + " while waiting for result",
                                         timeoutException
                                     );
                                 } catch (ExecutionException executionException) {
@@ -173,21 +184,6 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         executionException.getMessage(),
                                         executionException.getCause()
                                     );
-                                }
-
-                                if (result != null) {
-                                    if (result instanceof Message<?> msg) {
-                                        result = msg.getPayload();
-                                    }
-
-                                    response = MessageBuilder.withPayload(result).build();
-
-                                    String destination = headers.get(connectorBinding.outputHeader(), String.class);
-
-                                    if (StringUtils.hasText(destination)) {
-                                        getStreamBridge().send(destination, response);
-                                        return null;
-                                    }
                                 }
                             } catch (Exception connectorError) {
                                 connectorErrorHandlerDefinitionResolver

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.function.FunctionConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.core.GenericSelector;
@@ -198,10 +199,8 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         timeoutException
                                     );
                                 } catch (ExecutionException executionException) {
-                                    throw new RuntimeException(
-                                        executionException.getMessage(),
-                                        executionException.getCause()
-                                    );
+                                    final var cause = NestedExceptionUtils.getMostSpecificCause(executionException);
+                                    throw new RuntimeException(cause.getMessage(), cause);
                                 }
                             } catch (Exception connectorError) {
                                 connectorErrorHandlerDefinitionResolver

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -95,7 +95,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
         @Value(
             "${activiti.connector.async-executor.cancel-remaining-tasks-on-close:true}"
         ) Boolean cancelRemainingTasksOnClose,
-        @Value("${activiti.connector.async-executor.virutal-threads:true}") Boolean virtualThreads
+        @Value("${activiti.connector.async-executor.virtual-threads:true}") Boolean virtualThreads
     ) {
         return new SimpleAsyncTaskExecutorBuilder()
             .threadNamePrefix("connectorAsyncTaskExecutor-")
@@ -185,6 +185,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
                                         }
                                     }
                                 } catch (InterruptedException interruptedException) {
+                                    future.cancel(true);
                                     Thread.currentThread().interrupt();
                                     throw new RuntimeException(
                                         "Interrupted while waiting for result",
@@ -313,7 +314,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
         @Value("${activiti.connector.integration-result-timeout:PT25M}") Duration defaultResultTimeout,
         Function<String, String> resolveExpression
     ) {
-        final var ISO8601DurationPattern = Pattern.compile("^PT(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$");
+        final var ISO8601DurationPattern = Pattern.compile("^PT(?=.*\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?$");
         final Function<String, Duration> toDuration = value ->
             Optional.of(value)
                 .filter(Predicate.not(String::isBlank))

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/config/ConnectorConfiguration.java
@@ -86,12 +86,18 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
 
     @Bean
     @ConditionalOnMissingBean(name = "connectorAsyncTaskExecutor")
-    AsyncTaskExecutor connectorAsyncTaskExecutor() {
+    AsyncTaskExecutor connectorAsyncTaskExecutor(
+        @Value("${activiti.connector.async-executor.task-termination-timeout:20s}") Duration taskTerminationTimeout,
+        @Value(
+            "${activiti.connector.async-executor.cancel-remaining-tasks-on-close:true}"
+        ) Boolean cancelRemainingTasksOnClose,
+        @Value("${activiti.connector.async-executor.virutal-threads:true}") Boolean virtualThreads
+    ) {
         return new SimpleAsyncTaskExecutorBuilder()
-            .concurrencyLimit(Runtime.getRuntime().availableProcessors())
-            .cancelRemainingTasksOnClose(true)
-            .threadNamePrefix("connector-executor-")
-            .virtualThreads(true)
+            .threadNamePrefix("connectorAsyncTaskExecutor-")
+            .taskTerminationTimeout(taskTerminationTimeout)
+            .cancelRemainingTasksOnClose(cancelRemainingTasksOnClose)
+            .virtualThreads(virtualThreads)
             .build();
     }
 
@@ -108,7 +114,7 @@ public class ConnectorConfiguration extends AbstractFunctionalBindingConfigurati
         AsyncTaskExecutor connectorAsyncTaskExecutor,
         @Value("${activiti.connector.retry.default.max:-1}") int defaultMaxRetry,
         @Value("${activiti.connector.retry.default.delay:0}") Long defaultRetryDelay,
-        @Value("${activiti.connector.integration.resultTimeout:25m}") Duration defaultResultTimeout
+        @Value("${activiti.connector.integration-result-timeout:25m}") Duration defaultResultTimeout
     ) {
         return new BeanPostProcessor() {
             @Override

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
@@ -41,5 +41,5 @@ public @interface ConnectorBinding {
     // Time to wait before retry in second
     long retryDelay() default 0;
 
-    String integrationResultTimeout() default "PT25M";
+    String integrationResultTimeout() default "";
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/main/java/org/activiti/cloud/common/messaging/functional/ConnectorBinding.java
@@ -40,4 +40,6 @@ public @interface ConnectorBinding {
 
     // Time to wait before retry in second
     long retryDelay() default 0;
+
+    String integrationResultTimeout() default "PT25M";
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -284,7 +284,7 @@ public class ConnectorConfigurationIT {
             output = INTEGRATION_RESULTS,
             connectorType = "script.EXECUTE",
             condition = "headers['type']=='TestInterrupt'",
-            integrationResultTimeout = "PT10S"
+            integrationResultTimeout = "${SCRIPT_TIMEOUT:PT10S}"
         )
         public ThrowingConsumer<String> consumerInterrupt() {
             return payload -> {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -282,7 +282,7 @@ public class ConnectorConfigurationIT {
             output = INTEGRATION_RESULTS,
             connectorType = "script.EXECUTE",
             condition = "headers['type']=='TestInterrupt'",
-            integrationResultTimeout = "PT5S"
+            integrationResultTimeout = "PT10S"
         )
         public ThrowingConsumer<String> consumerInterrupt() {
             return payload -> {

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -271,6 +272,7 @@ public class ConnectorConfigurationIT {
 
                     TimeUnit.of(ChronoUnit.SECONDS).sleep(2);
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     connectorTimeoutCounter.incrementAndGet();
                 }
             };
@@ -293,8 +295,7 @@ public class ConnectorConfigurationIT {
                     Thread.sleep(Duration.ofSeconds(5).toMillis());
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt(); // Restores flag
-
-                    throw new InterruptedException();
+                    throw e;
                 }
             };
         }
@@ -304,6 +305,8 @@ public class ConnectorConfigurationIT {
     public void setUp() {
         expression = resolveExpression(condition);
         output.clear();
+        connectorWorkerThread.set(null);
+        clearInvocations(myErrorHandler);
         myErrorHandler.reset();
     }
 

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -15,12 +15,17 @@
  */
 package org.activiti.cloud.common.messaging.config.test;
 
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.*;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_RESULTS;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_REQUESTS;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_RESULTS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.nio.charset.StandardCharsets;

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -15,20 +15,16 @@
  */
 package org.activiti.cloud.common.messaging.config.test;
 
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_RESULTS;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_REQUESTS;
-import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_RESULTS;
+import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +72,7 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.util.function.ThrowingConsumer;
 
 @SpringBootTest(
     properties = {
@@ -107,11 +104,13 @@ public class ConnectorConfigurationIT {
     private static final String FUNCTION_NAME_ERROR = "connectorTestMyErrorHandler";
     private static final String FUNCTION_NAME_RETRY = "connectorWithRetry";
     private static final String FUNCTION_NAME_TIMEOUT = "connectorWithTimeout";
+    private static final String FUNCTION_NAME_INTERRUPT = "connectorWithInterrupt";
 
     private static final String FUNCTION_NAME_D = "auditProcessorVersionHandler";
     public static final String MY_ERROR_HANDLER = "myErrorHandler";
     private static final AtomicInteger connectorTestMyErrorHandlerCounter = new AtomicInteger(0);
     private static final AtomicInteger connectorTimeoutCounter = new AtomicInteger(0);
+    private static final AtomicReference<Thread> connectorWorkerThread = new AtomicReference<>();
 
     @Autowired
     private StandardEvaluationContext evaluationContext;
@@ -265,9 +264,32 @@ public class ConnectorConfigurationIT {
                 try {
                     assertThat(payload).isNotNull().isEqualTo("TestTimeout");
 
-                    TimeUnit.of(ChronoUnit.SECONDS).sleep(2000L);
+                    TimeUnit.of(ChronoUnit.SECONDS).sleep(2);
                 } catch (InterruptedException e) {
                     connectorTimeoutCounter.incrementAndGet();
+                }
+            };
+        }
+
+        @Bean(FUNCTION_NAME_INTERRUPT)
+        @ConnectorBinding(
+            input = INTEGRATION_REQUESTS,
+            output = INTEGRATION_RESULTS,
+            connectorType = "script.EXECUTE",
+            condition = "headers['type']=='TestInterrupt'",
+            integrationResultTimeout = "PT5S"
+        )
+        public ThrowingConsumer<String> consumerInterrupt() {
+            return payload -> {
+                assertThat(payload).isNotNull().isEqualTo("TestInterrupt");
+                connectorWorkerThread.set(Thread.currentThread());
+
+                try {
+                    Thread.sleep(Duration.ofSeconds(5).toMillis());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt(); // Restores flag
+
+                    throw new InterruptedException();
                 }
             };
         }
@@ -277,6 +299,7 @@ public class ConnectorConfigurationIT {
     public void setUp() {
         expression = resolveExpression(condition);
         output.clear();
+        myErrorHandler.reset();
     }
 
     @Test
@@ -547,7 +570,6 @@ public class ConnectorConfigurationIT {
             .build();
 
         // when
-        long start = System.currentTimeMillis();
         input.send(message, "script.EXECUTE");
 
         //Check delay execution = (retries -1) * delay time. It is a bit greater because some operation overload
@@ -567,7 +589,7 @@ public class ConnectorConfigurationIT {
     }
 
     @Test
-    public void testShouldDiscardMessageOnExecutionTimeout() {
+    public void testShouldHandleErrorOnExecutionTimeout() {
         // given
         connectorTimeoutCounter.set(0);
 
@@ -580,8 +602,7 @@ public class ConnectorConfigurationIT {
             .build();
 
         // when
-        long start = System.currentTimeMillis();
-        input.send(message, "script.EXECUTE");
+        new Thread(() -> input.send(message, "script.EXECUTE")).start();
 
         await().untilAtomic(myErrorHandler.getReference(), Matchers.notNullValue());
 
@@ -595,6 +616,34 @@ public class ConnectorConfigurationIT {
             .isEqualTo("Timeout after PT1S while waiting for result");
 
         assertThat(connectorTimeoutCounter.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void testShouldHandleErrorOnExecutionInterrupt() {
+        // given
+        byte[] payload = "TestInterrupt".getBytes();
+        Message<?> message = MessageBuilder.withPayload(payload)
+            .setHeader("appVersion", "20")
+            .setHeader("type", "TestInterrupt")
+            .setHeader("resultDestination", "commandResults")
+            .setHeader("connectorType", "script.EXECUTE")
+            .build();
+
+        // when
+        new Thread(() -> input.send(message, "script.EXECUTE")).start();
+
+        await().untilAtomic(connectorWorkerThread, Matchers.notNullValue());
+
+        connectorWorkerThread.get().interrupt();
+
+        await().untilAtomic(myErrorHandler.getReference(), Matchers.notNullValue());
+
+        // then
+        verify(myErrorHandler, times(1)).accept(any(ErrorMessage.class));
+
+        Assertions.assertThat(myErrorHandler.getReference().get().getPayload()).hasRootCauseInstanceOf(
+            InterruptedException.class
+        );
     }
 
     @Test
@@ -635,6 +684,10 @@ public class ConnectorConfigurationIT {
 
         public AtomicReference<ErrorMessage> getReference() {
             return reference;
+        }
+
+        public void reset() {
+            reference.set(null);
         }
     }
 }

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -29,8 +29,11 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.cloud.function.context.FunctionRegistration.REGISTRATION_NAME_SUFFIX;
 
 import java.nio.charset.StandardCharsets;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -103,10 +106,12 @@ public class ConnectorConfigurationIT {
     private static final String FUNCTION_NAME_C = "auditProcessorHandler";
     private static final String FUNCTION_NAME_ERROR = "connectorTestMyErrorHandler";
     private static final String FUNCTION_NAME_RETRY = "connectorWithRetry";
+    private static final String FUNCTION_NAME_TIMEOUT = "connectorWithTimeout";
 
     private static final String FUNCTION_NAME_D = "auditProcessorVersionHandler";
     public static final String MY_ERROR_HANDLER = "myErrorHandler";
     private static final AtomicInteger connectorTestMyErrorHandlerCounter = new AtomicInteger(0);
+    private static final AtomicInteger connectorTimeoutCounter = new AtomicInteger(0);
 
     @Autowired
     private StandardEvaluationContext evaluationContext;
@@ -244,6 +249,26 @@ public class ConnectorConfigurationIT {
         public ConsumerConnector<?> consumerRetry() {
             return payload -> {
                 assertThat(payload).isNotNull().isEqualTo("TestRetry");
+            };
+        }
+
+        @Bean(FUNCTION_NAME_TIMEOUT)
+        @ConnectorBinding(
+            input = INTEGRATION_REQUESTS,
+            output = INTEGRATION_RESULTS,
+            connectorType = "script.EXECUTE",
+            condition = "headers['type']=='TestTimeout'",
+            integrationResultTimeout = "PT1S"
+        )
+        public ConsumerConnector<String> consumerTimeout() {
+            return payload -> {
+                try {
+                    assertThat(payload).isNotNull().isEqualTo("TestTimeout");
+
+                    TimeUnit.of(ChronoUnit.SECONDS).sleep(2000L);
+                } catch (InterruptedException e) {
+                    connectorTimeoutCounter.incrementAndGet();
+                }
             };
         }
     }
@@ -539,6 +564,37 @@ public class ConnectorConfigurationIT {
             Message<byte[]> reply = output.receive(2000, bindingResolver.getBindingDestination(COMMAND_RESULTS));
             assertThat(reply).isNull();
         });
+    }
+
+    @Test
+    public void testShouldDiscardMessageOnExecutionTimeout() {
+        // given
+        connectorTimeoutCounter.set(0);
+
+        byte[] payload = "TestTimeout".getBytes();
+        Message<?> message = MessageBuilder.withPayload(payload)
+            .setHeader("appVersion", "20")
+            .setHeader("type", "TestTimeout")
+            .setHeader("resultDestination", "commandResults")
+            .setHeader("connectorType", "script.EXECUTE")
+            .build();
+
+        // when
+        long start = System.currentTimeMillis();
+        input.send(message, "script.EXECUTE");
+
+        await().untilAtomic(myErrorHandler.getReference(), Matchers.notNullValue());
+
+        // then
+        verify(myErrorHandler, times(1)).accept(any(ErrorMessage.class));
+
+        Assertions.assertThat(myErrorHandler.getReference().get().getPayload())
+            .hasRootCauseInstanceOf(TimeoutException.class)
+            .extracting(Throwable::getCause)
+            .extracting(Throwable::getMessage)
+            .isEqualTo("Timeout after PT1S while waiting for result");
+
+        assertThat(connectorTimeoutCounter.get()).isEqualTo(1);
     }
 
     @Test

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -111,6 +111,7 @@ public class ConnectorConfigurationIT {
     private static final String FUNCTION_NAME_RETRY = "connectorWithRetry";
     private static final String FUNCTION_NAME_TIMEOUT = "connectorWithTimeout";
     private static final String FUNCTION_NAME_INTERRUPT = "connectorWithInterrupt";
+    private static final String FUNCTION_NAME_TIMEOUT_HEADER = "connectorWithTimeoutHeader";
 
     private static final String FUNCTION_NAME_D = "auditProcessorVersionHandler";
     public static final String MY_ERROR_HANDLER = "myErrorHandler";
@@ -296,6 +297,33 @@ public class ConnectorConfigurationIT {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt(); // Restores flag
                     throw e;
+                }
+            };
+        }
+
+        @Bean(FUNCTION_NAME_TIMEOUT_HEADER)
+        @ConnectorBinding(
+            input = INTEGRATION_REQUESTS,
+            output = INTEGRATION_RESULTS,
+            connectorType = "script.EXECUTE",
+            condition = "headers['type']=='TestTimeoutHeader'"
+        )
+        public Consumer<Message<String>> consumerTimeoutHeader() {
+            return message -> {
+                try {
+                    final var integrationResultTimeout = assertThat(
+                        message.getHeaders().get("integrationResultTimeout", String.class)
+                    )
+                        .isNotNull()
+                        .isEqualTo("PT1S")
+                        .actual();
+
+                    TimeUnit.of(ChronoUnit.SECONDS).sleep(
+                        Duration.parse(integrationResultTimeout).plusSeconds(5).toSeconds()
+                    );
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    connectorTimeoutCounter.incrementAndGet();
                 }
             };
         }
@@ -652,6 +680,36 @@ public class ConnectorConfigurationIT {
         Assertions.assertThat(myErrorHandler.getReference().get().getPayload()).hasRootCauseInstanceOf(
             InterruptedException.class
         );
+    }
+
+    @Test
+    public void testShouldHandleErrorOnExecutionTimeoutHeader() {
+        // given
+        connectorTimeoutCounter.set(0);
+
+        Message<?> message = MessageBuilder.withPayload("TestTimeoutHeader".getBytes())
+            .setHeader("appVersion", "20")
+            .setHeader("type", "TestTimeoutHeader")
+            .setHeader("resultDestination", "commandResults")
+            .setHeader("connectorType", "script.EXECUTE")
+            .setHeader("integrationResultTimeout", "PT1S")
+            .build();
+
+        // when
+        new Thread(() -> input.send(message, "script.EXECUTE")).start();
+
+        await().untilAtomic(myErrorHandler.getReference(), Matchers.notNullValue());
+
+        // then
+        verify(myErrorHandler, times(1)).accept(any(ErrorMessage.class));
+
+        Assertions.assertThat(myErrorHandler.getReference().get().getPayload())
+            .hasRootCauseInstanceOf(TimeoutException.class)
+            .extracting(Throwable::getCause)
+            .extracting(Throwable::getMessage)
+            .isEqualTo("Timeout after PT1S while waiting for result");
+
+        assertThat(connectorTimeoutCounter.get()).isEqualTo(1);
     }
 
     @Test

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -278,7 +278,9 @@ public class ConnectorConfigurationIT {
         public Consumer<Message<String>> consumerTimeout() {
             return message -> {
                 try {
-                    assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT)).isNotNull().isEqualTo("PT1S");
+                    assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT))
+                        .isNotNull()
+                        .isEqualTo(Duration.ofSeconds(1));
 
                     TimeUnit.of(ChronoUnit.SECONDS).sleep(2);
                 } catch (InterruptedException e) {
@@ -299,7 +301,9 @@ public class ConnectorConfigurationIT {
         public Consumer<Message<String>> consumerInterrupt() {
             return message -> {
                 assertThat(message.getPayload()).isNotNull().isEqualTo("TestInterrupt");
-                assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT)).isNotNull().isEqualTo("PT10S");
+                assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT))
+                    .isNotNull()
+                    .isEqualTo(Duration.ofSeconds(10));
 
                 connectorWorkerThread.set(Thread.currentThread());
 
@@ -323,15 +327,13 @@ public class ConnectorConfigurationIT {
             return message -> {
                 try {
                     final var integrationResultTimeout = assertThat(
-                        message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT, String.class)
+                        message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT, Duration.class)
                     )
                         .isNotNull()
-                        .isEqualTo("PT1S")
+                        .isEqualTo(Duration.ofSeconds(1))
                         .actual();
 
-                    TimeUnit.of(ChronoUnit.SECONDS).sleep(
-                        Duration.parse(integrationResultTimeout).plusSeconds(5).toSeconds()
-                    );
+                    TimeUnit.of(ChronoUnit.SECONDS).sleep(integrationResultTimeout.plusSeconds(5).toSeconds());
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     connectorTimeoutCounter.incrementAndGet();

--- a/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-service-messaging-config/src/test/java/org/activiti/cloud/common/messaging/config/test/ConnectorConfigurationIT.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.common.messaging.config.test;
 
+import static org.activiti.cloud.common.messaging.config.ConnectorConfiguration.INTEGRATION_RESULT_TIMEOUT;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.AUDIT_CONSUMER;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.COMMAND_RESULTS;
 import static org.activiti.cloud.common.messaging.config.test.TestBindingsChannels.INTEGRATION_REQUESTS;
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import org.activiti.cloud.common.messaging.config.FunctionBindingConfiguration.BindingResolver;
 import org.activiti.cloud.common.messaging.config.FunctionBindingPropertySource;
@@ -70,6 +72,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -78,7 +81,6 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.util.function.ThrowingConsumer;
 
 @SpringBootTest(
     properties = {
@@ -98,6 +100,7 @@ import org.springframework.util.function.ThrowingConsumer;
         "spring.cloud.stream.bindings.integrationResults.destination=integrationResults",
         "spring.cloud.stream.bindings.[script.EXECUTE].destination=script.EXECUTE",
         "spring.cloud.stream.default.error-handler-definition=myErrorHandler",
+        "SCRIPT_EXECUTE_TIMEOUT=PT10S",
     }
 )
 @Import({ TestChannelBinderConfiguration.class, TestBindingsChannelsConfiguration.class })
@@ -142,6 +145,12 @@ public class ConnectorConfigurationIT {
 
     @Autowired
     private BindingServiceProperties bindingServiceProperties;
+
+    @Autowired
+    private AsyncTaskExecutor connectorAsyncTaskExecutor;
+
+    @Autowired
+    private BiFunction<Message<?>, ConnectorBinding, Duration> connectorIntegrationResultTimeoutResolver;
 
     @MockitoSpyBean
     private MyErrorHandler myErrorHandler;
@@ -266,10 +275,10 @@ public class ConnectorConfigurationIT {
             condition = "headers['type']=='TestTimeout'",
             integrationResultTimeout = "PT1S"
         )
-        public ConsumerConnector<String> consumerTimeout() {
-            return payload -> {
+        public Consumer<Message<String>> consumerTimeout() {
+            return message -> {
                 try {
-                    assertThat(payload).isNotNull().isEqualTo("TestTimeout");
+                    assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT)).isNotNull().isEqualTo("PT1S");
 
                     TimeUnit.of(ChronoUnit.SECONDS).sleep(2);
                 } catch (InterruptedException e) {
@@ -285,18 +294,20 @@ public class ConnectorConfigurationIT {
             output = INTEGRATION_RESULTS,
             connectorType = "script.EXECUTE",
             condition = "headers['type']=='TestInterrupt'",
-            integrationResultTimeout = "${SCRIPT_TIMEOUT:PT10S}"
+            integrationResultTimeout = "${SCRIPT_EXECUTE_TIMEOUT}"
         )
-        public ThrowingConsumer<String> consumerInterrupt() {
-            return payload -> {
-                assertThat(payload).isNotNull().isEqualTo("TestInterrupt");
+        public Consumer<Message<String>> consumerInterrupt() {
+            return message -> {
+                assertThat(message.getPayload()).isNotNull().isEqualTo("TestInterrupt");
+                assertThat(message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT)).isNotNull().isEqualTo("PT10S");
+
                 connectorWorkerThread.set(Thread.currentThread());
 
                 try {
                     Thread.sleep(Duration.ofSeconds(5).toMillis());
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt(); // Restores flag
-                    throw e;
+                    throw new RuntimeException(e);
                 }
             };
         }
@@ -312,7 +323,7 @@ public class ConnectorConfigurationIT {
             return message -> {
                 try {
                     final var integrationResultTimeout = assertThat(
-                        message.getHeaders().get("integrationResultTimeout", String.class)
+                        message.getHeaders().get(INTEGRATION_RESULT_TIMEOUT, String.class)
                     )
                         .isNotNull()
                         .isEqualTo("PT1S")
@@ -657,8 +668,7 @@ public class ConnectorConfigurationIT {
     @Test
     public void testShouldHandleErrorOnExecutionInterrupt() {
         // given
-        byte[] payload = "TestInterrupt".getBytes();
-        Message<?> message = MessageBuilder.withPayload(payload)
+        Message<?> message = MessageBuilder.withPayload("TestInterrupt".getBytes())
             .setHeader("appVersion", "20")
             .setHeader("type", "TestInterrupt")
             .setHeader("resultDestination", "commandResults")
@@ -692,7 +702,7 @@ public class ConnectorConfigurationIT {
             .setHeader("type", "TestTimeoutHeader")
             .setHeader("resultDestination", "commandResults")
             .setHeader("connectorType", "script.EXECUTE")
-            .setHeader("integrationResultTimeout", "PT1S")
+            .setHeader(INTEGRATION_RESULT_TIMEOUT, "PT1S")
             .build();
 
         // when
@@ -717,6 +727,62 @@ public class ConnectorConfigurationIT {
         assertThat(bindingServiceProperties.getBindings().get("integrationRequests")).isEqualTo(
             bindingServiceProperties.getBindings().get("integrationrequests")
         );
+    }
+
+    @Test
+    void connectorIntegrationResultTimeoutResolver() {
+        assertThat(
+            connectorIntegrationResultTimeoutResolver.apply(
+                MessageBuilder.withPayload("foo").build(),
+                AnnotationUtils.synthesizeAnnotation(ConnectorBinding.class)
+            )
+        )
+            .as("Should fallback to default value")
+            .isEqualTo(Duration.ofMinutes(25));
+
+        assertThat(
+            connectorIntegrationResultTimeoutResolver.apply(
+                MessageBuilder.withPayload("foo").setHeader(INTEGRATION_RESULT_TIMEOUT, "PT01S").build(),
+                AnnotationUtils.synthesizeAnnotation(ConnectorBinding.class)
+            )
+        )
+            .as("Should apply value from message headers")
+            .isEqualTo(Duration.ofSeconds(1));
+
+        assertThat(
+            connectorIntegrationResultTimeoutResolver.apply(
+                MessageBuilder.withPayload("foo").setHeader(INTEGRATION_RESULT_TIMEOUT, "PT30M").build(),
+                AnnotationUtils.synthesizeAnnotation(ConnectorBinding.class)
+            )
+        )
+            .as("Should apply default value if greater than PT25M")
+            .isEqualTo(Duration.ofMinutes(25));
+
+        assertThat(
+            connectorIntegrationResultTimeoutResolver.apply(
+                MessageBuilder.withPayload("foo").build(),
+                AnnotationUtils.synthesizeAnnotation(
+                    Map.of(INTEGRATION_RESULT_TIMEOUT, "PT30M"),
+                    ConnectorBinding.class,
+                    null
+                )
+            )
+        )
+            .as("Should apply default value if greater than PT25M")
+            .isEqualTo(Duration.ofMinutes(25));
+
+        assertThat(
+            connectorIntegrationResultTimeoutResolver.apply(
+                MessageBuilder.withPayload("foo").build(),
+                AnnotationUtils.synthesizeAnnotation(
+                    Map.of(INTEGRATION_RESULT_TIMEOUT, "30"),
+                    ConnectorBinding.class,
+                    null
+                )
+            )
+        )
+            .as("Should apply default value if incorrect timeout value provided")
+            .isEqualTo(Duration.ofMinutes(25));
     }
 
     @Captor


### PR DESCRIPTION
## Pull request overview

Adds configurable integration-result timeouts for connector executions in `activiti-cloud-service-messaging-config`, executing connector functions asynchronously and translating timeout/interrupt/async failures into the existing error-handler flow.

**Changes:**
- Introduces a new config property `activiti.connector.integration-result-timeout` (Duration) with a default value of 25 minutes.
- Extend `@ConnectorBinding` with `integrationResultTimeout` and resolve a timeout per-message / per-binding / global default.
- Run connector function invocation in an `AsyncTaskExecutor` and enforce a `Future.get(...)` timeout, cancelling on timeout and propagating errors to the configured error handler.
- Add IT coverage for timeout and interrupt scenarios.

https://hyland.atlassian.net/browse/AAE-47636