### PR TITLE
AAE-48644 Fix Query Rest OOM caused by the get service tasks admin API rest call with N+1 integration context entity queries

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.query.model;
 
+@SuppressWarnings("all")
 public interface JsonViews {
     interface General {}
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
@@ -19,5 +19,7 @@ public class JsonViews {
 
     public static class General {}
 
+    public static class IntegrationContexts extends General {}
+
     public static class ProcessVariables {}
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/JsonViews.java
@@ -15,11 +15,10 @@
  */
 package org.activiti.cloud.services.query.model;
 
-public class JsonViews {
+public interface JsonViews {
+    interface General {}
 
-    public static class General {}
+    interface IntegrationContexts extends General {}
 
-    public static class IntegrationContexts extends General {}
-
-    public static class ProcessVariables {}
+    interface ProcessVariables {}
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ServiceTaskEntity.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/main/java/org/activiti/cloud/services/query/model/ServiceTaskEntity.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.cloud.services.query.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.annotations.PropertyType;
 import com.querydsl.core.annotations.QueryType;
 import jakarta.persistence.Access;
@@ -39,8 +40,10 @@ import org.springframework.format.annotation.DateTimeFormat;
 @SQLRestriction("activity_type='serviceTask'")
 @DynamicInsert
 @DynamicUpdate
+@JsonView(JsonViews.General.class)
 public class ServiceTaskEntity extends BaseBPMNActivityEntity implements CloudServiceTask {
 
+    @JsonView(JsonViews.IntegrationContexts.class)
     @OneToMany(mappedBy = "serviceTask", fetch = FetchType.LAZY)
     private List<IntegrationContextEntity> integrationContexts;
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/JsonViewsTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-model/src/test/java/org/activiti/cloud/services/query/model/JsonViewsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+class JsonViewsTest {
+
+    private final JsonMapper objectMapper = new JsonMapper();
+
+    @Test
+    void should_notSerializeIntegrationContextsWithGeneralView() throws Exception {
+        ServiceTaskEntity serviceTaskEntity = new ServiceTaskEntity();
+        serviceTaskEntity.setIntegrationContexts(List.of());
+
+        JsonNode payload = objectMapper.readTree(
+            objectMapper.writerWithView(JsonViews.General.class).writeValueAsString(serviceTaskEntity)
+        );
+
+        assertThat(payload.has("integrationContexts")).isFalse();
+    }
+
+    @Test
+    void should_serializeIntegrationContextsWithIntegrationContextsView() throws Exception {
+        ServiceTaskEntity serviceTaskEntity = new ServiceTaskEntity();
+        serviceTaskEntity.setIntegrationContexts(List.of());
+
+        JsonNode payload = objectMapper.readTree(
+            objectMapper.writerWithView(JsonViews.IntegrationContexts.class).writeValueAsString(serviceTaskEntity)
+        );
+
+        assertThat(payload.has("integrationContexts")).isTrue();
+        assertThat(payload.get("integrationContexts").isArray()).isTrue();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ProcessInstanceServiceTasksAdminController.java
@@ -19,11 +19,13 @@ import static org.activiti.cloud.services.query.model.QServiceTaskEntity.service
 import static org.activiti.cloud.services.query.rest.RestDocConstants.PREDICATE_DESC;
 import static org.activiti.cloud.services.query.rest.RestDocConstants.PREDICATE_EXAMPLE;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.types.Predicate;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.api.process.model.CloudServiceTask;
 import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
+import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.ServiceTaskEntity;
 import org.activiti.cloud.services.query.rest.assembler.ServiceTaskRepresentationModelAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +65,7 @@ public class ProcessInstanceServiceTasksAdminController {
         this.pagedCollectionModelAssembler = pagedCollectionModelAssembler;
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/service-tasks", method = RequestMethod.GET)
     public PagedModel<EntityModel<CloudServiceTask>> getServiceTasks(
         @PathVariable String processInstanceId,

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskAdminController.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/ServiceTaskAdminController.java
@@ -18,12 +18,14 @@ package org.activiti.cloud.services.query.rest;
 import static org.activiti.cloud.services.query.rest.RestDocConstants.PREDICATE_DESC;
 import static org.activiti.cloud.services.query.rest.RestDocConstants.PREDICATE_EXAMPLE;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.querydsl.core.types.Predicate;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedModelAssembler;
 import org.activiti.cloud.api.process.model.CloudServiceTask;
 import org.activiti.cloud.services.query.app.repository.EntityFinder;
 import org.activiti.cloud.services.query.app.repository.ServiceTaskRepository;
+import org.activiti.cloud.services.query.model.JsonViews;
 import org.activiti.cloud.services.query.model.QServiceTaskEntity;
 import org.activiti.cloud.services.query.model.ServiceTaskEntity;
 import org.activiti.cloud.services.query.rest.assembler.ServiceTaskRepresentationModelAssembler;
@@ -65,6 +67,7 @@ public class ServiceTaskAdminController {
         this.pagedCollectionModelAssembler = pagedCollectionModelAssembler;
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(method = RequestMethod.GET)
     public PagedModel<EntityModel<CloudServiceTask>> findAllServiceTasks(
         @Parameter(description = PREDICATE_DESC, example = PREDICATE_EXAMPLE) @QuerydslPredicate(
@@ -79,6 +82,7 @@ public class ServiceTaskAdminController {
         );
     }
 
+    @JsonView(JsonViews.General.class)
     @RequestMapping(value = "/{serviceTaskId}", method = RequestMethod.GET)
     public EntityModel<CloudServiceTask> findByIdServiceTaskAdmin(@PathVariable String serviceTaskId) {
         Predicate filter = QServiceTaskEntity.serviceTaskEntity.id.eq(serviceTaskId);

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -294,8 +294,8 @@ public class QueryAdminProcessServiceTasksIT {
             assertThat(responseEntity.getBody()).isNotNull();
             assertThat(responseEntity.getBody().getContent())
                 .hasSize(1)
-                .extracting(CloudServiceTask::getActivityType)
-                .contains(SERVICE_TASK_TYPE);
+                .extracting(CloudServiceTask::getActivityType, CloudServiceTask::getIntegrationContextCounter)
+                .contains(tuple(SERVICE_TASK_TYPE, 1));
         });
     }
 
@@ -914,6 +914,17 @@ public class QueryAdminProcessServiceTasksIT {
     private ProcessInstanceImpl sendEventsForStartSimpleProcessInstance() {
         ProcessInstanceImpl process = startSimpleProcessInstance();
         eventsAggregator.sendAll();
+
+        final CloudServiceTask serviceTask = waitForServiceTask(BPMNActivityStatus.STARTED);
+
+        // when - Create and send integration context
+        IntegrationContext integrationContext1 = buildIntegrationContext(
+            process,
+            serviceTask.getProcessInstanceId(),
+            serviceTask
+        );
+        sendIntegrationRequestedEvent(integrationContext1);
+
         return process;
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/java/org/activiti/cloud/starter/tests/QueryAdminProcessServiceTasksIT.java
@@ -275,6 +275,16 @@ public class QueryAdminProcessServiceTasksIT {
         //given
         ProcessInstanceImpl process = sendEventsForStartSimpleProcessInstance();
 
+        final CloudServiceTask serviceTask = waitForServiceTask(BPMNActivityStatus.STARTED);
+
+        // when - Create and send integration context
+        IntegrationContext integrationContext1 = buildIntegrationContext(
+            process,
+            serviceTask.getProcessInstanceId(),
+            serviceTask
+        );
+        sendIntegrationRequestedEvent(integrationContext1);
+
         //then
         await().untilAsserted(() -> {
             assertThat(bpmnActivityRepository.findByProcessInstanceId(process.getId())).hasSize(2);
@@ -914,16 +924,6 @@ public class QueryAdminProcessServiceTasksIT {
     private ProcessInstanceImpl sendEventsForStartSimpleProcessInstance() {
         ProcessInstanceImpl process = startSimpleProcessInstance();
         eventsAggregator.sendAll();
-
-        final CloudServiceTask serviceTask = waitForServiceTask(BPMNActivityStatus.STARTED);
-
-        // when - Create and send integration context
-        IntegrationContext integrationContext1 = buildIntegrationContext(
-            process,
-            serviceTask.getProcessInstanceId(),
-            serviceTask
-        );
-        sendIntegrationRequestedEvent(integrationContext1);
 
         return process;
     }

--- a/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query/src/test/resources/swagger-expected.json
@@ -51,8 +51,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -61,8 +61,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -121,8 +121,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -131,8 +131,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -201,8 +201,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -211,8 +211,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -286,8 +286,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -296,8 +296,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -356,8 +356,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -366,8 +366,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -733,8 +733,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -743,8 +743,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1084,8 +1084,8 @@
           }
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1094,8 +1094,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1384,8 +1384,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1394,8 +1394,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1481,8 +1481,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1491,8 +1491,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1551,8 +1551,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1561,8 +1561,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1859,8 +1859,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1869,8 +1869,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2159,8 +2159,8 @@
           }
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2169,8 +2169,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2424,8 +2424,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2434,8 +2434,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2521,8 +2521,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2531,8 +2531,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2591,8 +2591,8 @@
           "required" : true
         },
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2601,8 +2601,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2968,8 +2968,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2978,8 +2978,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3081,8 +3081,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3091,8 +3091,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3149,8 +3149,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3159,8 +3159,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3217,8 +3217,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3227,8 +3227,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3291,8 +3291,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3301,8 +3301,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3603,8 +3603,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3613,8 +3613,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3671,8 +3671,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3681,8 +3681,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3796,8 +3796,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3806,8 +3806,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3903,8 +3903,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3913,8 +3913,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4213,8 +4213,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4223,8 +4223,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4281,8 +4281,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4291,8 +4291,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4418,8 +4418,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4428,8 +4428,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4486,8 +4486,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4496,8 +4496,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4586,8 +4586,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4596,8 +4596,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4699,8 +4699,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4709,8 +4709,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4767,8 +4767,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4777,8 +4777,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4835,8 +4835,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4845,8 +4845,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4909,8 +4909,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4919,8 +4919,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5043,8 +5043,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5053,8 +5053,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5078,12 +5078,12 @@
             "content" : {
               "application/hal+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask_General"
                 }
               },
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask_General"
                 }
               }
             }
@@ -5111,8 +5111,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5121,8 +5121,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5146,12 +5146,12 @@
             "content" : {
               "application/hal+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask_General"
                 }
               },
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask_General"
                 }
               }
             }
@@ -5205,8 +5205,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5215,8 +5215,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5273,8 +5273,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5283,8 +5283,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5342,8 +5342,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5352,8 +5352,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5467,8 +5467,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5477,8 +5477,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5561,8 +5561,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5571,8 +5571,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5861,8 +5861,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5871,8 +5871,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5996,8 +5996,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6006,8 +6006,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6031,12 +6031,12 @@
             "content" : {
               "application/hal+json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask_General"
                 }
               },
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask"
+                  "$ref" : "#/components/schemas/ListResponseContentCloudServiceTask_General"
                 }
               }
             }
@@ -6182,8 +6182,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6192,8 +6192,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6250,8 +6250,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6260,8 +6260,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6339,8 +6339,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6349,8 +6349,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6433,8 +6433,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6443,8 +6443,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6700,8 +6700,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6710,8 +6710,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6858,8 +6858,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6868,8 +6868,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6926,8 +6926,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6936,8 +6936,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6989,8 +6989,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -6999,8 +6999,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -7094,8 +7094,8 @@
           }
         } ],
         "responses" : {
-          "404" : {
-            "description" : "Not Found",
+          "400" : {
+            "description" : "Bad Request",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -7104,8 +7104,8 @@
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -7154,12 +7154,12 @@
       "ActivitiErrorMessage" : {
         "type" : "object",
         "properties" : {
+          "message" : {
+            "type" : "string"
+          },
           "code" : {
             "type" : "integer",
             "format" : "int32"
-          },
-          "message" : {
-            "type" : "string"
           }
         },
         "title" : "ActivitiErrorMessage"
@@ -7389,35 +7389,35 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "taskId" : {
-            "type" : "string"
-          },
-          "taskVariable" : {
-            "type" : "boolean"
           },
           "name" : {
             "type" : "string"
           },
           "value" : { },
           "type" : {
+            "type" : "string"
+          },
+          "taskVariable" : {
+            "type" : "boolean"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           }
         },
@@ -7484,11 +7484,12 @@
       "QueryCloudTask_ProcessVariables" : {
         "type" : "object",
         "properties" : {
-          "processDefinitionName" : {
-            "type" : "string"
-          },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "permissions" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
+            }
           },
           "processVariables" : {
             "type" : "array",
@@ -7497,96 +7498,29 @@
             },
             "uniqueItems" : true
           },
-          "permissions" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
-            }
+          "rootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "processDefinitionName" : {
+            "type" : "string"
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "businessKey" : {
-            "type" : "string"
-          },
-          "formKey" : {
-            "type" : "string"
-          },
-          "completedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "candidateUsers" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "candidateGroups" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "assignee" : {
-            "type" : "string"
-          },
-          "processDefinitionId" : {
-            "type" : "string"
-          },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "taskDefinitionKey" : {
-            "type" : "string"
-          },
-          "createdDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "claimedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "parentTaskId" : {
-            "type" : "string"
-          },
-          "completedBy" : {
-            "type" : "string"
-          },
-          "taskProcessRootProcessInstanceId" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
           },
           "name" : {
             "type" : "string"
@@ -7607,6 +7541,72 @@
           },
           "standalone" : {
             "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
+          },
+          "formKey" : {
+            "type" : "string"
+          },
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "taskProcessRootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "createdDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "claimedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "parentTaskId" : {
+            "type" : "string"
+          },
+          "taskDefinitionKey" : {
+            "type" : "string"
+          },
+          "completedBy" : {
+            "type" : "string"
+          },
+          "assignee" : {
+            "type" : "string"
+          },
+          "completedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "candidateUsers" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "candidateGroups" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "processInstanceId" : {
+            "type" : "string"
+          },
+          "businessKey" : {
+            "type" : "string"
+          },
+          "processDefinitionId" : {
+            "type" : "string"
+          },
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         },
         "title" : "QueryCloudTask_ProcessVariables"
