### PR TITLE
AAE-49187 Address flaky OrphanedIntegrationRecoveryIT

### DIFF
--- a/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
+++ b/activiti-cloud-runtime-bundle-service/activiti-cloud-starter-runtime-bundle-it/src/test/java/org/activiti/cloud/starter/tests/recovery/OrphanedIntegrationRecoveryIT.java
@@ -309,8 +309,10 @@ class OrphanedIntegrationRecoveryIT {
 
     @Test
     void should_runRecoveryOnlyOnce_when_twoInstancesRunConcurrently() {
-        ctx1 = buildLightweightContext();
-        ctx2 = buildLightweightContext();
+        // ctx1's own scheduler is disabled: its lock acquisition below is manual/simulated only,
+        // so it never competes with itself for the "orphanedIntegrationRecovery" lock.
+        ctx1 = buildLightweightContext(false);
+        ctx2 = buildLightweightContext(true);
 
         var lockConfig = new LockConfiguration(Instant.now(), LOCK_NAME, Duration.ofMinutes(5), Duration.ZERO);
 
@@ -391,14 +393,14 @@ class OrphanedIntegrationRecoveryIT {
             .run();
     }
 
-    private static ConfigurableApplicationContext buildLightweightContext() {
+    private static ConfigurableApplicationContext buildLightweightContext(boolean schedulerEnabled) {
         return new SpringApplicationBuilder(LockTestApplication.class, LockTestConfiguration.class)
             .web(WebApplicationType.NONE)
             .initializers(ctx ->
                 TestPropertyValues.of(
                     "spring.main.banner-mode=off",
                     "activiti.orphaned-integration-recovery.threshold-seconds=0",
-                    "activiti.orphaned-integration-recovery.cron=*/1 * * * * *",
+                    "activiti.orphaned-integration-recovery.cron=" + (schedulerEnabled ? "*/1 * * * * *" : "-"),
                     "activiti.features.rb.orphaned-integration-recovery.enabled=true"
                 ).applyTo(ctx.getEnvironment())
             )


### PR DESCRIPTION
This addresses the flakiness reported for `OrphanedIntegrationRecoveryIT`, specifically `should_runRecoveryOnlyOnce_when_twoInstancesRunConcurrently`, which would occasionally fail with:

```
java.lang.AssertionError:
[ctx1 should acquire the scheduler lock]
Expecting Optional to contain a value but it was empty.
```

## What was actually going on

The test spins up two lightweight Spring contexts, `ctx1` and `ctx2`, and each one runs its own real `OrphanedIntegrationRecoveryScheduler`, firing every second through `@Scheduled` plus `@SchedulerLock`. On top of that, the test also tries to manually grab the same ShedLock name on `ctx1`, to simulate "ctx1's scheduler is currently running."

The problem is that `ctx1` already has a real scheduler doing exactly that in the background, so the manual lock call was competing with `ctx1`'s own scheduled task for the same lock row. Whenever the manual call landed at the moment the real scheduler already held the lock, `lock()` returned an empty `Optional` and the assertion failed. It's a genuine race, not a bad assertion, so it only showed up intermittently.

I confirmed this by temporarily widening the window (adding a short delay to the mocked service and running the test repeatedly) and was able to reproduce the same failure fairly reliably, about four times out of twenty runs, always at that exact assertion.

## The fix

`ctx1` never needed its own live scheduler running, since the test only ever drives its lock manually. `buildLightweightContext` now takes a flag and uses the special cron value Spring recognizes for turning a scheduled task off entirely, applied only to `ctx1`. `ctx2` keeps its real scheduler enabled since that is the side the test is actually exercising.

With that change there is no longer a second actor fighting over the same lock row, so the manual acquisition on `ctx1` is deterministic.

## Testing

* Reproduced the failure with the widened race window described above, twenty runs, four failures.
* Reran the same widened scenario after the fix, twenty runs, zero failures.
* Ran the test normally (single run, no artificial delay) to confirm it still passes as expected.
