### PR TITLE
AAE-47668 Revert 'Add interface for GET /v1/groups/{id} (#2404)'

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementService.java
@@ -273,13 +273,6 @@ public class KeycloakManagementService implements IdentityManagementService, Ide
     }
 
     @Override
-    public Group findGroupById(String groupId) {
-        return Optional.of(keycloakClient.getGroupById(groupId))
-            .map(KeycloakGroupToGroup::toGroup)
-            .orElseThrow(() -> new IdentityInvalidGroupException(groupId));
-    }
-
-    @Override
     public List<User> findUsersByGroupName(String groupName) {
         Group groupFound = findGroupStrictlyEqualToGroupName(groupName);
         return getUsersByGroupId(groupFound.getId());

--- a/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakManagementServiceTest.java
@@ -643,16 +643,6 @@ class KeycloakManagementServiceTest {
     }
 
     @Test
-    void should_returnGroup_when_searchingByGroupId() {
-        when(keycloakClient.getGroupById(kGroupOne.getId())).thenReturn(kGroupOne);
-
-        Group group = keycloakManagementService.findGroupById(kGroupOne.getId());
-        assertThat(group).isNotNull();
-        assertThat(group).isEqualTo(groupOne);
-        assertThat(group.getName()).isEqualTo(kGroupOne.getName());
-    }
-
-    @Test
     void should_throwException_when_groupNameNotFound() {
         Throwable thrown = catchThrowable(() -> keycloakManagementService.findUsersByGroupName(NON_EXISTENT_GROUP));
         assertThat(thrown)

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/IdentityManagementService.java
@@ -41,6 +41,4 @@ public interface IdentityManagementService {
     List<SecurityResponseRepresentation> getApplicationPermissions(String application, Set<String> roles);
 
     User findUserById(String userId);
-
-    Group findGroupById(String groupId);
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementController.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-security/src/main/java/org/activiti/cloud/identity/web/controller/IdentityManagementController.java
@@ -102,9 +102,4 @@ public class IdentityManagementController {
     public User getUsersById(@PathVariable String id) {
         return identityManagementService.findUserById(id);
     }
-
-    @GetMapping(value = "/groups/{id}")
-    public Group getGroupsById(@PathVariable String id) {
-        return identityManagementService.findGroupById(id);
-    }
 }

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/pom.xml
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/pom.xml
@@ -19,11 +19,6 @@
       <artifactId>spring-boot-starter-security-test</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-test-security/src/main/java/org/activiti/cloud/identity/web/controller/AbstractIdentityManagementControllerIT.java
@@ -25,7 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
-import com.jayway.jsonpath.JsonPath;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,21 +63,6 @@ public abstract class AbstractIdentityManagementControllerIT {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(2)))
             .andExpect(jsonPath("$[?(@.name)].name", containsInAnyOrder("testgroup", "salesgroup")));
-    }
-
-    @Test
-    public void should_returnGroup_when_searchById() throws Exception {
-        String content = this.mockMvc.perform(get("/v1/groups?search=testgroup"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-        String groupId = JsonPath.read(content, "$[0].id");
-
-        this.mockMvc.perform(get("/v1/groups/{id}", groupId))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id", is(groupId)))
-            .andExpect(jsonPath("$.name", is("testgroup")));
     }
 
     @Test


### PR DESCRIPTION
This reverts the new method added here: https://github.com/Activiti/activiti-cloud/pull/2404. I just learned this repo is deprecated and that new endpoints should not be added to it.