### PR TITLE
AAE-41740 Apply outbox mapper config to message payload deserialization

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/main/java/org/activiti/cloud/starter/query/consumer/config/ActivitiQueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/main/java/org/activiti/cloud/starter/query/consumer/config/ActivitiQueryConsumerAutoConfiguration.java
@@ -38,12 +38,23 @@ import org.springframework.integration.jdbc.store.channel.JsonChannelMessageStor
 import org.springframework.integration.jdbc.store.channel.JsonMessageRowMapper;
 import org.springframework.integration.jdbc.store.channel.OracleChannelMessageStoreQueryProvider;
 import org.springframework.integration.jdbc.store.channel.PostgresChannelMessageStoreQueryProvider;
+import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.store.ChannelMessageStore;
+import org.springframework.integration.support.MutableMessage;
+import org.springframework.integration.support.json.AdviceMessageJsonDeserializer;
+import org.springframework.integration.support.json.ErrorMessageJsonDeserializer;
+import org.springframework.integration.support.json.GenericMessageJsonDeserializer;
 import org.springframework.integration.support.json.JacksonJsonObjectMapper;
 import org.springframework.integration.support.json.JacksonMessagingUtils;
+import org.springframework.integration.support.json.MutableMessageJsonDeserializer;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.MetaDataAccessException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.cfg.ConstructorDetector;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 @AutoConfiguration(before = QueryConsumerAutoConfiguration.class, after = DataSourceAutoConfiguration.class)
 @PropertySource("classpath:query-messaging.properties")
@@ -90,15 +101,53 @@ public class ActivitiQueryConsumerAutoConfiguration {
             "${activiti.cloud.query.consumer.events.json.trusted-packages:org.activiti.api,org.activiti.cloud.api,java.math,java.time}"
         ) String[] trustedPackages
     ) {
-        final var jsonObjectMapper = new JacksonJsonObjectMapper(
-            JacksonMessagingUtils.messagingAwareMapper(trustedPackages)
-                .rebuild()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
-                .build()
-        );
+        return () -> new JacksonJsonObjectMapper(outboxMessageMapper(trustedPackages));
+    }
 
-        return () -> jsonObjectMapper;
+    /**
+     * Builds the {@link JsonMapper} used to persist and read back {@code queryEvents} outbox messages.
+     *
+     * <p>{@link JacksonMessagingUtils#messagingAwareMapper} captures the mapper instance it builds inside
+     * the message deserializers it registers (each {@code Message} payload is read with that captured
+     * instance). Calling {@code .rebuild()} on the returned mapper produces a <em>new</em> mapper whose
+     * deserializers still reference the original, so any configuration applied through {@code rebuild()}
+     * never reaches the payload. We therefore re-register fresh message deserializers, build the mapper
+     * with our settings, and wire that same instance back into them — so the configuration applies to the
+     * payload as well as the envelope. See AAE-41740.
+     *
+     * <p>{@code EXPLICIT_ONLY} is the actual fix: Jackson 3 otherwise auto-promotes a single all-args
+     * constructor to a properties-based creator, which looks up parameters by name (e.g. {@code isPublic})
+     * while the JSON carries the getter-derived property name ({@code public}); the parameter then arrives
+     * absent and a primitive blows up. {@code EXPLICIT_ONLY} keeps deserialization on the no-arg
+     * constructor + setters path, so every event type round-trips without per-class annotations. The
+     * {@code FAIL_ON_*} relaxations are retained as outbox forward-compatibility, not as the fix.
+     */
+    private static JsonMapper outboxMessageMapper(String[] trustedPackages) {
+        final var genericMessageDeserializer = new GenericMessageJsonDeserializer();
+        final var errorMessageDeserializer = new ErrorMessageJsonDeserializer();
+        final var adviceMessageDeserializer = new AdviceMessageJsonDeserializer();
+        final var mutableMessageDeserializer = new MutableMessageJsonDeserializer();
+
+        final var messageModule = new SimpleModule()
+            .addDeserializer(GenericMessage.class, genericMessageDeserializer)
+            .addDeserializer(ErrorMessage.class, errorMessageDeserializer)
+            .addDeserializer(AdviceMessage.class, adviceMessageDeserializer)
+            .addDeserializer(MutableMessage.class, mutableMessageDeserializer);
+
+        final var mapper = JacksonMessagingUtils.messagingAwareMapper(trustedPackages)
+            .rebuild()
+            .constructorDetector(ConstructorDetector.EXPLICIT_ONLY)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+            .addModules(messageModule)
+            .build();
+
+        genericMessageDeserializer.setMapper(mapper);
+        errorMessageDeserializer.setMapper(mapper);
+        adviceMessageDeserializer.setMapper(mapper);
+        mutableMessageDeserializer.setMapper(mapper);
+
+        return mapper;
     }
 
     @Bean


