### PR TITLE
AAE-43069 Restore missing IT modules in maven-build-common CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,11 +128,15 @@ jobs:
         id: common-modules
         run: |
           STANDALONE_MODULES=(
+            activiti-cloud-messages-service/integration-tests
             activiti-cloud-messages-service/starters/hazelcast
+            activiti-cloud-messages-service/starters/jdbc
             activiti-cloud-messages-service/starters/redis
             activiti-cloud-notifications-graphql-service/gatling
+            activiti-cloud-notifications-graphql-service/starter
             activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-basic
             activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-runtime-bundle-rest-client
+            activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it
           )
           MODULES=$(
             {


### PR DESCRIPTION
## Summary

- Add four standalone modules back to the `maven-build-common` `STANDALONE_MODULES` list that were dropped after the parallel CI pipeline rebase
- Restores integration test coverage for modules not covered by Playwright acceptance tests

## Context

Follow-up to [AAE-43069](https://hyland.atlassian.net/browse/AAE-43069) / [AAE-47784](https://hyland.atlassian.net/browse/AAE-47784).

Reported gap in PR builds: https://github.com/Activiti/activiti-cloud/actions/runs/28384465410/job/84095576327?pr=2399#step:4:1003

## Modules added

- `activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it`
- `activiti-cloud-messages-service/integration-tests`
- `activiti-cloud-messages-service/starters/jdbc`
- `activiti-cloud-notifications-graphql-service/starter` (`activiti-cloud-starter-notifications-graphql`)

## Test plan

- [ ] CI `maven-build-common` job includes the four modules in its reactor
- [ ] Integration tests for the listed modules run and pass on PR builds


Made with [Cursor](https://cursor.com)

[AAE-43069]: https://hyland.atlassian.net/browse/AAE-43069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAE-47784]: https://hyland.atlassian.net/browse/AAE-47784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