### PR TITLE
AAE-48186 Fix setup of kubeconfig for acceptance-tests

### DIFF
--- a/activiti-cloud-acceptance-tests-playwright/config/connection/gateway-url.ts
+++ b/activiti-cloud-acceptance-tests-playwright/config/connection/gateway-url.ts
@@ -32,7 +32,7 @@ export function resolveGatewayConnection(): GatewayConnection {
         const hostHeader = stripPort(gatewayHost || new URL(gatewayUrl!).host);
 
         return {
-            baseURL: `http://localhost:${localPort}`,
+            baseURL: `http://127.0.0.1:${localPort}`,
             hostHeader,
         };
     }

--- a/activiti-cloud-acceptance-tests-playwright/config/connection/sso-url.ts
+++ b/activiti-cloud-acceptance-tests-playwright/config/connection/sso-url.ts
@@ -39,7 +39,7 @@ export function resolveSsoConnection(): SsoConnection {
         if (preview && cluster) {
             const hostHeader = stripPort(buildIdentityHost(preview, cluster, domain));
             return {
-                tokenUrl: `http://localhost:${localPort}/auth/realms/${realm}/protocol/openid-connect/token`,
+                tokenUrl: `http://127.0.0.1:${localPort}/auth/realms/${realm}/protocol/openid-connect/token`,
                 hostHeader,
             };
         }

--- a/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
+++ b/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
@@ -18,6 +18,7 @@ import { timeouts } from '../../runtime/timeouts';
 import { paths } from '../../paths';
 
 const execAsync = promisify(exec);
+const LOCAL_LOOPBACK = '127.0.0.1';
 
 export async function checkKubectlAvailable(): Promise<void> {
     try {
@@ -37,19 +38,19 @@ async function checkPortForwardingActive(localPort: string, throwOnError: boolea
         if (stdout.trim()) {
             acceptanceLog('traefik', '✓ kubectl port-forward process detected');
         } else {
-            acceptanceLog('traefik', 'No port-forward process in ps — probing localhost anyway');
+            acceptanceLog('traefik', `No port-forward process in ps — probing ${LOCAL_LOOPBACK} anyway`);
         }
     } catch {
-        acceptanceLog('traefik', 'Could not detect port-forward process — probing localhost anyway');
+        acceptanceLog('traefik', `Could not detect port-forward process — probing ${LOCAL_LOOPBACK} anyway`);
     }
 
     try {
         const context = await request.newContext();
-        const response = await context.get(`http://127.0.0.1:${localPort}`, {
+        const response = await context.get(`http://${LOCAL_LOOPBACK}:${localPort}`, {
             timeout: timeouts.http.localPortProbe,
             ignoreHTTPSErrors: true,
         });
-        acceptanceLog('traefik', `✓ localhost:${localPort} reachable (HTTP ${response.status()})`);
+        acceptanceLog('traefik', `✓ ${LOCAL_LOOPBACK}:${localPort} reachable (HTTP ${response.status()})`);
         await context.dispose();
         return true;
     } catch (error) {
@@ -64,7 +65,7 @@ Error: ${error}`;
         if (throwOnError) {
             throw new Error(errorMessage);
         }
-        acceptanceLog('traefik', 'localhost not reachable yet — will start port-forward automatically');
+        acceptanceLog('traefik', `${LOCAL_LOOPBACK} not reachable yet — will start port-forward automatically`);
         return false;
     }
 }
@@ -140,7 +141,7 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
     try {
         const hostWithoutPort = expectedGatewayHost.replace(/:\d+$/, '');
         const context = await request.newContext();
-        const response = await context.get(`http://127.0.0.1:${localPort}`, {
+        const response = await context.get(`http://${LOCAL_LOOPBACK}:${localPort}`, {
             timeout: timeouts.http.healthCheck,
             ignoreHTTPSErrors: true,
             headers: { Host: hostWithoutPort },
@@ -148,7 +149,7 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
 
         acceptanceLog(
             'traefik',
-            `✓ Gateway reachable via tunnel (HTTP ${response.status()}) — ${hostWithoutPort} → localhost:${localPort}`
+            `✓ Gateway reachable via tunnel (HTTP ${response.status()}) — ${hostWithoutPort} → ${LOCAL_LOOPBACK}:${localPort}`
         );
         await context.dispose();
     } catch (error) {
@@ -157,7 +158,7 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
 
    ${pfCmd}
    kubectl get pods -n ${process.env.PREVIEW_NAME || '<PREVIEW_NAME>'}
-   curl -H "Host: ${expectedGatewayHost.replace(/:\d+$/, '')}" http://localhost:${localPort}/rb/actuator/health
+   curl -H "Host: ${expectedGatewayHost.replace(/:\d+$/, '')}" http://${LOCAL_LOOPBACK}:${localPort}/rb/actuator/health
 
 Error: ${error}`);
     }
@@ -176,7 +177,7 @@ export async function setupPortForwarding(): Promise<void> {
     acceptancePhase('traefik', 'Local gateway tunnel');
     acceptanceStep(
         'traefik',
-        `API traffic: http://localhost:${localPort} + Host: ${hostWithoutPort} (auto port-forward — no second terminal)`
+        `API traffic: http://${LOCAL_LOOPBACK}:${localPort} + Host: ${hostWithoutPort} (auto port-forward — no second terminal)`
     );
 
     await checkKubectlAvailable();

--- a/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
+++ b/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
@@ -44,14 +44,13 @@ async function checkPortForwardingActive(localPort: string, throwOnError: boolea
         acceptanceLog('traefik', `Could not detect port-forward process — probing ${LOCAL_LOOPBACK} anyway`);
     }
 
+    const context = await request.newContext();
     try {
-        const context = await request.newContext();
         const response = await context.get(`http://${LOCAL_LOOPBACK}:${localPort}`, {
             timeout: timeouts.http.localPortProbe,
             ignoreHTTPSErrors: true,
         });
         acceptanceLog('traefik', `✓ ${LOCAL_LOOPBACK}:${localPort} reachable (HTTP ${response.status()})`);
-        await context.dispose();
         return true;
     } catch (error) {
         const pfCmd = getPortForwardHelpCommand(localPort);
@@ -67,6 +66,8 @@ Error: ${error}`;
         }
         acceptanceLog('traefik', `${LOCAL_LOOPBACK} not reachable yet — will start port-forward automatically`);
         return false;
+    } finally {
+        await context.dispose();
     }
 }
 
@@ -138,9 +139,9 @@ Error: ${error}`);
 }
 
 async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: string): Promise<void> {
+    const hostWithoutPort = expectedGatewayHost.replace(/:\d+$/, '');
+    const context = await request.newContext();
     try {
-        const hostWithoutPort = expectedGatewayHost.replace(/:\d+$/, '');
-        const context = await request.newContext();
         const response = await context.get(`http://${LOCAL_LOOPBACK}:${localPort}`, {
             timeout: timeouts.http.healthCheck,
             ignoreHTTPSErrors: true,
@@ -151,7 +152,6 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
             'traefik',
             `✓ Gateway reachable via tunnel (HTTP ${response.status()}) — ${hostWithoutPort} → ${LOCAL_LOOPBACK}:${localPort}`
         );
-        await context.dispose();
     } catch (error) {
         const pfCmd = getPortForwardHelpCommand(localPort);
         throw new Error(`Cannot reach gateway through port-forward.
@@ -161,6 +161,8 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
    curl -H "Host: ${expectedGatewayHost.replace(/:\d+$/, '')}" http://${LOCAL_LOOPBACK}:${localPort}/rb/actuator/health
 
 Error: ${error}`);
+    } finally {
+        await context.dispose();
     }
 }
 

--- a/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
+++ b/activiti-cloud-acceptance-tests-playwright/config/lifecycle/setup/port-forward.ts
@@ -45,7 +45,7 @@ async function checkPortForwardingActive(localPort: string, throwOnError: boolea
 
     try {
         const context = await request.newContext();
-        const response = await context.get(`http://localhost:${localPort}`, {
+        const response = await context.get(`http://127.0.0.1:${localPort}`, {
             timeout: timeouts.http.localPortProbe,
             ignoreHTTPSErrors: true,
         });
@@ -140,7 +140,7 @@ async function checkGatewayConnectivity(localPort: string, expectedGatewayHost: 
     try {
         const hostWithoutPort = expectedGatewayHost.replace(/:\d+$/, '');
         const context = await request.newContext();
-        const response = await context.get(`http://localhost:${localPort}`, {
+        const response = await context.get(`http://127.0.0.1:${localPort}`, {
             timeout: timeouts.http.healthCheck,
             ignoreHTTPSErrors: true,
             headers: { Host: hostWithoutPort },

--- a/activiti-cloud-acceptance-tests-playwright/scripts/check-local-env.ts
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/check-local-env.ts
@@ -7,15 +7,24 @@
 import '../config/load-env';
 import { applyResolvedHostsToEnv } from '../config/connection/env-hosts';
 import { runPreflightChecks } from '../config/validation/environment-validator';
+import { setupPortForwarding } from '../config/lifecycle/setup/port-forward';
 
 applyResolvedHostsToEnv();
 
 const project = process.argv[2] || 'all';
 
-async function main(): Promise<void> {
-  console.log(`\n🔍 Playwright environment check (project: ${project})\n`);
+function isCI(): boolean {
+    return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+}
 
-  const result = await runPreflightChecks(project);
+async function main(): Promise<void> {
+    console.log(`\n🔍 Playwright environment check (project: ${project})\n`);
+
+    if (!isCI()) {
+        await setupPortForwarding();
+    }
+
+    const result = await runPreflightChecks(project);
 
   for (const w of result.warnings) {
     console.warn(`⚠️  ${w}`);

--- a/activiti-cloud-acceptance-tests-playwright/scripts/check-local-env.ts
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/check-local-env.ts
@@ -26,23 +26,24 @@ async function main(): Promise<void> {
 
     const result = await runPreflightChecks(project);
 
-  for (const w of result.warnings) {
-    console.warn(`⚠️  ${w}`);
-  }
-
-  if (!result.ok) {
-    console.error('\n❌ Environment check failed:\n');
-    for (const e of result.errors) {
-      console.error(`   • ${e}`);
+    for (const w of result.warnings) {
+        console.warn(`⚠️  ${w}`);
     }
-    console.error('\nSee README.md and .env.example\n');
-    process.exit(1);
-  }
 
-  console.log('\n✅ Environment ready — run tests with npm run test\n');
+    if (!result.ok) {
+        console.error('\n❌ Environment check failed:\n');
+        for (const e of result.errors) {
+            console.error(`   • ${e}`);
+        }
+        console.error('\nSee README.md and .env.example\n');
+        process.exit(1);
+    }
+
+    console.log('\n✅ Environment ready — run tests with npm run test\n');
+    process.exit(0);
 }
 
 main().catch((err) => {
-  console.error(err);
-  process.exit(1);
+    console.error(err);
+    process.exit(1);
 });

--- a/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
@@ -7,12 +7,84 @@
 #
 # Or:
 #   source .../use-kubeconfig.sh ~/Downloads/activiti.yaml
+#
+# Picks the first kubeconfig that can reach the cluster (cluster-info).
+# A stale ~/Downloads/activiti.yaml is skipped when ~/.kube/config works.
 
-KUBECONFIG_CANDIDATE="${1:-${ACTIVITI_KUBECONFIG:-${KUBECONFIG:-$HOME/Downloads/activiti.yaml}}}"
+kubeconfig_connects() {
+  KUBECONFIG="$1" kubectl cluster-info &>/dev/null
+}
 
-if [[ ! -f "${KUBECONFIG_CANDIDATE}" ]]; then
-  echo "❌ Kubeconfig not found: ${KUBECONFIG_CANDIDATE}" >&2
-  echo "   export ACTIVITI_KUBECONFIG=/path/to/activiti.yaml" >&2
+collect_kubeconfig_candidates() {
+  local explicit="${1:-}"
+  local -a candidates=()
+
+  if [[ -n "${explicit}" ]]; then
+    candidates+=("${explicit}")
+  else
+    [[ -n "${ACTIVITI_KUBECONFIG:-}" ]] && candidates+=("${ACTIVITI_KUBECONFIG}")
+    [[ -n "${KUBECONFIG:-}" ]] && candidates+=("${KUBECONFIG}")
+    candidates+=("${HOME}/Downloads/activiti.yaml")
+    candidates+=("${HOME}/.kube/config")
+  fi
+
+  local c seen=""
+  for c in "${candidates[@]}"; do
+    [[ -z "${c}" ]] && continue
+    case ",${seen}," in
+      *",${c},"*) continue ;;
+    esac
+    seen="${seen},${c}"
+    echo "${c}"
+  done
+}
+
+resolve_working_kubeconfig() {
+  local explicit="${1:-}"
+  local candidate chosen="" skipped=""
+
+  while IFS= read -r candidate; do
+    [[ -z "${candidate}" ]] && continue
+    if [[ ! -f "${candidate}" ]]; then
+      continue
+    fi
+    if kubeconfig_connects "${candidate}"; then
+      chosen="${candidate}"
+      break
+    fi
+    skipped="${skipped} ${candidate}"
+  done < <(collect_kubeconfig_candidates "${explicit}")
+
+  if [[ -n "${chosen}" ]]; then
+  if [[ -n "${skipped}" ]]; then
+      echo "⚠ Skipping kubeconfig(s) that cannot reach the cluster:${skipped}" >&2
+      echo "  Using: ${chosen}" >&2
+    fi
+    echo "${chosen}"
+    return 0
+  fi
+
+  # Explicit path requested but none connect — surface the first existing file for diagnostics.
+  while IFS= read -r candidate; do
+    [[ -z "${candidate}" ]] && continue
+    if [[ -f "${candidate}" ]]; then
+      echo "${candidate}"
+      return 1
+    fi
+  done < <(collect_kubeconfig_candidates "${explicit}")
+
+  return 1
+}
+
+EXPLICIT_KUBECONFIG="${1:-}"
+if ! KUBECONFIG_CANDIDATE="$(resolve_working_kubeconfig "${EXPLICIT_KUBECONFIG}")"; then
+  echo "❌ No working kubeconfig found." >&2
+  if [[ -n "${KUBECONFIG_CANDIDATE:-}" ]]; then
+    echo "   Tried: ${KUBECONFIG_CANDIDATE} (file exists but kubectl cannot connect)" >&2
+  else
+    echo "   Set ACTIVITI_KUBECONFIG or run: npm run kube:use" >&2
+    echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
+  fi
   return 1 2>/dev/null || exit 1
 fi
 

--- a/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
@@ -84,18 +84,21 @@ elif [[ -n "${EXPLICIT_KUBECONFIG}" && ! -f "${EXPLICIT_KUBECONFIG}" ]]; then
   echo "❌ Kubeconfig not found: ${EXPLICIT_KUBECONFIG}" >&2
   echo "   export ACTIVITI_KUBECONFIG=/path/to/kubeconfig.yaml" >&2
   echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
-  return 1 2>/dev/null || exit 1
+  return 1 2>/dev/null
+  exit 1
 elif [[ -n "${KUBECONFIG_CANDIDATE}" ]]; then
   echo "❌ kubectl cannot connect using: ${KUBECONFIG_CANDIDATE}" >&2
   echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
   echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
-  return 1 2>/dev/null || exit 1
+  return 1 2>/dev/null
+  exit 1
 else
   echo "❌ No kubeconfig file found." >&2
   echo "   export ACTIVITI_KUBECONFIG=/path/to/kubeconfig.yaml" >&2
   echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
   echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
-  return 1 2>/dev/null || exit 1
+  return 1 2>/dev/null
+  exit 1
 fi
 
 export KUBECONFIG="${KUBECONFIG_CANDIDATE}"

--- a/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
@@ -12,7 +12,7 @@
 # A stale ~/Downloads/activiti.yaml is skipped when ~/.kube/config works.
 
 kubeconfig_connects() {
-  KUBECONFIG="$1" kubectl cluster-info &>/dev/null
+  KUBECONFIG="$1" kubectl cluster-info --request-timeout=10s &>/dev/null
 }
 
 collect_kubeconfig_candidates() {

--- a/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
+++ b/activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh
@@ -56,7 +56,7 @@ resolve_working_kubeconfig() {
   done < <(collect_kubeconfig_candidates "${explicit}")
 
   if [[ -n "${chosen}" ]]; then
-  if [[ -n "${skipped}" ]]; then
+    if [[ -n "${skipped}" ]]; then
       echo "⚠ Skipping kubeconfig(s) that cannot reach the cluster:${skipped}" >&2
       echo "  Using: ${chosen}" >&2
     fi
@@ -77,14 +77,24 @@ resolve_working_kubeconfig() {
 }
 
 EXPLICIT_KUBECONFIG="${1:-}"
-if ! KUBECONFIG_CANDIDATE="$(resolve_working_kubeconfig "${EXPLICIT_KUBECONFIG}")"; then
-  echo "❌ No working kubeconfig found." >&2
-  if [[ -n "${KUBECONFIG_CANDIDATE:-}" ]]; then
-    echo "   Tried: ${KUBECONFIG_CANDIDATE} (file exists but kubectl cannot connect)" >&2
-  else
-    echo "   Set ACTIVITI_KUBECONFIG or run: npm run kube:use" >&2
-    echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
-  fi
+KUBECONFIG_CANDIDATE=""
+if KUBECONFIG_CANDIDATE="$(resolve_working_kubeconfig "${EXPLICIT_KUBECONFIG}")"; then
+  :
+elif [[ -n "${EXPLICIT_KUBECONFIG}" && ! -f "${EXPLICIT_KUBECONFIG}" ]]; then
+  echo "❌ Kubeconfig not found: ${EXPLICIT_KUBECONFIG}" >&2
+  echo "   export ACTIVITI_KUBECONFIG=/path/to/kubeconfig.yaml" >&2
+  echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
+  return 1 2>/dev/null || exit 1
+elif [[ -n "${KUBECONFIG_CANDIDATE}" ]]; then
+  echo "❌ kubectl cannot connect using: ${KUBECONFIG_CANDIDATE}" >&2
+  echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
+  echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
+  return 1 2>/dev/null || exit 1
+else
+  echo "❌ No kubeconfig file found." >&2
+  echo "   export ACTIVITI_KUBECONFIG=/path/to/kubeconfig.yaml" >&2
+  echo "   source activiti-cloud-acceptance-tests-playwright/scripts/use-kubeconfig.sh" >&2
+  echo "   Or refresh: ./scripts/fix-kubectl-config.sh activiti" >&2
   return 1 2>/dev/null || exit 1
 fi
 

--- a/scripts/fix-kubectl-config.sh
+++ b/scripts/fix-kubectl-config.sh
@@ -95,7 +95,7 @@ echo -e "${YELLOW}Using cluster ID: $CLUSTER_ID${NC}"
 if rancher clusters kubeconfig "$CLUSTER_ID" > ~/.kube/config; then
     echo -e "${GREEN}✓ kubectl config generated successfully${NC}"
 
-    # Parent scripts (e.g. test:setup) may set KUBECONFIG to a stale file — use the config we just wrote.
+    # Use the config we just wrote for kubectl checks in this script (callers must export KUBECONFIG themselves).
     export KUBECONFIG="${HOME}/.kube/config"
 
     # Test the configuration

--- a/scripts/fix-kubectl-config.sh
+++ b/scripts/fix-kubectl-config.sh
@@ -95,6 +95,9 @@ echo -e "${YELLOW}Using cluster ID: $CLUSTER_ID${NC}"
 if rancher clusters kubeconfig "$CLUSTER_ID" > ~/.kube/config; then
     echo -e "${GREEN}✓ kubectl config generated successfully${NC}"
 
+    # Parent scripts (e.g. test:setup) may set KUBECONFIG to a stale file — use the config we just wrote.
+    export KUBECONFIG="${HOME}/.kube/config"
+
     # Test the configuration
     if kubectl cluster-info >/dev/null 2>&1; then
         echo -e "${GREEN}✓ kubectl can now connect to cluster${NC}"

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -290,6 +290,17 @@ configure_cluster() {
         return 0
     fi
 
+    # kubectl not working — a stale KUBECONFIG from test:setup often blocks the default ~/.kube/config.
+    if [[ -n "${KUBECONFIG:-}" ]] && [[ -f "${HOME}/.kube/config" ]]; then
+        echo -e "${YELLOW}kubectl failed with KUBECONFIG=${KUBECONFIG}; trying default ~/.kube/config...${NC}"
+        if KUBECONFIG="${HOME}/.kube/config" kubectl cluster-info &> /dev/null; then
+            export KUBECONFIG="${HOME}/.kube/config"
+            CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "unknown")
+            echo -e "${GREEN}✓ kubectl connected via ~/.kube/config: $CURRENT_CONTEXT${NC}"
+            return 0
+        fi
+    fi
+
     # kubectl not working, try to configure it
     echo -e "${YELLOW}kubectl not connected to cluster. Attempting to configure...${NC}"
 
@@ -303,6 +314,7 @@ configure_cluster() {
             echo -e "${CYAN}[DRY-RUN] Would run: ./scripts/fix-kubectl-config.sh $target_cluster${NC}"
         else
             if "$SCRIPT_DIR/fix-kubectl-config.sh" "$target_cluster"; then
+                export KUBECONFIG="${HOME}/.kube/config"
                 echo -e "${GREEN}✓ kubectl configured successfully${NC}"
                 CLUSTER_NAME="$target_cluster"
             else

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -260,6 +260,30 @@ configure_hosts_file() {
 }
 
 # Function to configure cluster connection
+auto_detect_cluster_name_from_context() {
+    if [[ -n "$CLUSTER_NAME" ]]; then
+        return 0
+    fi
+
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "unknown")
+    case "$current_context" in
+        "activiti-hackathon")
+            CLUSTER_NAME="activiti-hackathon"
+            ;;
+        "activiti-community")
+            CLUSTER_NAME="activiti-community"
+            ;;
+        *rancher*)
+            CLUSTER_NAME="activiti"
+            ;;
+        *)
+            CLUSTER_NAME="$current_context"
+            ;;
+    esac
+    echo -e "${YELLOW}Auto-detected cluster: $CLUSTER_NAME${NC}"
+}
+
 configure_cluster() {
     echo -e "${BLUE}=== Configuring Cluster Connection ===${NC}"
 
@@ -268,25 +292,7 @@ configure_cluster() {
         CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "unknown")
         echo -e "${GREEN}✓ kubectl already connected to: $CURRENT_CONTEXT${NC}"
 
-        # Auto-detect cluster name if not specified
-        if [[ -z "$CLUSTER_NAME" ]]; then
-            case "$CURRENT_CONTEXT" in
-                "activiti-hackathon")
-                    CLUSTER_NAME="activiti-hackathon"
-                    ;;
-                "activiti-community")
-                    CLUSTER_NAME="activiti-community"
-                    ;;
-                *rancher*)
-                    CLUSTER_NAME="activiti"
-                    ;;
-                *)
-                    # Use the context name directly for other clusters like aae-38098
-                    CLUSTER_NAME="$CURRENT_CONTEXT"
-                    ;;
-            esac
-            echo -e "${YELLOW}Auto-detected cluster: $CLUSTER_NAME${NC}"
-        fi
+        auto_detect_cluster_name_from_context
         return 0
     fi
 
@@ -298,6 +304,7 @@ configure_cluster() {
             export ACTIVITI_KUBECONFIG="${HOME}/.kube/config"
             CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "unknown")
             echo -e "${GREEN}✓ kubectl connected via ~/.kube/config: $CURRENT_CONTEXT${NC}"
+            auto_detect_cluster_name_from_context
             return 0
         fi
     fi

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -295,6 +295,7 @@ configure_cluster() {
         echo -e "${YELLOW}kubectl failed with KUBECONFIG=${KUBECONFIG}; trying default ~/.kube/config...${NC}"
         if KUBECONFIG="${HOME}/.kube/config" kubectl cluster-info &> /dev/null; then
             export KUBECONFIG="${HOME}/.kube/config"
+            export ACTIVITI_KUBECONFIG="${HOME}/.kube/config"
             CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "unknown")
             echo -e "${GREEN}✓ kubectl connected via ~/.kube/config: $CURRENT_CONTEXT${NC}"
             return 0
@@ -315,6 +316,7 @@ configure_cluster() {
         else
             if "$SCRIPT_DIR/fix-kubectl-config.sh" "$target_cluster"; then
                 export KUBECONFIG="${HOME}/.kube/config"
+                export ACTIVITI_KUBECONFIG="${HOME}/.kube/config"
                 echo -e "${GREEN}✓ kubectl configured successfully${NC}"
                 CLUSTER_NAME="$target_cluster"
             else


### PR DESCRIPTION
## Summary

Two related local-setup issues for Playwright acceptance tests.

### 1. Kubeconfig selection (`test:setup`)

`npm run test:setup -- --install` failed with kubectl connection errors even when the cluster was reachable from the shell.

**Root cause:** `use-kubeconfig.sh` always preferred a stale `~/Downloads/activiti.yaml` (403 / wrong cluster). `kubectl config current-context` looked fine, but `kubectl cluster-info` failed. When `fix-kubectl-config.sh` regenerated `~/.kube/config`, `KUBECONFIG` still pointed at the broken file, so recovery never worked.

**Fix:**
- Pick the first kubeconfig that passes `kubectl cluster-info` (skip stale files)
- After Rancher config generation, set `KUBECONFIG=~/.kube/config` for in-script checks
- Fall back to `~/.kube/config` in `local-install.sh` when the current `KUBECONFIG` is broken

### 2. Environment check (`check:env`)

`npm run check:env` failed with `connect ECONNREFUSED ::1:8080` while tests passed.

**Root cause:** `check:env` probed the gateway without starting port-forward (Playwright global-setup does that automatically). Node also resolved `localhost` to IPv6 `::1`, which kubectl port-forward may not listen on.

**Fix:**
- Start port-forward in `check-local-env.ts` before preflight checks (local runs only)
- Use `127.0.0.1` instead of `localhost` for gateway/SSO/port-forward probes

## Test plan

- [x] `npm run test:setup -- --install --name demo` connects without Rancher recovery loop
- [x] Stale `~/Downloads/activiti.yaml` is skipped when `~/.kube/config` works
- [x] `npm run check:env` passes without a manual port-forward terminal