@@ -7799,12 +7799,11 @@
       "QueryCloudProcessInstance_ProcessVariables" : {
         "type" : "object",
         "properties" : {
-          "subprocesses" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance_ProcessVariables"
-            },
-            "uniqueItems" : true
+          "linkedProcessInstanceType" : {
+            "type" : "string"
+          },
+          "linkedProcessInstanceId" : {
+            "type" : "string"
           },
           "linkedProcesses" : {
             "type" : "array",
@@ -7813,31 +7812,42 @@
             },
             "uniqueItems" : true
           },
-          "linkedProcessInstanceType" : {
-            "type" : "string"
-          },
-          "linkedProcessInstanceId" : {
-            "type" : "string"
+          "subprocesses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance_ProcessVariables"
+            },
+            "uniqueItems" : true
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
           },
-          "businessKey" : {
+          "name" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
+          },
+          "parentId" : {
             "type" : "string"
           },
           "initiator" : {
@@ -7847,38 +7857,28 @@
             "type" : "string",
             "format" : "date-time"
           },
+          "businessKey" : {
+            "type" : "string"
+          },
           "processDefinitionId" : {
             "type" : "string"
           },
           "processDefinitionKey" : {
             "type" : "string"
           },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
+          "rootProcessInstanceId" : {
+            "type" : "string"
           },
           "processDefinitionName" : {
             "type" : "string"
           },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           },
           "startDate" : {
             "type" : "string",
             "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
-          },
-          "parentId" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
           }
         },
         "title" : "QueryCloudProcessInstance_ProcessVariables"
