### PR TITLE
AAE-48854 Increase orphaned integration recovery threshold to 3 hours and improve error message formatting

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryConfiguration.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryConfiguration.java
@@ -36,7 +36,7 @@ public class OrphanedIntegrationRecoveryConfiguration {
         IntegrationContextService integrationContextService,
         IntegrationRequestBuilder integrationRequestBuilder,
         ServiceTaskIntegrationErrorEventHandler errorEventHandler,
-        @Value("${activiti.orphaned-integration-recovery.threshold-seconds:1800}") int thresholdSeconds,
+        @Value("${activiti.orphaned-integration-recovery.threshold-seconds:10800}") int thresholdSeconds, // 3 hours
         FeatureToggle featureToggle
     ) {
         return new OrphanedIntegrationRecoveryScheduler(

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryScheduler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryScheduler.java
@@ -110,11 +110,9 @@ public class OrphanedIntegrationRecoveryScheduler {
         }
     }
 
-    public String buildErrorMessage() {
-        return (
-            "Service task did not complete: the integration was not resolved within the expected time (threshold: %s). Possible causes include application shutdown, connector crash, or task interruption.".formatted(
-                formatThreshold()
-            )
+    private String buildErrorMessage() {
+        return "Service task did not complete: the integration was not resolved within the expected time (threshold: %s). Possible causes include application shutdown, connector crash, or task interruption.".formatted(
+            formatThreshold()
         );
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryScheduler.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoveryScheduler.java
@@ -37,10 +37,6 @@ public class OrphanedIntegrationRecoveryScheduler {
 
     public static final String ORPHANED_INTEGRATION_ERROR_CODE = "ORPHANED_INTEGRATION";
 
-    public static final String ORPHANED_INTEGRATION_ERROR_MESSAGE =
-        "Service task did not complete: the integration was not resolved within the expected time." +
-        " Possible causes include application shutdown, connector crash, or task interruption.";
-
     private final IntegrationContextService integrationContextService;
     private final IntegrationRequestBuilder integrationRequestBuilder;
     private final ServiceTaskIntegrationErrorEventHandler errorEventHandler;
@@ -99,7 +95,7 @@ public class OrphanedIntegrationRecoveryScheduler {
             var integrationRequest = integrationRequestBuilder.build(integrationContext);
             var integrationError = new IntegrationErrorImpl(
                 integrationRequest,
-                new CloudBpmnError(ORPHANED_INTEGRATION_ERROR_CODE, ORPHANED_INTEGRATION_ERROR_MESSAGE)
+                new CloudBpmnError(ORPHANED_INTEGRATION_ERROR_CODE, buildErrorMessage())
             );
 
             errorEventHandler.receive(integrationError);
@@ -112,5 +108,21 @@ public class OrphanedIntegrationRecoveryScheduler {
         } catch (Exception e) {
             LOGGER.error("Failed to recover orphaned integration context {}.", entity.getId(), e);
         }
+    }
+
+    public String buildErrorMessage() {
+        return (
+            "Service task did not complete: the integration was not resolved within the expected time (threshold: %s). Possible causes include application shutdown, connector crash, or task interruption.".formatted(
+                formatThreshold()
+            )
+        );
+    }
+
+    private String formatThreshold() {
+        var minutes = thresholdSeconds / 60;
+        var seconds = thresholdSeconds % 60;
+        if (minutes == 0) return seconds + " sec";
+        if (seconds == 0) return minutes + " min";
+        return minutes + " min " + seconds + " sec";
     }
 }

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoverySchedulerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoverySchedulerTest.java
@@ -109,7 +109,10 @@ class OrphanedIntegrationRecoverySchedulerTest {
         verify(errorEventHandler).receive(errorCaptor.capture());
         assertThat(errorCaptor.getValue()).satisfies(error -> {
             assertThat(error.getErrorClassName()).isEqualTo(CloudBpmnError.class.getName());
-            assertThat(error.getErrorMessage()).isEqualTo(scheduler.buildErrorMessage());
+            assertThat(error.getErrorMessage()).isEqualTo(
+                "Service task did not complete: the integration was not resolved within the expected time (threshold: 0 sec). " +
+                    "Possible causes include application shutdown, connector crash, or task interruption."
+            );
         });
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoverySchedulerTest.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/recovery/OrphanedIntegrationRecoverySchedulerTest.java
@@ -109,9 +109,7 @@ class OrphanedIntegrationRecoverySchedulerTest {
         verify(errorEventHandler).receive(errorCaptor.capture());
         assertThat(errorCaptor.getValue()).satisfies(error -> {
             assertThat(error.getErrorClassName()).isEqualTo(CloudBpmnError.class.getName());
-            assertThat(error.getErrorMessage()).isEqualTo(
-                OrphanedIntegrationRecoveryScheduler.ORPHANED_INTEGRATION_ERROR_MESSAGE
-            );
+            assertThat(error.getErrorMessage()).isEqualTo(scheduler.buildErrorMessage());
         });
     }
 

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
@@ -261,17 +261,16 @@ class OrphanedIntegrationRecoveryIT {
             ctx2.getBean(ServiceTaskIntegrationErrorEventHandler.class)
         );
 
-        AopTestUtils.<OrphanedIntegrationRecoveryScheduler>getTargetObject(
+        var scheduler = AopTestUtils.<OrphanedIntegrationRecoveryScheduler>getTargetObject(
             ctx2.getBean(OrphanedIntegrationRecoveryScheduler.class)
-        ).recoverOrphanedIntegrations();
+        );
+        scheduler.recoverOrphanedIntegrations();
 
         var errorCaptor = ArgumentCaptor.forClass(IntegrationError.class);
         verify(errorHandler, atLeastOnce()).receive(errorCaptor.capture());
         assertThat(errorCaptor.getValue()).satisfies(error -> {
             assertThat(error.getErrorClassName()).isEqualTo(CloudBpmnError.class.getName());
-            assertThat(error.getErrorMessage()).isEqualTo(
-                OrphanedIntegrationRecoveryScheduler.ORPHANED_INTEGRATION_ERROR_MESSAGE
-            );
+            assertThat(error.getErrorMessage()).isEqualTo(scheduler.buildErrorMessage());
         });
         assertThat(
             ctx2

--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
@@ -270,7 +270,10 @@ class OrphanedIntegrationRecoveryIT {
         verify(errorHandler, atLeastOnce()).receive(errorCaptor.capture());
         assertThat(errorCaptor.getValue()).satisfies(error -> {
             assertThat(error.getErrorClassName()).isEqualTo(CloudBpmnError.class.getName());
-            assertThat(error.getErrorMessage()).isEqualTo(scheduler.buildErrorMessage());
+            assertThat(error.getErrorMessage()).isEqualTo(
+                "Service task did not complete: the integration was not resolved within the expected time (threshold: 0 sec). " +
+                    "Possible causes include application shutdown, connector crash, or task interruption."
+            );
         });
         assertThat(
             ctx2


### PR DESCRIPTION
## Pull request overview

This PR updates the orphaned-integration recovery behavior in the runtime-bundle connectors by increasing the default recovery threshold to **3 hours** and by generating a more informative Cloud BPMN error message that includes the configured threshold (instead of relying on a fixed constant message).

**Changes:**
- Increase default `activiti.orphaned-integration-recovery.threshold-seconds` from 1800 (30 min) to 10800 (3 h).
- Replace the static error-message constant with a dynamically built message that includes the threshold.
- Update unit/integration tests to align with the new error-message generation approach.