### PR DESCRIPTION
## What this fixes

The `queryEvents` transactional outbox (added under AAE-41740) persists each Spring Integration `Message` to the `QUERY_INT_CHANNEL_MESSAGE` table as JSON, then reads it back when the poller dequeues it. Under Jackson 3, certain event payloads **serialize fine but cannot be read back**, so the row becomes a poison message: the poller throws forever and the query-events relay stalls.

Observed failure:

```
Cannot map `null` into type `boolean`
 (through reference chain:
   ArrayList[0]
   -> CloudUserActionFormSubmittedEventImpl["entity"]
   -> FormSubmittedEventImpl["isPublic"])
```

## Why it happens

It's the **same** `JsonObjectMapper` on both the write and read side, but Jackson uses different machinery for each direction and they disagree on the property name:

| Direction | Driven by | Property name |
|---|---|---|
| **Write** | the boolean getter `isPublic()` (Jackson strips the `is` prefix) | `public` |
| **Read** | the single all-args **constructor**, which Jackson 3 now auto-selects as a *properties-based creator*; its parameter is named `isPublic` (from `-parameters`) | `isPublic` |

So we write `"public": false` but on read-back Jackson looks for `isPublic`, doesn't find it, treats it as absent → `null` → and a primitive `boolean` can't be null → exception.

This is a **Jackson 3 behavioural change**. In Jackson 2 that constructor would not have been auto-promoted to a creator, so deserialization fell back to *no-arg constructor + setters*, and the `setPublic(...)` setter maps to property `public` — matching the getter. Jackson 3 silently broke that symmetry.

## Why earlier attempts didn't work

Previous fixes set `FAIL_ON_NULL_FOR_PRIMITIVES=false` / `EXPLICIT_ONLY` via `messagingAwareMapper(...).rebuild()...build()`. These had **no effect on the payload**, because of a subtlety in Spring Integration:

`JacksonMessagingUtils.messagingAwareMapper()` builds a mapper and **captures that exact instance inside the message deserializers** it registers (`genericMessageDeserializer.setMapper(mapper)`). The message *payload* is deserialized with that captured instance. Calling `.rebuild()` produces a **new** mapper carrying our settings, but the deserializers embedded in it still point at the **original** un-configured mapper. Net result: our config reached the envelope, never the payload.

## The fix

Build the outbox mapper the same way `messagingAwareMapper` does, but:
1. apply our settings to the builder **before** `build()`, and
2. **re-wire the freshly-built mapper back into the message deserializers** via `setMapper(...)`,

so the configuration actually applies to the payload as well as the envelope.

The actual fix is `ConstructorDetector.EXPLICIT_ONLY`, which stops Jackson 3 from auto-promoting the all-args constructor to a creator — restoring the Jackson-2 no-arg + setter path so `public` round-trips correctly. This is a **single global setting that covers every event type**, with no per-class annotations to remember when new message types are added. The `FAIL_ON_*` relaxations are retained as outbox forward-compatibility (tolerate unknown/absent fields across schema changes), not as the fix.

## Verification

Reproduced standalone against the **exact** production message and the real compiled event classes (with `-parameters`):
- ❌ before: throws the exact production stack trace, frame-for-frame
- ✅ after: deserializes; `isPublic` value is **preserved** (`true`→`true`, `false`→`false`, not silently defaulted)
- ✅ the trusted-package allow-list still rejects untrusted classes (security unchanged)

## Scope

One file: `ActivitiQueryConsumerAutoConfiguration`. Behaviour-only change to how the outbox `JsonObjectMapper` is constructed; no schema or API changes.