@@ -7919,35 +7919,35 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "taskId" : {
-            "type" : "string"
-          },
-          "taskVariable" : {
-            "type" : "boolean"
           },
           "name" : {
             "type" : "string"
           },
           "value" : { },
           "type" : {
+            "type" : "string"
+          },
+          "taskVariable" : {
+            "type" : "boolean"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           }
         },
@@ -8014,11 +8014,12 @@
       "QueryCloudTask" : {
         "type" : "object",
         "properties" : {
-          "processDefinitionName" : {
-            "type" : "string"
-          },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "permissions" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
+            }
           },
           "processVariables" : {
             "type" : "array",
@@ -8027,96 +8028,29 @@
             },
             "uniqueItems" : true
           },
-          "permissions" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
-            }
+          "rootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "processDefinitionName" : {
+            "type" : "string"
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "businessKey" : {
-            "type" : "string"
-          },
-          "formKey" : {
-            "type" : "string"
-          },
-          "completedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "candidateUsers" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "candidateGroups" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "assignee" : {
-            "type" : "string"
-          },
-          "processDefinitionId" : {
-            "type" : "string"
-          },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "taskDefinitionKey" : {
-            "type" : "string"
-          },
-          "createdDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "claimedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "parentTaskId" : {
-            "type" : "string"
-          },
-          "completedBy" : {
-            "type" : "string"
-          },
-          "taskProcessRootProcessInstanceId" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
           },
           "name" : {
             "type" : "string"
@@ -8137,6 +8071,72 @@
           },
           "standalone" : {
             "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
+          },
+          "formKey" : {
+            "type" : "string"
+          },
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "taskProcessRootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "createdDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "claimedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "parentTaskId" : {
+            "type" : "string"
+          },
+          "taskDefinitionKey" : {
+            "type" : "string"
+          },
+          "completedBy" : {
+            "type" : "string"
+          },
+          "assignee" : {
+            "type" : "string"
+          },
+          "completedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "candidateUsers" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "candidateGroups" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "processInstanceId" : {
+            "type" : "string"
+          },
+          "businessKey" : {
+            "type" : "string"
+          },
+          "processDefinitionId" : {
+            "type" : "string"
+          },
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         },
         "title" : "QueryCloudTask"
