### PR TITLE
AAE-50659 Bump netty to 4.2.17

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -17,7 +17,7 @@
     <graphql-java.version>25.0</graphql-java.version>
     <postgresql.version>42.7.13</postgresql.version>
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
-    <netty.version>4.2.16.Final</netty.version>
+    <netty.version>4.2.17.Final</netty.version>
     <jackson.version>3.1.5</jackson.version>
     <jackson2.version>2.22.1</jackson2.version>
     <rest-assured.version>6.0.0</rest-assured.version>


### PR DESCRIPTION
Bumps the pinned io.netty:netty-bom version from 4.2.16.Final to 4.2.17.Final to remediate two CVEs affecting Netty modules that are versioned together via the BOM:

GHSA-2qj4-mmr9-4v2f (netty-transport-sctp).
GHSA-8c42-7qj2-3j46 (netty-codec-http)

Both CVEs affect Netty 4.2.0.Final–4.2.16.Final (and the parallel 4.1.x line up to 4.1.136.Final) and are fixed in 4.2.17.Final / 4.1.137.Final respectively.