### PR TITLE
AAE-48218 Re-enable query admin acceptance tests and fix bulk delete

### DIFF
--- a/activiti-cloud-acceptance-tests-playwright/services/query/endpoints/process-instances.endpoint.ts
+++ b/activiti-cloud-acceptance-tests-playwright/services/query/endpoints/process-instances.endpoint.ts
@@ -188,6 +188,10 @@ export class QueryProcessInstancesEndpoint extends BaseService {
 
     async deleteAllProcessInstances(): Promise<CloudProcessInstance[]> {
         const response = await this.delete(`${this.basePath}/process-instances`);
+        if (response.httpStatus && response.httpStatus >= 400) {
+            const detail = typeof response.body === 'string' ? response.body : JSON.stringify(response);
+            throw new Error(`deleteAllProcessInstances failed (${response.httpStatus}): ${detail}`);
+        }
         return this.unwrapList<CloudProcessInstance>(response, 'processInstances');
     }
 

--- a/activiti-cloud-acceptance-tests-playwright/services/query/endpoints/tasks.endpoint.ts
+++ b/activiti-cloud-acceptance-tests-playwright/services/query/endpoints/tasks.endpoint.ts
@@ -157,6 +157,10 @@ export class QueryTasksEndpoint extends BaseService {
 
     async deleteAllTasks(): Promise<CloudTask[]> {
         const response = await this.delete(`${this.basePath}/tasks`);
+        if (response.httpStatus && response.httpStatus >= 400) {
+            const detail = typeof response.body === 'string' ? response.body : JSON.stringify(response);
+            throw new Error(`deleteAllTasks failed (${response.httpStatus}): ${detail}`);
+        }
         return this.unwrapList<CloudTask>(response, 'tasks');
     }
 

--- a/activiti-cloud-acceptance-tests-playwright/services/query/query.service.ts
+++ b/activiti-cloud-acceptance-tests-playwright/services/query/query.service.ts
@@ -616,6 +616,15 @@ export class QueryService extends BaseService {
         );
     }
 
+    async waitForAdminTasksCount(expectedCount: number): Promise<number> {
+        return QueryService.waitFor(
+            () => this.adminTasks.countTasks({}),
+            (count) => count === expectedCount,
+            'querySync',
+            `admin tasks count to equal ${expectedCount}`
+        );
+    }
+
     async waitForAllTasksAdminCountGreaterThan(minCount: number): Promise<CloudTask[]> {
         return QueryService.waitFor(
             () => this.adminTasks.getAllTasks(),

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/delete-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/delete-actions.spec.ts
@@ -14,36 +14,21 @@
  * limitations under the License.
  */
 
+import { randomUUID } from 'node:crypto';
+
 import { activiti, expect } from '../../fixtures/services.fixture';
-import { pickScenarioTest, type AcceptanceScenarioMeta } from '../../helpers/acceptance-scenario';
-import { startCatalogProcess } from '../../flows/start-process-with-first-task';
-
-const QUERY_ADMIN_DELETE_ISSUE = 'https://hyland.atlassian.net/browse/AAE-47783';
-
-const auditScenario: AcceptanceScenarioMeta = {
-    title: 'delete records in audit service',
-};
-
-const queryTasksScenario: AcceptanceScenarioMeta = {
-    title: 'delete all tasks in query service',
-    exclude: QUERY_ADMIN_DELETE_ISSUE,
-};
-
-const queryProcessInstancesScenario: AcceptanceScenarioMeta = {
-    title: 'delete all process instances in query service',
-    exclude: QUERY_ADMIN_DELETE_ISSUE,
-};
+import { startCatalogProcess, startCatalogProcessWithFirstTask } from '../../flows/start-process-with-first-task';
 
 activiti.describe('Runtime — Delete Actions', { tag: ['@slow', '@destructive'] }, () => {
     activiti.describe.configure({ mode: 'serial' });
 
-    pickScenarioTest(activiti, auditScenario)(auditScenario.title, async ({
+    activiti('delete records in audit service', async ({
         runtimeBundleServiceTestUser,
         auditAdminServiceTestAdmin,
     }) => {
-        await activiti.step(
-            'Given the user is authenticated as testuser ' +
-                'When the user starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED',
+        activiti.slow();
+
+        await activiti.step('When the testuser starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED',
             async () => {
                 const processInstance = await startCatalogProcess(
                     runtimeBundleServiceTestUser,
@@ -59,8 +44,7 @@ activiti.describe('Runtime — Delete Actions', { tag: ['@slow', '@destructive']
         });
 
         await activiti.step(
-            'And another user is authenticated as testadmin ' +
-                'Then the user is able to delete all events in audit service',
+            'And another user is authenticated as testadmin the user is able to delete all events in audit service',
             async () => {
                 const before = await auditAdminServiceTestAdmin.adminEvents.getAllEvents();
                 expect(before.length).toBeGreaterThan(0);
@@ -71,76 +55,90 @@ activiti.describe('Runtime — Delete Actions', { tag: ['@slow', '@destructive']
         );
     });
 
-    pickScenarioTest(activiti, queryTasksScenario)(queryTasksScenario.title, async ({
+    activiti('delete all tasks in query service', async ({
         runtimeBundleServiceTestUser,
         taskServiceTestUser,
         queryAdminServiceTestAdmin,
     }) => {
+        activiti.slow();
+
+        let processTaskId = '';
+        let standaloneTaskId = '';
+
         await activiti.step(
-            'Given the user is authenticated as testuser ' +
-                'When the user starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED',
+            'Given a process task and a standalone task synced to query',
             async () => {
-                const processInstance = await startCatalogProcess(
+                const { processInstance, task } = await startCatalogProcessWithFirstTask(
                     runtimeBundleServiceTestUser,
+                    taskServiceTestUser,
                     'PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED'
                 );
-                expect(processInstance.id).toBeTruthy();
+                processTaskId = task.id;
+                await queryAdminServiceTestAdmin.waitForProcessInstanceAdminSynced(processInstance.id);
+                await queryAdminServiceTestAdmin.waitForTaskAdminSynced(processTaskId);
+
+                const standalone = await taskServiceTestUser.createStandaloneTask({
+                    name: `delete-actions-standalone-${randomUUID()}`,
+                });
+                standaloneTaskId = standalone.id;
+                await queryAdminServiceTestAdmin.waitForTaskAdminSynced(standaloneTaskId);
             }
         );
 
-        await activiti.step('And the user creates a standalone task', async () => {
-            const task = await taskServiceTestUser.createStandaloneTask();
-            expect(task.id).toBeTruthy();
-        });
-
-        await activiti.step('And query service has synced tasks', async () => {
-            const tasks = await queryAdminServiceTestAdmin.waitForAllTasksAdminCountGreaterThan(0);
-            expect(tasks.length).toBeGreaterThan(0);
-        });
-
         await activiti.step(
-            'And another user is authenticated as testadmin ' +
-                'Then the user is able to delete all tasks in query service',
+            'And another user is authenticated as testadmin the user is able to delete all tasks in query service',
             async () => {
-                const before = await queryAdminServiceTestAdmin.adminTasks.getAllTasks();
-                expect(before.length).toBeGreaterThan(0);
+                const processTask = await queryAdminServiceTestAdmin.adminTasks.getTask(processTaskId);
+                const standaloneTask = await queryAdminServiceTestAdmin.adminTasks.getTask(standaloneTaskId);
+                expect(processTask.id).toBe(processTaskId);
+                expect(standaloneTask.id).toBe(standaloneTaskId);
+
+                const beforeCount = await queryAdminServiceTestAdmin.adminTasks.countTasks({});
+                expect(beforeCount).toBeGreaterThanOrEqual(2);
+
                 await queryAdminServiceTestAdmin.adminTasks.deleteAllTasks();
-                const after = await queryAdminServiceTestAdmin.waitForAllTasksAdminCount(0);
-                expect(after.length).toBe(0);
+
+                const afterCount = await queryAdminServiceTestAdmin.waitForAdminTasksCount(0);
+                expect(afterCount).toBe(0);
             }
         );
     });
 
-    pickScenarioTest(activiti, queryProcessInstancesScenario)(queryProcessInstancesScenario.title, async ({
+    activiti('delete all process instances in query service', async ({
         runtimeBundleServiceTestUser,
         queryAdminServiceTestAdmin,
     }) => {
-        await activiti.step(
-            'Given the user is authenticated as testuser ' +
-                'When the user starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED',
+        activiti.slow();
+
+        let processInstanceId = '';
+
+        await activiti.step('When the testuser starts an instance of the process called PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED',
             async () => {
                 const processInstance = await startCatalogProcess(
                     runtimeBundleServiceTestUser,
                     'PROCESS_INSTANCE_WITH_SINGLE_TASK_ASSIGNED'
                 );
-                expect(processInstance.id).toBeTruthy();
+                processInstanceId = processInstance.id;
+                expect(processInstanceId).toBeTruthy();
             }
         );
 
-        await activiti.step('And query service has synced process instances', async () => {
-            const instances = await queryAdminServiceTestAdmin.waitForAllProcessInstancesAdminCountGreaterThan(0);
-            expect(instances.length).toBeGreaterThan(0);
+        await activiti.step('And query service has synced the process instance', async () => {
+            await queryAdminServiceTestAdmin.waitForProcessInstanceAdminSynced(processInstanceId);
+            const processInstance = await queryAdminServiceTestAdmin.adminProcessInstances.getProcessInstance(
+                processInstanceId
+            );
+            expect(processInstance.id).toBe(processInstanceId);
         });
 
         await activiti.step(
-            'And another user is authenticated as testadmin ' +
-                'Then the user is able to delete all process instances in query service',
+            'And another user is authenticated as testadmin the user is able to delete all process instances in query service',
             async () => {
-                const before = await queryAdminServiceTestAdmin.adminProcessInstances.getAllProcessInstances();
-                expect(before.length).toBeGreaterThan(0);
+                const beforeCount = await queryAdminServiceTestAdmin.adminProcessInstances.countProcessInstances({});
+                expect(beforeCount).toBeGreaterThan(0);
                 await queryAdminServiceTestAdmin.adminProcessInstances.deleteAllProcessInstances();
-                const after = await queryAdminServiceTestAdmin.waitForAllProcessInstancesAdminCount(0);
-                expect(after.length).toBe(0);
+                const afterCount = await queryAdminServiceTestAdmin.waitForAllProcessInstancesAdminCount(0);
+                expect(afterCount.length).toBe(0);
             }
         );
     });

--- a/activiti-cloud-acceptance-tests-playwright/tests/runtime/query-admin-remaining-actions.spec.ts
+++ b/activiti-cloud-acceptance-tests-playwright/tests/runtime/query-admin-remaining-actions.spec.ts
@@ -17,20 +17,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { activiti, expect } from '../../fixtures/services.fixture';
-import { pickScenarioTest, type AcceptanceScenarioMeta } from '../../helpers/acceptance-scenario';
 import { startCatalogProcessWithFirstTask } from '../../flows/start-process-with-first-task';
-
-const QUERY_ADMIN_POST_ISSUE = 'https://hyland.atlassian.net/browse/AAE-47783';
-
-const postTasksScenario: AcceptanceScenarioMeta = {
-    title: 'admin POST tasks list query',
-    exclude: QUERY_ADMIN_POST_ISSUE,
-};
-
-const postProcessInstancesScenario: AcceptanceScenarioMeta = {
-    title: 'admin POST process instances list query',
-    exclude: QUERY_ADMIN_POST_ISSUE,
-};
 
 activiti.describe('Runtime — Query Admin Remaining Actions', () => {
     activiti('should cover query admin process instance tasks GET', async ({
@@ -59,7 +46,7 @@ activiti.describe('Runtime — Query Admin Remaining Actions', () => {
         });
     });
 
-    pickScenarioTest(activiti, postTasksScenario)(postTasksScenario.title, async ({
+    activiti('admin POST tasks list query', async ({
         runtimeBundleServiceTestUser,
         taskServiceTestUser,
         queryAdminServiceTestAdmin,
@@ -86,7 +73,7 @@ activiti.describe('Runtime — Query Admin Remaining Actions', () => {
         });
     });
 
-    pickScenarioTest(activiti, postProcessInstancesScenario)(postProcessInstancesScenario.title, async ({
+    activiti('admin POST process instances list query', async ({
         runtimeBundleServiceTestUser,
         taskServiceTestUser,
         queryAdminServiceTestAdmin,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNActivityRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNActivityRepository.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
 import com.querydsl.core.types.dsl.StringPath;
+import java.util.Collection;
 import java.util.List;
 import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
@@ -48,6 +49,8 @@ public interface BPMNActivityRepository
     );
 
     List<BPMNActivityEntity> findByProcessInstanceId(String processInstanceId);
+
+    List<BPMNActivityEntity> findByProcessInstanceIdIn(Collection<String> processInstanceIds);
 
     BPMNActivityEntity findByProcessInstanceIdAndElementId(String processInstanceId, String elementId);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNSequenceFlowRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/BPMNSequenceFlowRepository.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
 import com.querydsl.core.types.dsl.StringPath;
+import java.util.Collection;
 import java.util.List;
 import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
 import org.activiti.cloud.services.query.model.QBPMNSequenceFlowEntity;
@@ -42,6 +43,8 @@ public interface BPMNSequenceFlowRepository
     }
 
     List<BPMNSequenceFlowEntity> findByProcessInstanceId(String processInstanceId);
+
+    List<BPMNSequenceFlowEntity> findByProcessInstanceIdIn(Collection<String> processInstanceIds);
 
     BPMNSequenceFlowEntity findByProcessInstanceIdAndElementId(String processInstanceId, String elementId);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ServiceTaskRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/ServiceTaskRepository.java
@@ -18,6 +18,7 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
 import com.querydsl.core.types.dsl.StringPath;
+import java.util.Collection;
 import java.util.List;
 import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.services.query.model.QServiceTaskEntity;
@@ -52,6 +53,8 @@ public interface ServiceTaskRepository
     );
 
     List<ServiceTaskEntity> findByProcessInstanceId(String processInstanceId);
+
+    List<ServiceTaskEntity> findByProcessInstanceIdIn(Collection<String> processInstanceIds);
 
     ServiceTaskEntity findByProcessInstanceIdAndElementId(String processInstanceId, String elementId);
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/TaskRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/TaskRepository.java
@@ -19,6 +19,8 @@ import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsH
 
 import com.querydsl.core.types.dsl.StringPath;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import org.activiti.cloud.services.query.model.QTaskEntity;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
@@ -36,6 +38,8 @@ public interface TaskRepository
         CustomizedTaskRepository,
         CrudRepository<TaskEntity, String>
 {
+    List<TaskEntity> findByProcessInstanceIdIn(Collection<String> processInstanceIds);
+
     @Override
     default void customize(QuerydslBindings bindings, QTaskEntity root) {
         bindings.bind(String.class).first((StringPath path, String value) -> path.eq(value));

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/TaskVariableRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/TaskVariableRepository.java
@@ -18,6 +18,8 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
 import com.querydsl.core.types.dsl.StringPath;
+import java.util.Collection;
+import java.util.Set;
 import org.activiti.cloud.services.query.model.QTaskVariableEntity;
 import org.activiti.cloud.services.query.model.TaskVariableEntity;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
@@ -33,6 +35,8 @@ public interface TaskVariableRepository
         QuerydslBinderCustomizer<QTaskVariableEntity>,
         CrudRepository<TaskVariableEntity, Long>
 {
+    Set<TaskVariableEntity> findByTaskIdIn(Collection<String> taskIds);
+
     @Override
     default void customize(QuerydslBindings bindings, QTaskVariableEntity root) {
         whitelist(root).apply(bindings);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/VariableRepository.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-repo/src/main/java/org/activiti/cloud/services/query/app/repository/VariableRepository.java
@@ -18,6 +18,8 @@ package org.activiti.cloud.services.query.app.repository;
 import static org.activiti.cloud.services.query.app.repository.QuerydslBindingsHelper.whitelist;
 
 import com.querydsl.core.types.dsl.StringPath;
+import java.util.Collection;
+import java.util.List;
 import org.activiti.cloud.services.query.model.ProcessVariableEntity;
 import org.activiti.cloud.services.query.model.QProcessVariableEntity;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -35,6 +37,8 @@ public interface VariableRepository
         QuerydslBinderCustomizer<QProcessVariableEntity>,
         CrudRepository<ProcessVariableEntity, Long>
 {
+    List<ProcessVariableEntity> findByProcessInstanceIdIn(Collection<String> processInstanceIds);
+
     @Override
     default void customize(QuerydslBindings bindings, QProcessVariableEntity root) {
         whitelist(root).apply(bindings);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceDeleteController.java
@@ -24,16 +24,23 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.activiti.cloud.api.process.model.QueryCloudProcessInstance;
 import org.activiti.cloud.services.query.app.repository.BPMNActivityRepository;
 import org.activiti.cloud.services.query.app.repository.BPMNSequenceFlowRepository;
 import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.ProcessInstanceEntity;
+import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.query.rest.assembler.ProcessInstanceRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -66,6 +73,12 @@ public class ProcessInstanceDeleteController {
 
     private final BPMNSequenceFlowRepository bpmnSequenceFlowRepository;
 
+    private final TaskCandidateUserRepository taskCandidateUserRepository;
+
+    private final TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    private final TaskVariableRepository taskVariableRepository;
+
     private ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler;
 
     @Autowired
@@ -76,6 +89,9 @@ public class ProcessInstanceDeleteController {
         ServiceTaskRepository serviceTaskRepository,
         BPMNActivityRepository bpmnActivityRepository,
         BPMNSequenceFlowRepository bpmnSequenceFlowRepository,
+        TaskCandidateUserRepository taskCandidateUserRepository,
+        TaskCandidateGroupRepository taskCandidateGroupRepository,
+        TaskVariableRepository taskVariableRepository,
         ProcessInstanceRepresentationModelAssembler processInstanceRepresentationModelAssembler
     ) {
         this.processInstanceRepository = processInstanceRepository;
@@ -84,6 +100,9 @@ public class ProcessInstanceDeleteController {
         this.serviceTaskRepository = serviceTaskRepository;
         this.bpmnActivityRepository = bpmnActivityRepository;
         this.bpmnSequenceFlowRepository = bpmnSequenceFlowRepository;
+        this.taskCandidateUserRepository = taskCandidateUserRepository;
+        this.taskCandidateGroupRepository = taskCandidateGroupRepository;
+        this.taskVariableRepository = taskVariableRepository;
         this.processInstanceRepresentationModelAssembler = processInstanceRepresentationModelAssembler;
     }
 
@@ -95,21 +114,51 @@ public class ProcessInstanceDeleteController {
             root = ProcessInstanceEntity.class
         ) Predicate predicate
     ) {
+        List<ProcessInstanceEntity> processInstances = StreamSupport.stream(
+            processInstanceRepository.findAll(predicate).spliterator(),
+            false
+        ).toList();
+        Set<String> processInstanceIds = processInstances
+            .stream()
+            .map(ProcessInstanceEntity::getId)
+            .collect(Collectors.toSet());
+
         Collection<EntityModel<QueryCloudProcessInstance>> result = new ArrayList<>();
-        Iterable<ProcessInstanceEntity> iterable = processInstanceRepository.findAll(predicate);
-
-        for (ProcessInstanceEntity entity : iterable) {
-            Optional.ofNullable(entity.getTasks()).ifPresent(taskRepository::deleteAll);
-            Optional.ofNullable(entity.getVariables()).ifPresent(variableRepository::deleteAll);
-            Optional.ofNullable(entity.getServiceTasks()).ifPresent(serviceTaskRepository::deleteAll);
-            Optional.ofNullable(entity.getActivities()).ifPresent(bpmnActivityRepository::deleteAll);
-            Optional.ofNullable(entity.getSequenceFlows()).ifPresent(bpmnSequenceFlowRepository::deleteAll);
-
+        for (ProcessInstanceEntity entity : processInstances) {
             result.add(processInstanceRepresentationModelAssembler.toModel(entity));
         }
 
-        processInstanceRepository.deleteAll(iterable);
+        if (!processInstanceIds.isEmpty()) {
+            deleteRelatedTasks(processInstanceIds);
+            variableRepository.deleteAll(variableRepository.findByProcessInstanceIdIn(processInstanceIds));
+            serviceTaskRepository.deleteAll(serviceTaskRepository.findByProcessInstanceIdIn(processInstanceIds));
+            bpmnActivityRepository.deleteAll(bpmnActivityRepository.findByProcessInstanceIdIn(processInstanceIds));
+            bpmnSequenceFlowRepository.deleteAll(
+                bpmnSequenceFlowRepository.findByProcessInstanceIdIn(processInstanceIds)
+            );
+        }
+
+        processInstanceRepository.deleteAll(processInstances);
 
         return CollectionModel.of(result);
+    }
+
+    /**
+     * Deletes child rows via fresh queries (by processInstanceId / taskId) rather than by navigating the
+     * process instance's lazy collections. Initializing a collection and then deleting its managed elements
+     * leaves dangling references in the collection, which triggers a TransientPropertyValueException on flush.
+     * Nothing lazy is serialized under {@link JsonViews.General}, so the collections are never touched.
+     */
+    private void deleteRelatedTasks(Set<String> processInstanceIds) {
+        List<TaskEntity> tasks = taskRepository.findByProcessInstanceIdIn(processInstanceIds);
+        if (tasks.isEmpty()) {
+            return;
+        }
+
+        Set<String> taskIds = tasks.stream().map(TaskEntity::getId).collect(Collectors.toSet());
+        taskCandidateUserRepository.deleteAll(taskCandidateUserRepository.findByTaskIdIn(taskIds));
+        taskCandidateGroupRepository.deleteAll(taskCandidateGroupRepository.findByTaskIdIn(taskIds));
+        taskVariableRepository.deleteAll(taskVariableRepository.findByTaskIdIn(taskIds));
+        taskRepository.deleteAll(tasks);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskDeleteController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/TaskDeleteController.java
@@ -24,12 +24,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.activiti.cloud.api.task.model.QueryCloudTask;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
+import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.query.rest.assembler.TaskRepresentationModelAssembler;
-import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.querydsl.binding.QuerydslPredicate;
@@ -48,14 +55,26 @@ public class TaskDeleteController {
 
     private final TaskRepository taskRepository;
 
+    private final TaskCandidateUserRepository taskCandidateUserRepository;
+
+    private final TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    private final TaskVariableRepository taskVariableRepository;
+
     private TaskRepresentationModelAssembler taskRepresentationModelAssembler;
 
     @Autowired
     public TaskDeleteController(
         TaskRepository taskRepository,
+        TaskCandidateUserRepository taskCandidateUserRepository,
+        TaskCandidateGroupRepository taskCandidateGroupRepository,
+        TaskVariableRepository taskVariableRepository,
         TaskRepresentationModelAssembler taskRepresentationModelAssembler
     ) {
         this.taskRepository = taskRepository;
+        this.taskCandidateUserRepository = taskCandidateUserRepository;
+        this.taskCandidateGroupRepository = taskCandidateGroupRepository;
+        this.taskVariableRepository = taskVariableRepository;
         this.taskRepresentationModelAssembler = taskRepresentationModelAssembler;
     }
 
@@ -68,16 +87,34 @@ public class TaskDeleteController {
         ) Predicate predicate
     ) {
         Collection<EntityModel<QueryCloudTask>> result = new ArrayList<>();
-        Iterable<TaskEntity> iterable = taskRepository.findAll(predicate);
+        List<TaskEntity> tasks = StreamSupport.stream(taskRepository.findAll(predicate).spliterator(), false).toList();
+        Set<String> taskIds = tasks.stream().map(TaskEntity::getId).collect(Collectors.toSet());
 
-        for (TaskEntity entity : iterable) {
-            Hibernate.initialize(entity.getTaskCandidateUsers());
-            Hibernate.initialize(entity.getTaskCandidateGroups());
+        if (!taskIds.isEmpty()) {
+            taskCandidateUserRepository.deleteAll(taskCandidateUserRepository.findByTaskIdIn(taskIds));
+            taskCandidateGroupRepository.deleteAll(taskCandidateGroupRepository.findByTaskIdIn(taskIds));
+            taskVariableRepository.deleteAll(taskVariableRepository.findByTaskIdIn(taskIds));
+        }
+
+        for (TaskEntity entity : tasks) {
+            touchLazyAssociations(entity);
             result.add(taskRepresentationModelAssembler.toModel(entity));
         }
 
-        taskRepository.deleteAll(iterable);
+        taskRepository.deleteAll(tasks);
 
         return CollectionModel.of(result);
+    }
+
+    /**
+     * JSON serialization runs after the transaction closes; touch lazy associations while the
+     * persistence context is still open (same pattern as {@link ProcessInstanceDeleteController}).
+     */
+    private static void touchLazyAssociations(TaskEntity entity) {
+        Optional.ofNullable(entity.getTaskCandidateUsers()).ifPresent(Collection::size);
+        Optional.ofNullable(entity.getTaskCandidateGroups()).ifPresent(Collection::size);
+        Optional.ofNullable(entity.getVariables()).ifPresent(Collection::size);
+        Optional.ofNullable(entity.getProcessVariables()).ifPresent(Collection::size);
+        Optional.ofNullable(entity.getProcessInstance()).ifPresent(processInstance -> processInstance.getId());
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/ProcessInstanceEntityDeleteControllerIT.java
@@ -17,6 +17,7 @@ package org.activiti.cloud.services.query.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.querydsl.core.types.Predicate;
 import jakarta.persistence.EntityManagerFactory;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -47,6 +49,7 @@ import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
 import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
 import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.BPMNActivityEntity;
 import org.activiti.cloud.services.query.model.BPMNSequenceFlowEntity;
@@ -92,6 +95,9 @@ public class ProcessInstanceEntityDeleteControllerIT {
 
     @MockitoBean
     private TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    @MockitoBean
+    private TaskVariableRepository taskVariableRepository;
 
     @MockitoBean
     private SecurityManager securityManager;
@@ -166,17 +172,29 @@ public class ProcessInstanceEntityDeleteControllerIT {
         List<ProcessInstanceEntity> processInstanceEntities = Collections.singletonList(processInstanceEntity);
         given(processInstanceRepository.findAll(any(Predicate.class))).willReturn(processInstanceEntities);
 
+        List<TaskEntity> tasks = new ArrayList<>(processInstanceEntity.getTasks());
+        List<ProcessVariableEntity> variables = new ArrayList<>(processInstanceEntity.getVariables());
+        List<ServiceTaskEntity> serviceTasks = new ArrayList<>(processInstanceEntity.getServiceTasks());
+        List<BPMNActivityEntity> activities = new ArrayList<>(processInstanceEntity.getActivities());
+        List<BPMNSequenceFlowEntity> sequenceFlows = new ArrayList<>(processInstanceEntity.getSequenceFlows());
+
+        given(taskRepository.findByProcessInstanceIdIn(anyCollection())).willReturn(tasks);
+        given(variableRepository.findByProcessInstanceIdIn(anyCollection())).willReturn(variables);
+        given(serviceTaskRepository.findByProcessInstanceIdIn(anyCollection())).willReturn(serviceTasks);
+        given(bpmnActivityRepository.findByProcessInstanceIdIn(anyCollection())).willReturn(activities);
+        given(bpmnSequenceFlowRepository.findByProcessInstanceIdIn(anyCollection())).willReturn(sequenceFlows);
+
         //when
         mockMvc
             .perform(delete("/admin/v1/process-instances").with(csrf()).accept(MediaType.APPLICATION_JSON))
             //then
             .andExpect(status().isOk());
 
-        verify(taskRepository).deleteAll(processInstanceEntity.getTasks());
-        verify(variableRepository).deleteAll(processInstanceEntity.getVariables());
-        verify(bpmnActivityRepository).deleteAll(processInstanceEntity.getActivities());
-        verify(serviceTaskRepository).deleteAll(processInstanceEntity.getServiceTasks());
-        verify(bpmnSequenceFlowRepository).deleteAll(processInstanceEntity.getSequenceFlows());
+        verify(taskRepository).deleteAll(tasks);
+        verify(variableRepository).deleteAll(variables);
+        verify(bpmnActivityRepository).deleteAll(activities);
+        verify(serviceTaskRepository).deleteAll(serviceTasks);
+        verify(bpmnSequenceFlowRepository).deleteAll(sequenceFlows);
 
         verify(processInstanceRepository).deleteAll(processInstanceEntities);
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskAdminControllerIT.java
@@ -147,9 +147,9 @@ class TaskAdminControllerIT extends AbstractTaskControllerIT {
             .buildProcessInstance()
             .withProcessDefinitionKey(PROCESS_DEFINITION_KEY)
             .withVariables(new QueryTestUtils.VariableInput(VAR_NAME, VariableType.STRING, "value1"))
-            .withTasks(queryTestUtils.buildTask())
+            .withTasks(queryTestUtils.buildTask().withTaskCandidateUsers("candidate-user"))
             .buildAndSave();
-        queryTestUtils.buildTask().buildAndSave();
+        queryTestUtils.buildTask().withTaskCandidateGroups("candidate-group").buildAndSave();
 
         given()
             .contentType(MediaType.APPLICATION_JSON)

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskEntityDeleteControllerIT.java
@@ -39,6 +39,7 @@ import org.activiti.cloud.services.query.app.repository.ProcessInstanceRepositor
 import org.activiti.cloud.services.query.app.repository.TaskCandidateGroupRepository;
 import org.activiti.cloud.services.query.app.repository.TaskCandidateUserRepository;
 import org.activiti.cloud.services.query.app.repository.TaskRepository;
+import org.activiti.cloud.services.query.app.repository.TaskVariableRepository;
 import org.activiti.cloud.services.query.app.repository.VariableRepository;
 import org.activiti.cloud.services.query.model.TaskEntity;
 import org.activiti.cloud.services.security.TaskLookupRestrictionService;
@@ -86,6 +87,9 @@ public class TaskEntityDeleteControllerIT {
 
     @MockitoBean
     private TaskCandidateGroupRepository taskCandidateGroupRepository;
+
+    @MockitoBean
+    private TaskVariableRepository taskVariableRepository;
 
     @MockitoBean
     private SecurityManager securityManager;


### PR DESCRIPTION
## Summary

Clean re-do of #2466 (auto-merged, then reverted in #2468) as a **single commit**.

Re-enables the previously excluded query admin acceptance tests (AAE-47783) and fixes the query-service bulk delete endpoints so they survive the full Playwright suite followed by the destructive delete tests.

### Backend
- **`TaskDeleteController`**: delete candidate users/groups and task variables via fresh `findByTaskIdIn` queries before removing tasks. Prevents `TransientPropertyValueException` on bulk delete once the namespace is populated by the full suite.
- **`ProcessInstanceDeleteController`**: delete child rows (tasks + their children, process variables, service tasks, activities, sequence flows) via fresh `findByProcessInstanceIdIn` / `findByTaskIdIn` queries **without initializing the process instance's lazy collections**. Initializing a collection and then deleting its managed elements left dangling references, triggering `TransientPropertyValueException (ProcessInstanceEntity.activities -> BPMNActivityEntity)` on flush. Nothing lazy is serialized under `JsonViews.General`, so the collections no longer need touching.
- New `findByProcessInstanceIdIn` finders on the affected repositories.

### Acceptance tests
- Assert against specific task/process ids and counts.
- `deleteAllProcessInstances` now surfaces `>= 400` responses instead of letting the test time out (this was masking the real 400 error).

## Notes
- Branch is based on the pre-change `develop` (`9c2d55c37b`), so it applies cleanly whether or not the revert #2468 has landed.
- Tree is byte-for-byte identical to the previously merged #2466 change.

## Test plan
- [x] `ProcessInstanceEntityDeleteControllerIT` (2/2) and `TaskEntityDeleteControllerIT` (1/1) pass locally.
- [x] Full Playwright acceptance suite green in CI (destructive delete tests: delete all tasks + delete all process instances).