@@ -8189,12 +8189,11 @@
       "QueryCloudProcessInstance" : {
         "type" : "object",
         "properties" : {
-          "subprocesses" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance"
-            },
-            "uniqueItems" : true
+          "linkedProcessInstanceType" : {
+            "type" : "string"
+          },
+          "linkedProcessInstanceId" : {
+            "type" : "string"
           },
           "linkedProcesses" : {
             "type" : "array",
@@ -8203,31 +8202,42 @@
             },
             "uniqueItems" : true
           },
-          "linkedProcessInstanceType" : {
-            "type" : "string"
-          },
-          "linkedProcessInstanceId" : {
-            "type" : "string"
+          "subprocesses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance"
+            },
+            "uniqueItems" : true
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
           },
-          "businessKey" : {
+          "name" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
+          },
+          "parentId" : {
             "type" : "string"
           },
           "initiator" : {
@@ -8237,38 +8247,28 @@
             "type" : "string",
             "format" : "date-time"
           },
+          "businessKey" : {
+            "type" : "string"
+          },
           "processDefinitionId" : {
             "type" : "string"
           },
           "processDefinitionKey" : {
             "type" : "string"
           },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
+          "rootProcessInstanceId" : {
+            "type" : "string"
           },
           "processDefinitionName" : {
             "type" : "string"
           },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           },
           "startDate" : {
             "type" : "string",
             "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
-          },
-          "parentId" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
           }
         },
         "title" : "QueryCloudProcessInstance"
