### PR TITLE
AAE-48234: use queue max for CI workflow concurrency

### DIFF
--- a/.github/workflows/_reusable-playwright-tests.yml
+++ b/.github/workflows/_reusable-playwright-tests.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: playwright-activiti-slot-${{ matrix.concurrency-slot }}
-      cancel-in-progress: false
+      queue: max
     strategy:
       max-parallel: 4 # this is a max parallel - above that, the jobs will fail
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - prettier-plugin-java@2.8.1
         exclude: ^\.github/workflows/.*\.(lock\.yml|md)$
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.31.2
+    rev: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-actions


### PR DESCRIPTION
Replace cancel-in-progress with queue: max so pending CI runs are queued (FIFO, up to 100) instead of canceled on every new push. queue: max cannot be combined with cancel-in-progress per GitHub docs.