### PR TITLE
AAE-48222: Skip Playwright on develop; require PR rebase within 1 day

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,12 @@ jobs:
       skip-tests: ${{ steps.check-skip-tests.outputs.result }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Check PR freshness with develop
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: bash scripts/ci/check-pr-develop-freshness.sh
       - name: Check dependabot build
         uses: Alfresco/alfresco-build-tools/.github/actions/github-require-secrets@ed80b0eef8e432f517ea1aa51d8a82637c1d1cc1 # v18.12.0
         with:
@@ -285,7 +291,8 @@ jobs:
       - create-tag
       - maven-build
     if: >-
-      needs.pre-checks.outputs.skip != 'true'
+      github.event_name != 'push'
+      && needs.pre-checks.outputs.skip != 'true'
       && needs.pre-checks.outputs.skip-tests != 'true'
       && needs.maven-build.result == 'success'
     uses: ./.github/workflows/_reusable-playwright-tests.yml
@@ -331,8 +338,8 @@ jobs:
            || contains(needs.maven-test.result, 'cancelled')
            || contains(needs.sonar.result, 'failure')
            || contains(needs.sonar.result, 'cancelled')
-           || contains(needs.playwright-tests.result, 'failure')
-           || contains(needs.playwright-tests.result, 'cancelled')
+           || (needs.playwright-tests.result != 'skipped' && contains(needs.playwright-tests.result, 'failure'))
+           || (needs.playwright-tests.result != 'skipped' && contains(needs.playwright-tests.result, 'cancelled'))
           }}
         run: |
           echo "CI jobs have failed or been cancelled. Exiting ..."

--- a/scripts/ci/check-pr-develop-freshness.sh
+++ b/scripts/ci/check-pr-develop-freshness.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fail when a PR merge-base with develop is older than the allowed age.
+# Ensures acceptance-tested PRs are rebased onto recent develop before merge.
+set -euo pipefail
+
+MAX_AGE_SECONDS="${PR_DEVELOP_MAX_AGE_SECONDS:-86400}"
+BASE_REF="${PR_DEVELOP_BASE_REF:-develop}"
+
+git fetch --no-tags origin "${BASE_REF}"
+
+MERGE_BASE="$(git merge-base HEAD "origin/${BASE_REF}")"
+MERGE_BASE_EPOCH="$(git show -s --format=%ct "${MERGE_BASE}")"
+NOW_EPOCH="$(date -u +%s)"
+AGE=$((NOW_EPOCH - MERGE_BASE_EPOCH))
+
+if [[ "${AGE}" -gt "${MAX_AGE_SECONDS}" ]]; then
+  MAX_HOURS=$((MAX_AGE_SECONDS / 3600))
+  AGE_HOURS=$((AGE / 3600))
+  echo "::error::This pull request must be rebased onto ${BASE_REF}. Merge-base with ${BASE_REF} is ${AGE_HOURS}h old (max ${MAX_HOURS}h). Run: git fetch origin ${BASE_REF} && git rebase origin/${BASE_REF} && git push --force-with-lease"
+  exit 1
+fi
+
+echo "PR merge-base with ${BASE_REF} is ${AGE}s old (within ${MAX_AGE_SECONDS}s limit)."


### PR DESCRIPTION
## Summary
- Skip the Playwright acceptance matrix on `develop` pushes to reduce shared-cluster CI load (~22 min saved per merge).
- Keep full Playwright acceptance on pull requests and `workflow_dispatch`.
- Block PR merge when merge-base with `develop` is older than **24 hours** — developers must rebase before merging.

## Motivation
Acceptance tests already gate every PR. Re-running the full 7-profile matrix on every `develop` push duplicates that signal while consuming cluster capacity and contributing to job cancellations on rapid pushes.

## Changes
- `playwright-tests` job runs only for `pull_request` and `workflow_dispatch` events.
- New `scripts/ci/check-pr-develop-freshness.sh` in `pre-checks` (PRs only).
- `build-summary` tolerates skipped Playwright on develop pushes.

## Test plan
- [ ] PR CI runs Playwright matrix as before.
- [ ] Freshness check passes on this PR (merge-base < 1 day).
- [ ] After merge: next `develop` push should skip Playwright jobs.
- [ ] Stale PR (>24h merge-base age) fails pre-checks with rebase instructions.

## Jira
https://hyland.atlassian.net/browse/AAE-48222

Parent epic: AAE-46799 (QA Automation Tech Debt)

Made with [Cursor](https://cursor.com)