@@ -8321,6 +8321,13 @@
       "ProcessInstanceSearchResult_ProcessVariables" : {
         "type" : "object",
         "properties" : {
+          "variables" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/QueryCloudVariableInstance_ProcessVariables"
+            },
+            "uniqueItems" : true
+          },
           "subprocessesCount" : {
             "type" : "integer",
             "format" : "int64"
@@ -8328,13 +8335,6 @@
           "linkedProcessesCount" : {
             "type" : "integer",
             "format" : "int64"
-          },
-          "variables" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/QueryCloudVariableInstance_ProcessVariables"
-            },
-            "uniqueItems" : true
           },
           "linkedProcessInstanceType" : {
             "type" : "string"
@@ -8345,22 +8345,32 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
           },
-          "businessKey" : {
+          "name" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
+          },
+          "parentId" : {
             "type" : "string"
           },
           "initiator" : {
@@ -8370,38 +8380,28 @@
             "type" : "string",
             "format" : "date-time"
           },
+          "businessKey" : {
+            "type" : "string"
+          },
           "processDefinitionId" : {
             "type" : "string"
           },
           "processDefinitionKey" : {
             "type" : "string"
           },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
+          "rootProcessInstanceId" : {
+            "type" : "string"
           },
           "processDefinitionName" : {
             "type" : "string"
           },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           },
           "startDate" : {
             "type" : "string",
             "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
-          },
-          "parentId" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
           }
         },
         "title" : "ProcessInstanceSearchResult_ProcessVariables"
@@ -8415,35 +8415,35 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "taskId" : {
-            "type" : "string"
-          },
-          "taskVariable" : {
-            "type" : "boolean"
           },
           "name" : {
             "type" : "string"
           },
           "value" : { },
           "type" : {
+            "type" : "string"
+          },
+          "taskVariable" : {
+            "type" : "boolean"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           }
         },
@@ -8488,35 +8488,35 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "taskId" : {
-            "type" : "string"
-          },
-          "taskVariable" : {
-            "type" : "boolean"
           },
           "name" : {
             "type" : "string"
           },
           "value" : { },
           "type" : {
+            "type" : "string"
+          },
+          "taskVariable" : {
+            "type" : "boolean"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           }
         },
