### PR TITLE
AAE-48168 Handle unsupported symbolic links in tests on Windows

### DIFF
--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipEntryPathsTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipEntryPathsTest.java
@@ -192,7 +192,11 @@ class ZipEntryPathsTest {
         Path realDir = tempDir.resolve("real");
         Files.createDirectory(realDir);
         Path link = tempDir.resolve("link");
-        Files.createSymbolicLink(link, realDir);
+        try {
+            Files.createSymbolicLink(link, realDir);
+        } catch (UnsupportedOperationException | IOException ignored) {
+            org.junit.jupiter.api.Assumptions.abort("Symbolic links are not supported in this environment");
+        }
 
         assertThatThrownBy(() -> ZipEntryPaths.resolveTargetRoot(link))
             .isInstanceOf(IOException.class)

--- a/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipEntryPathsTest.java
+++ b/activiti-cloud-service-common/activiti-cloud-services-common-util/src/test/java/org/activiti/cloud/services/common/zip/ZipEntryPathsTest.java
@@ -194,7 +194,7 @@ class ZipEntryPathsTest {
         Path link = tempDir.resolve("link");
         try {
             Files.createSymbolicLink(link, realDir);
-        } catch (UnsupportedOperationException | IOException ignored) {
+        } catch (UnsupportedOperationException | IOException _) {
             org.junit.jupiter.api.Assumptions.abort("Symbolic links are not supported in this environment");
         }
 
@@ -231,7 +231,7 @@ class ZipEntryPathsTest {
         Path link = targetRoot.resolve("link.txt");
         try {
             Files.createSymbolicLink(link, outside);
-        } catch (UnsupportedOperationException | IOException ignored) {
+        } catch (UnsupportedOperationException | IOException _) {
             org.junit.jupiter.api.Assumptions.abort("Symbolic links are not supported in this environment");
         }
 


### PR DESCRIPTION
This pull request improves the robustness of the `resolveTargetRoot_shouldRejectSymbolicLinkTarget` test by handling environments that do not support symbolic links. The test will now be skipped if symbolic link creation is not possible, preventing false negatives in such environments.

- **Test robustness and environment compatibility:**
  * Updated `ZipEntryPathsTest.java` to catch exceptions when creating a symbolic link and abort the test if symbolic links are not supported, using JUnit assumptions.