### PR TITLE
AAE-47849 Implement channel partitioning to improve Audit Consumer audit messages processing

### DIFF
--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/pom.xml
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/pom.xml
@@ -37,5 +37,10 @@
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.springframework.integration</groupId>
+          <artifactId>spring-integration-test</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditConsumerPartitionedChannelCountProvider.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditConsumerPartitionedChannelCountProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.streams.config;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface AuditConsumerPartitionedChannelCountProvider extends Supplier<Integer> {}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditConsumerPartitionedChannelKeySelector.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditConsumerPartitionedChannelKeySelector.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.streams.config;
+
+import java.util.function.Function;
+import org.springframework.messaging.Message;
+
+@FunctionalInterface
+public interface AuditConsumerPartitionedChannelKeySelector extends Function<Message<?>, Object> {
+    public static final String ROOT_PROCESS_INSTANCE_ID = "rootProcessInstanceId";
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
@@ -92,7 +92,7 @@ public class AuditJPAStreamsAutoConfiguration {
     }
 
     @Bean
-    public IntegrationFlow partitionedAudutConsumerErrorIntegrationFlow() {
+    public IntegrationFlow partitionedAuditConsumerErrorIntegrationFlow() {
         return IntegrationFlow.from(PARTITIONED_AUDIT_CONSUMER_ERROR_CHANNEL)
             .handle(message -> {
                 if (message instanceof ErrorMessage errorMessage) {
@@ -132,18 +132,19 @@ public class AuditJPAStreamsAutoConfiguration {
     GenericHandler<List<CloudRuntimeEvent<?, ?>>> genericAuditConsumerChannelHandlerAdapter(
         AuditConsumerChannelHandler auditConsumerChannelHandler
     ) {
-        return (events, headers) -> {
+        return (payload, headers) -> {
+            final var events = Optional.ofNullable(payload)
+                .orElseGet(Collections::emptyList)
+                .toArray(CloudRuntimeEvent[]::new);
+
             LOGGER.debug(
                 "Handling {} events with root process instance id {} on partition thread: {}",
-                events.size(),
+                events.length,
                 headers.get(AuditConsumerPartitionedChannelKeySelector.ROOT_PROCESS_INSTANCE_ID),
                 Thread.currentThread().getName()
             );
 
-            auditConsumerChannelHandler.receiveCloudRuntimeEvent(
-                headers,
-                Optional.of(events).orElse(Collections.emptyList()).toArray(CloudRuntimeEvent[]::new)
-            );
+            auditConsumerChannelHandler.receiveCloudRuntimeEvent(headers, events);
 
             return null;
         };

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.ErrorMessage;
 
 @AutoConfiguration
@@ -97,11 +98,15 @@ public class AuditJPAStreamsAutoConfiguration {
             .handle(message -> {
                 if (message instanceof ErrorMessage errorMessage) {
                     final var exception = errorMessage.getPayload();
+                    final var failedMessage =
+                        exception instanceof MessageHandlingException
+                            ? ((MessageHandlingException) exception).getFailedMessage()
+                            : errorMessage.getOriginalMessage();
 
                     LOGGER.error(
                         "{} while handling {} for partition thread {}",
                         exception.getMessage(),
-                        errorMessage.getOriginalMessage(),
+                        failedMessage,
                         Thread.currentThread().getName(),
                         Optional.ofNullable(exception.getCause()).orElse(exception)
                     );

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/AuditJPAStreamsAutoConfiguration.java
@@ -26,13 +26,25 @@ import org.activiti.cloud.services.audit.api.streams.AuditConsumerChannelHandler
 import org.activiti.cloud.services.audit.api.streams.AuditConsumerChannels;
 import org.activiti.cloud.services.audit.jpa.repository.EventsRepository;
 import org.activiti.cloud.services.audit.jpa.streams.AuditConsumerChannelHandlerImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.integration.core.GenericHandler;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
 
 @AutoConfiguration
 public class AuditJPAStreamsAutoConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditJPAStreamsAutoConfiguration.class);
+    public static final String PARTITIONED_AUDIT_CONSUMER_INTEGRATION_FLOW_INPUT =
+        "partitionedAuditConsumerIntegrationFlowInput";
+    public static final String PARTITIONED_AUDIT_CONSUMER_ERROR_CHANNEL = "partitionedAuditConsumerErrorChannel";
 
     @Bean
     @ConditionalOnMissingBean
@@ -46,15 +58,94 @@ public class AuditJPAStreamsAutoConfiguration {
     @FunctionBinding(input = AuditConsumerChannels.AUDIT_CONSUMER)
     @Bean
     public Consumer<Message<List<CloudRuntimeEvent<?, ?>>>> auditConsumerChannelHandlerConsumer(
-        AuditConsumerChannelHandler handler
+        IntegrationFlow partitionedAuditConsumerIntegrationFlow
     ) {
-        return message -> {
-            handler.receiveCloudRuntimeEvent(
-                message.getHeaders(),
-                Optional.ofNullable(message.getPayload())
-                    .orElse(Collections.emptyList())
-                    .toArray(new CloudRuntimeEvent[0])
+        return message -> partitionedAuditConsumerIntegrationFlow.getInputChannel().send(message);
+    }
+
+    @Bean
+    public IntegrationFlow partitionedAuditConsumerIntegrationFlow(
+        AuditConsumerPartitionedChannelCountProvider auditConsumerPartitionedChannelCountProvider,
+        AuditConsumerPartitionedChannelKeySelector auditConsumerPartitionedChannelKeySelector,
+        GenericHandler<List<CloudRuntimeEvent<?, ?>>> genericAuditConsumerChannelHandlerAdapter,
+        @Value("${activiti.cloud.query.consumer.worker-queue-size:10}") Integer workerQueueSize
+    ) {
+        LOGGER.info(
+            "Initializing AuditJPAStreamsAutoConfiguration with {} partitioned channel count using worker-queue size {}",
+            auditConsumerPartitionedChannelCountProvider.get(),
+            workerQueueSize
+        );
+        return IntegrationFlow.from(PARTITIONED_AUDIT_CONSUMER_INTEGRATION_FLOW_INPUT)
+            .gateway(
+                request ->
+                    request
+                        .enrichHeaders(headers -> headers.errorChannel(PARTITIONED_AUDIT_CONSUMER_ERROR_CHANNEL, true))
+                        .channel(
+                            MessageChannels.partitioned(auditConsumerPartitionedChannelCountProvider.get())
+                                .partitionKey(auditConsumerPartitionedChannelKeySelector)
+                                .workerQueueSize(workerQueueSize)
+                        )
+                        .handle(genericAuditConsumerChannelHandlerAdapter),
+                gatewayEndpointSpec -> gatewayEndpointSpec.requiresReply(false).replyTimeout(0L)
+            )
+            .get();
+    }
+
+    @Bean
+    public IntegrationFlow partitionedAudutConsumerErrorIntegrationFlow() {
+        return IntegrationFlow.from(PARTITIONED_AUDIT_CONSUMER_ERROR_CHANNEL)
+            .handle(message -> {
+                if (message instanceof ErrorMessage errorMessage) {
+                    final var exception = errorMessage.getPayload();
+
+                    LOGGER.error(
+                        "{} while handling {} for partition thread {}",
+                        exception.getMessage(),
+                        errorMessage.getOriginalMessage(),
+                        Thread.currentThread().getName(),
+                        Optional.ofNullable(exception.getCause()).orElse(exception)
+                    );
+                } else {
+                    LOGGER.error(
+                        "Unexpected message type {} on {}: {}",
+                        message.getClass(),
+                        PARTITIONED_AUDIT_CONSUMER_ERROR_CHANNEL,
+                        message
+                    );
+                }
+            })
+            .get();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    AuditConsumerPartitionedChannelCountProvider auditConsumerPartitionedChannelCountProvider() {
+        return () -> Runtime.getRuntime().availableProcessors() * 2;
+    }
+
+    @Bean
+    AuditConsumerPartitionedChannelKeySelector auditConsumerPartitionedChannelKeySelector() {
+        return new DefaultConsumerPartitionedChannelKeySelector();
+    }
+
+    @Bean
+    GenericHandler<List<CloudRuntimeEvent<?, ?>>> genericAuditConsumerChannelHandlerAdapter(
+        AuditConsumerChannelHandler auditConsumerChannelHandler
+    ) {
+        return (events, headers) -> {
+            LOGGER.debug(
+                "Handling {} events with root process instance id {} on partition thread: {}",
+                events.size(),
+                headers.get(AuditConsumerPartitionedChannelKeySelector.ROOT_PROCESS_INSTANCE_ID),
+                Thread.currentThread().getName()
             );
+
+            auditConsumerChannelHandler.receiveCloudRuntimeEvent(
+                headers,
+                Optional.of(events).orElse(Collections.emptyList()).toArray(CloudRuntimeEvent[]::new)
+            );
+
+            return null;
         };
     }
 }

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/DefaultConsumerPartitionedChannelKeySelector.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/main/java/org/activiti/cloud/services/audit/jpa/streams/config/DefaultConsumerPartitionedChannelKeySelector.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.streams.config;
+
+import org.springframework.messaging.Message;
+
+public class DefaultConsumerPartitionedChannelKeySelector implements AuditConsumerPartitionedChannelKeySelector {
+
+    @Override
+    public Object apply(Message<?> message) {
+        return message.getHeaders().getOrDefault(ROOT_PROCESS_INSTANCE_ID, 0);
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerAutoConfigurationTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/AuditConsumerAutoConfigurationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.audit.jpa.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.activiti.cloud.services.audit.jpa.streams.config.AuditJPAStreamsAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.test.context.SpringIntegrationTest;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringIntegrationTest
+@SpringJUnitConfig(AuditConsumerAutoConfigurationTest.TestConfiguration.class)
+@ExtendWith(OutputCaptureExtension.class)
+class AuditConsumerAutoConfigurationTest {
+
+    @Autowired
+    private MessageChannel partitionedAuditConsumerErrorChannel;
+
+    @Test
+    void shouldHandleErrorMessageInPartitionedQueryConsumerErrorIntegrationFlow(CapturedOutput output) {
+        ErrorMessage errorMessage = new ErrorMessage(
+            new MessagingException("Error message"),
+            MessageBuilder.withPayload("payload").build()
+        );
+
+        assertThat(partitionedAuditConsumerErrorChannel).isNotNull();
+        assertThatCode(() -> partitionedAuditConsumerErrorChannel.send(errorMessage)).doesNotThrowAnyException();
+        assertThat(output).contains("Error message while handling GenericMessage [payload=payload");
+    }
+
+    @Test
+    void shouldHandleUnexpectedMessageTypeInPartitionedQueryConsumerErrorIntegrationFlow(CapturedOutput output) {
+        assertThatCode(() ->
+            partitionedAuditConsumerErrorChannel.send(MessageBuilder.withPayload("unexpected").build())
+        ).doesNotThrowAnyException();
+        assertThat(output).contains(
+            " Unexpected message type class org.springframework.messaging.support.GenericMessage"
+        );
+    }
+
+    @Configuration
+    @EnableIntegration
+    static class TestConfiguration {
+
+        @Bean
+        IntegrationFlow partitionedAuditConsumerErrorIntegrationFlow() {
+            return new AuditJPAStreamsAutoConfiguration().partitionedAuditConsumerErrorIntegrationFlow();
+        }
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/DefaultConsumerPartitionedChannelKeySelectorTest.java
+++ b/activiti-cloud-audit-service/activiti-cloud-services-audit-consumer/src/test/java/org/activiti/cloud/services/audit/jpa/streams/DefaultConsumerPartitionedChannelKeySelectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.audit.jpa.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.services.audit.jpa.streams.config.AuditConsumerPartitionedChannelKeySelector;
+import org.activiti.cloud.services.audit.jpa.streams.config.DefaultConsumerPartitionedChannelKeySelector;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+class DefaultConsumerPartitionedChannelKeySelectorTest {
+
+    private final DefaultConsumerPartitionedChannelKeySelector keySelector =
+        new DefaultConsumerPartitionedChannelKeySelector();
+
+    @Test
+    void shouldUseRootProcessInstanceIdHeaderWhenPresent() {
+        String rootProcessInstanceId = "root-process-instance-id";
+        Message<String> message = MessageBuilder.withPayload("payload")
+            .setHeader(AuditConsumerPartitionedChannelKeySelector.ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId)
+            .build();
+
+        Object selectedKey = keySelector.apply(message);
+
+        assertThat(selectedKey).isEqualTo(rootProcessInstanceId);
+    }
+
+    @Test
+    void shouldUseDefaultPartitionWhenHeaderIsMissing() {
+        Message<String> message = MessageBuilder.withPayload("payload").build();
+
+        Object selectedKey = keySelector.apply(message);
+
+        assertThat(selectedKey).isEqualTo(0);
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/src/main/java/org/activiti/cloud/starter/audit/consumer/config/ActivitiAuditConsumerAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/src/main/java/org/activiti/cloud/starter/audit/consumer/config/ActivitiAuditConsumerAutoConfiguration.java
@@ -15,9 +15,33 @@
  */
 package org.activiti.cloud.starter.audit.consumer.config;
 
+import com.zaxxer.hikari.HikariDataSource;
+import org.activiti.cloud.services.audit.jpa.streams.config.AuditConsumerPartitionedChannelCountProvider;
+import org.activiti.cloud.services.audit.jpa.streams.config.AuditJPAStreamsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
-@AutoConfiguration
+@AutoConfiguration(before = AuditJPAStreamsAutoConfiguration.class, after = DataSourceAutoConfiguration.class)
 @PropertySource("classpath:audit-messaging.properties")
-public class ActivitiAuditConsumerAutoConfiguration {}
+public class ActivitiAuditConsumerAutoConfiguration {
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(HikariDataSource.class)
+    @ConditionalOnBean(HikariDataSource.class)
+    static class HikariDataSourceQueryConsumerPartitionedChannelConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        AuditConsumerPartitionedChannelCountProvider auditConsumerPartitionedChannelCountProvider(
+            HikariDataSource dataSource
+        ) {
+            return dataSource::getMaximumPoolSize;
+        }
+    }
+}

--- a/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/src/main/java/org/activiti/cloud/starter/audit/consumer/config/ActivitiAuditConsumerAutoConfiguration.java
+++ b/activiti-cloud-audit-service/activiti-cloud-starter-audit-consumer/src/main/java/org/activiti/cloud/starter/audit/consumer/config/ActivitiAuditConsumerAutoConfiguration.java
@@ -34,7 +34,7 @@ public class ActivitiAuditConsumerAutoConfiguration {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(HikariDataSource.class)
     @ConditionalOnBean(HikariDataSource.class)
-    static class HikariDataSourceQueryConsumerPartitionedChannelConfiguration {
+    static class HikariDataSourceAuditConsumerPartitionedChannelConfiguration {
 
         @Bean
         @ConditionalOnMissingBean

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.integration.store.ChannelMessageStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.Trigger;
@@ -112,11 +113,15 @@ public class QueryConsumerAutoConfiguration {
             .handle(message -> {
                 if (message instanceof ErrorMessage errorMessage) {
                     final var exception = errorMessage.getPayload();
+                    final var failedMessage =
+                        exception instanceof MessageHandlingException
+                            ? ((MessageHandlingException) exception).getFailedMessage()
+                            : errorMessage.getOriginalMessage();
 
                     LOGGER.error(
                         "{} while handling {} for partition thread {}",
                         exception.getMessage(),
-                        errorMessage.getOriginalMessage(),
+                        failedMessage,
                         Thread.currentThread().getName(),
                         Optional.ofNullable(exception.getCause()).orElse(exception)
                     );

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/QueryConsumerAutoConfiguration.java
@@ -140,7 +140,7 @@ public class QueryConsumerAutoConfiguration {
         @Value("${activiti.cloud.query.consumer.worker-queue-size:10}") Integer workerQueueSize
     ) {
         return IntegrationFlow.from(PARTITIONED_QUERY_CONSUMER_INTEGRATION_FLOW_INPUT)
-            .enrichHeaders(headers -> headers.errorChannel(PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL))
+            .enrichHeaders(headers -> headers.errorChannel(PARTITIONED_QUERY_CONSUMER_ERROR_CHANNEL, true))
             .channel(
                 MessageChannels.partitioned(queryConsumerPartitionedChannelCountProvider.get())
                     .partitionKey(queryConsumerPartitionedChannelKeySelector)


### PR DESCRIPTION
This PR introduces partitioned channel processing for the Audit JPA consumer (similar to the existing Query consumer approach) to improve throughput by handling audit event batches concurrently while preserving ordering per partition key.

Changes:

- Reworks AuditJPAStreamsAutoConfiguration to route audit messages through a partitioned IntegrationFlow, with a dedicated error channel flow.
- Adds audit-specific partitioning SPI (AuditConsumerPartitionedChannelCountProvider / AuditConsumerPartitionedChannelKeySelector) plus a default key selector implementation.
- Aligns Query consumer header enrichment to explicitly overwrite the errorChannel header.

https://hyland.atlassian.net/browse/AAE-47849