@@ -8534,11 +8534,12 @@
       "QueryCloudTask_General" : {
         "type" : "object",
         "properties" : {
-          "processDefinitionName" : {
-            "type" : "string"
-          },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "permissions" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
+            }
           },
           "processVariables" : {
             "type" : "array",
@@ -8547,96 +8548,29 @@
             },
             "uniqueItems" : true
           },
-          "permissions" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "VIEW", "CLAIM", "RELEASE", "UPDATE" ]
-            }
+          "rootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "processDefinitionName" : {
+            "type" : "string"
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "businessKey" : {
-            "type" : "string"
-          },
-          "formKey" : {
-            "type" : "string"
-          },
-          "completedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "candidateUsers" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "candidateGroups" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "assignee" : {
-            "type" : "string"
-          },
-          "processDefinitionId" : {
-            "type" : "string"
-          },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "taskDefinitionKey" : {
-            "type" : "string"
-          },
-          "createdDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "dueDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "claimedDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "parentTaskId" : {
-            "type" : "string"
-          },
-          "completedBy" : {
-            "type" : "string"
-          },
-          "taskProcessRootProcessInstanceId" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
           },
           "name" : {
             "type" : "string"
@@ -8657,6 +8591,72 @@
           },
           "standalone" : {
             "type" : "boolean"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "ASSIGNED", "SUSPENDED", "COMPLETED", "CANCELLED", "DELETED" ]
+          },
+          "formKey" : {
+            "type" : "string"
+          },
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "taskProcessRootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "createdDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "claimedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "parentTaskId" : {
+            "type" : "string"
+          },
+          "taskDefinitionKey" : {
+            "type" : "string"
+          },
+          "completedBy" : {
+            "type" : "string"
+          },
+          "assignee" : {
+            "type" : "string"
+          },
+          "completedDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "candidateUsers" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "candidateGroups" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "processInstanceId" : {
+            "type" : "string"
+          },
+          "businessKey" : {
+            "type" : "string"
+          },
+          "processDefinitionId" : {
+            "type" : "string"
+          },
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         },
         "title" : "QueryCloudTask_General"
@@ -8673,12 +8673,11 @@
       "QueryCloudProcessInstance_General" : {
         "type" : "object",
         "properties" : {
-          "subprocesses" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance_General"
-            },
-            "uniqueItems" : true
+          "linkedProcessInstanceType" : {
+            "type" : "string"
+          },
+          "linkedProcessInstanceId" : {
+            "type" : "string"
           },
           "linkedProcesses" : {
             "type" : "array",
@@ -8687,31 +8686,42 @@
             },
             "uniqueItems" : true
           },
-          "linkedProcessInstanceType" : {
-            "type" : "string"
-          },
-          "linkedProcessInstanceId" : {
-            "type" : "string"
+          "subprocesses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/QueryCloudSubprocessInstance_General"
+            },
+            "uniqueItems" : true
           },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
             "type" : "string"
           },
-          "businessKey" : {
+          "name" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
+          },
+          "parentId" : {
             "type" : "string"
           },
           "initiator" : {
@@ -8721,38 +8731,28 @@
             "type" : "string",
             "format" : "date-time"
           },
+          "businessKey" : {
+            "type" : "string"
+          },
           "processDefinitionId" : {
             "type" : "string"
           },
           "processDefinitionKey" : {
             "type" : "string"
           },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
+          "rootProcessInstanceId" : {
+            "type" : "string"
           },
           "processDefinitionName" : {
             "type" : "string"
           },
-          "rootProcessInstanceId" : {
-            "type" : "string"
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
           },
           "startDate" : {
             "type" : "string",
             "format" : "date-time"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "CREATED", "RUNNING", "SUSPENDED", "CANCELLED", "COMPLETED" ]
-          },
-          "parentId" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "id" : {
-            "type" : "string"
           }
         },
         "title" : "QueryCloudProcessInstance_General"
@@ -8811,35 +8811,35 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
             "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "taskId" : {
-            "type" : "string"
-          },
-          "taskVariable" : {
-            "type" : "boolean"
           },
           "name" : {
             "type" : "string"
           },
           "value" : { },
           "type" : {
+            "type" : "string"
+          },
+          "taskVariable" : {
+            "type" : "boolean"
+          },
+          "taskId" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           }
         },
@@ -8924,28 +8924,19 @@
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           },
           "appVersion" : {
-            "type" : "string"
-          },
-          "formKey" : {
-            "type" : "string"
-          },
-          "category" : {
-            "type" : "string"
-          },
-          "description" : {
             "type" : "string"
           },
           "name" : {
@@ -8960,6 +8951,15 @@
           "version" : {
             "type" : "integer",
             "format" : "int32"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "formKey" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
           }
         },
         "title" : "CloudProcessDefinition"
@@ -9045,27 +9045,34 @@
         },
         "title" : "ListResponseContentCloudApplication"
       },
-      "CloudServiceTask" : {
+      "CloudServiceTask_General" : {
         "type" : "object",
         "properties" : {
           "integrationContextCounter" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "businessKey" : {
+          "id" : {
             "type" : "string"
           },
-          "startedDate" : {
+          "status" : {
+            "type" : "string",
+            "enum" : [ "STARTED", "COMPLETED", "CANCELLED", "ERROR" ]
+          },
+          "completedDate" : {
             "type" : "string",
             "format" : "date-time"
           },
-          "completedDate" : {
+          "startedDate" : {
             "type" : "string",
             "format" : "date-time"
           },
           "cancelledDate" : {
             "type" : "string",
             "format" : "date-time"
+          },
+          "businessKey" : {
+            "type" : "string"
           },
           "processDefinitionKey" : {
             "type" : "string"
@@ -9074,102 +9081,101 @@
             "type" : "integer",
             "format" : "int32"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "STARTED", "COMPLETED", "CANCELLED", "ERROR" ]
-          },
-          "id" : {
-            "type" : "string"
-          },
           "appName" : {
-            "type" : "string"
-          },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
-            "type" : "string"
-          },
-          "serviceType" : {
             "type" : "string"
           },
           "serviceVersion" : {
             "type" : "string"
           },
+          "serviceType" : {
+            "type" : "string"
+          },
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
+            "type" : "string"
+          },
           "appVersion" : {
-            "type" : "string"
-          },
-          "activityType" : {
-            "type" : "string"
-          },
-          "executionId" : {
             "type" : "string"
           },
           "activityName" : {
             "type" : "string"
           },
-          "processInstanceId" : {
+          "executionId" : {
             "type" : "string"
           },
-          "elementId" : {
+          "activityType" : {
+            "type" : "string"
+          },
+          "processInstanceId" : {
             "type" : "string"
           },
           "processDefinitionId" : {
             "type" : "string"
+          },
+          "elementId" : {
+            "type" : "string"
           }
         },
-        "title" : "CloudServiceTask"
+        "title" : "CloudServiceTask_General"
       },
-      "EntriesResponseContentCloudServiceTask" : {
+      "EntriesResponseContentCloudServiceTask_General" : {
         "type" : "object",
         "properties" : {
           "entries" : {
             "type" : "array",
             "items" : {
-              "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask"
+              "$ref" : "#/components/schemas/EntryResponseContentCloudServiceTask_General"
             }
           },
           "pagination" : {
-            "$ref" : "#/components/schemas/PaginationMetadata"
+            "$ref" : "#/components/schemas/PaginationMetadata_General"
           }
         },
-        "title" : "EntriesResponseContentCloudServiceTask"
+        "title" : "EntriesResponseContentCloudServiceTask_General"
       },
-      "EntryResponseContentCloudServiceTask" : {
+      "EntryResponseContentCloudServiceTask_General" : {
         "type" : "object",
         "properties" : {
           "entry" : {
-            "$ref" : "#/components/schemas/CloudServiceTask"
+            "$ref" : "#/components/schemas/CloudServiceTask_General"
           }
         },
-        "title" : "EntryResponseContentCloudServiceTask"
+        "title" : "EntryResponseContentCloudServiceTask_General"
       },
-      "ListResponseContentCloudServiceTask" : {
+      "ListResponseContentCloudServiceTask_General" : {
         "type" : "object",
         "properties" : {
           "list" : {
-            "$ref" : "#/components/schemas/EntriesResponseContentCloudServiceTask"
+            "$ref" : "#/components/schemas/EntriesResponseContentCloudServiceTask_General"
           }
         },
-        "title" : "ListResponseContentCloudServiceTask"
+        "title" : "ListResponseContentCloudServiceTask_General"
       },
       "CloudIntegrationContext" : {
         "type" : "object",
         "properties" : {
-          "requestDate" : {
+          "status" : {
             "type" : "string",
-            "format" : "date-time"
+            "enum" : [ "INTEGRATION_REQUESTED", "INTEGRATION_RESULT_RECEIVED", "INTEGRATION_ERROR_RECEIVED" ]
+          },
+          "errorMessage" : {
+            "type" : "string"
+          },
+          "errorCode" : {
+            "type" : "string"
           },
           "resultDate" : {
             "type" : "string",
             "format" : "date-time"
           },
-          "errorDate" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
           "errorClassName" : {
             "type" : "string"
+          },
+          "requestDate" : {
+            "type" : "string",
+            "format" : "date-time"
           },
           "stackTraceElements" : {
             "type" : "array",
@@ -9204,52 +9210,19 @@
               }
             }
           },
-          "errorCode" : {
-            "type" : "string"
-          },
-          "errorMessage" : {
-            "type" : "string"
-          },
-          "status" : {
+          "errorDate" : {
             "type" : "string",
-            "enum" : [ "INTEGRATION_REQUESTED", "INTEGRATION_RESULT_RECEIVED", "INTEGRATION_ERROR_RECEIVED" ]
+            "format" : "date-time"
           },
-          "clientId" : {
-            "type" : "string"
-          },
-          "clientName" : {
-            "type" : "string"
-          },
-          "processInstanceId" : {
-            "type" : "string"
-          },
-          "appVersion" : {
-            "type" : "string"
-          },
-          "businessKey" : {
-            "type" : "string"
-          },
-          "executionId" : {
-            "type" : "string"
-          },
-          "parentProcessInstanceId" : {
-            "type" : "string"
-          },
-          "processDefinitionId" : {
-            "type" : "string"
-          },
-          "processDefinitionKey" : {
-            "type" : "string"
-          },
-          "processDefinitionVersion" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "rootProcessInstanceId" : {
+          "id" : {
             "type" : "string"
           },
           "connectorType" : {
             "type" : "string"
+          },
+          "outBoundVariables" : {
+            "type" : "object",
+            "additionalProperties" : { }
           },
           "clientType" : {
             "type" : "string"
@@ -9258,26 +9231,53 @@
             "type" : "object",
             "additionalProperties" : { }
           },
-          "outBoundVariables" : {
-            "type" : "object",
-            "additionalProperties" : { }
+          "executionId" : {
+            "type" : "string"
           },
-          "id" : {
+          "processInstanceId" : {
+            "type" : "string"
+          },
+          "parentProcessInstanceId" : {
+            "type" : "string"
+          },
+          "businessKey" : {
+            "type" : "string"
+          },
+          "processDefinitionId" : {
+            "type" : "string"
+          },
+          "appVersion" : {
+            "type" : "string"
+          },
+          "processDefinitionKey" : {
+            "type" : "string"
+          },
+          "rootProcessInstanceId" : {
+            "type" : "string"
+          },
+          "processDefinitionVersion" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "clientId" : {
+            "type" : "string"
+          },
+          "clientName" : {
             "type" : "string"
           },
           "appName" : {
             "type" : "string"
           },
-          "serviceName" : {
-            "type" : "string"
-          },
-          "serviceFullName" : {
+          "serviceVersion" : {
             "type" : "string"
           },
           "serviceType" : {
             "type" : "string"
           },
-          "serviceVersion" : {
+          "serviceFullName" : {
+            "type" : "string"
+          },
+          "serviceName" : {
             "type" : "string"
           }
         },


### PR DESCRIPTION
This PR targets an OutOf-Memory risk in the Query REST service caused by N+1 lazy-loading of `integrationContexts` when calling the admin “service tasks” API, by constraining JSON serialization via Jackson `@JsonView` and validating integration-context counting in integration tests.

**Changes:**
- Add `@JsonView(JsonViews.General.class)` to `ServiceTaskAdminController` GET endpoints to avoid serializing heavy/lazy fields by default.
- Introduce/extend JSON views (`JsonViews.IntegrationContexts`) and annotate `ServiceTaskEntity` / `integrationContexts` to gate serialization of the LAZY collection.
- Update `QueryAdminProcessServiceTasksIT` assertions around `integrationContextCounter` and integration-context event setup.

https://hyland.atlassian.net/browse/AAE-48644