### PR TITLE
AAE-50919 Exclude requestId from the task count cache key

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKey.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKey.java
@@ -16,10 +16,112 @@
 package org.activiti.cloud.services.query.rest;
 
 import java.util.List;
+import java.util.Objects;
 import org.activiti.cloud.services.query.rest.payload.TaskSearchRequest;
 
 public record RestrictedTaskCountCacheKey(
     String authenticatedUserId,
     List<String> authenticatedUserGroups,
     TaskSearchRequest taskSearchRequest
-) {}
+) {
+    // requestId is a client-supplied correlation id, excluded so polls differing only by it reuse the cached count.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RestrictedTaskCountCacheKey that = (RestrictedTaskCountCacheKey) o;
+        return (
+            Objects.equals(authenticatedUserId, that.authenticatedUserId) &&
+            Objects.equals(authenticatedUserGroups, that.authenticatedUserGroups) &&
+            taskSearchRequestEqualsIgnoringRequestId(taskSearchRequest, that.taskSearchRequest)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            authenticatedUserId,
+            authenticatedUserGroups,
+            taskSearchRequestHashCodeIgnoringRequestId(taskSearchRequest)
+        );
+    }
+
+    private static boolean taskSearchRequestEqualsIgnoringRequestId(TaskSearchRequest a, TaskSearchRequest b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        return (
+            a.onlyStandalone() == b.onlyStandalone() &&
+            a.onlyRoot() == b.onlyRoot() &&
+            Objects.equals(a.id(), b.id()) &&
+            Objects.equals(a.parentId(), b.parentId()) &&
+            Objects.equals(a.processInstanceId(), b.processInstanceId()) &&
+            Objects.equals(a.name(), b.name()) &&
+            Objects.equals(a.description(), b.description()) &&
+            Objects.equals(a.processDefinitionName(), b.processDefinitionName()) &&
+            Objects.equals(a.priority(), b.priority()) &&
+            Objects.equals(a.status(), b.status()) &&
+            Objects.equals(a.completedBy(), b.completedBy()) &&
+            Objects.equals(a.assignee(), b.assignee()) &&
+            Objects.equals(a.createdFrom(), b.createdFrom()) &&
+            Objects.equals(a.createdTo(), b.createdTo()) &&
+            Objects.equals(a.lastModifiedFrom(), b.lastModifiedFrom()) &&
+            Objects.equals(a.lastModifiedTo(), b.lastModifiedTo()) &&
+            Objects.equals(a.lastClaimedFrom(), b.lastClaimedFrom()) &&
+            Objects.equals(a.lastClaimedTo(), b.lastClaimedTo()) &&
+            Objects.equals(a.dueDateFrom(), b.dueDateFrom()) &&
+            Objects.equals(a.dueDateTo(), b.dueDateTo()) &&
+            Objects.equals(a.completedFrom(), b.completedFrom()) &&
+            Objects.equals(a.completedTo(), b.completedTo()) &&
+            Objects.equals(a.candidateUserId(), b.candidateUserId()) &&
+            Objects.equals(a.candidateGroupId(), b.candidateGroupId()) &&
+            Objects.equals(a.taskVariableFilters(), b.taskVariableFilters()) &&
+            Objects.equals(a.processVariableFilters(), b.processVariableFilters()) &&
+            Objects.equals(a.processVariableKeys(), b.processVariableKeys()) &&
+            Objects.equals(a.sort(), b.sort())
+        );
+    }
+
+    private static int taskSearchRequestHashCodeIgnoringRequestId(TaskSearchRequest r) {
+        if (r == null) {
+            return 0;
+        }
+        return Objects.hash(
+            r.onlyStandalone(),
+            r.onlyRoot(),
+            r.id(),
+            r.parentId(),
+            r.processInstanceId(),
+            r.name(),
+            r.description(),
+            r.processDefinitionName(),
+            r.priority(),
+            r.status(),
+            r.completedBy(),
+            r.assignee(),
+            r.createdFrom(),
+            r.createdTo(),
+            r.lastModifiedFrom(),
+            r.lastModifiedTo(),
+            r.lastClaimedFrom(),
+            r.lastClaimedTo(),
+            r.dueDateFrom(),
+            r.dueDateTo(),
+            r.completedFrom(),
+            r.completedTo(),
+            r.candidateUserId(),
+            r.candidateGroupId(),
+            r.taskVariableFilters(),
+            r.processVariableFilters(),
+            r.processVariableKeys(),
+            r.sort()
+        );
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKey.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/main/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKey.java
@@ -16,7 +16,6 @@
 package org.activiti.cloud.services.query.rest;
 
 import java.util.List;
-import java.util.Objects;
 import org.activiti.cloud.services.query.rest.payload.TaskSearchRequest;
 
 public record RestrictedTaskCountCacheKey(
@@ -24,76 +23,17 @@ public record RestrictedTaskCountCacheKey(
     List<String> authenticatedUserGroups,
     TaskSearchRequest taskSearchRequest
 ) {
-    // requestId is a client-supplied correlation id, excluded so polls differing only by it reuse the cached count.
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RestrictedTaskCountCacheKey that = (RestrictedTaskCountCacheKey) o;
-        return (
-            Objects.equals(authenticatedUserId, that.authenticatedUserId) &&
-            Objects.equals(authenticatedUserGroups, that.authenticatedUserGroups) &&
-            taskSearchRequestEqualsIgnoringRequestId(taskSearchRequest, that.taskSearchRequest)
-        );
+    // requestId is a client-supplied correlation id, normalized away so polls differing only by it reuse the cached count.
+    public RestrictedTaskCountCacheKey {
+        taskSearchRequest = withoutRequestId(taskSearchRequest);
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            authenticatedUserId,
-            authenticatedUserGroups,
-            taskSearchRequestHashCodeIgnoringRequestId(taskSearchRequest)
-        );
-    }
-
-    private static boolean taskSearchRequestEqualsIgnoringRequestId(TaskSearchRequest a, TaskSearchRequest b) {
-        if (a == b) {
-            return true;
+    private static TaskSearchRequest withoutRequestId(TaskSearchRequest r) {
+        if (r.requestId() == null) {
+            return r;
         }
-        if (a == null || b == null) {
-            return false;
-        }
-        return (
-            a.onlyStandalone() == b.onlyStandalone() &&
-            a.onlyRoot() == b.onlyRoot() &&
-            Objects.equals(a.id(), b.id()) &&
-            Objects.equals(a.parentId(), b.parentId()) &&
-            Objects.equals(a.processInstanceId(), b.processInstanceId()) &&
-            Objects.equals(a.name(), b.name()) &&
-            Objects.equals(a.description(), b.description()) &&
-            Objects.equals(a.processDefinitionName(), b.processDefinitionName()) &&
-            Objects.equals(a.priority(), b.priority()) &&
-            Objects.equals(a.status(), b.status()) &&
-            Objects.equals(a.completedBy(), b.completedBy()) &&
-            Objects.equals(a.assignee(), b.assignee()) &&
-            Objects.equals(a.createdFrom(), b.createdFrom()) &&
-            Objects.equals(a.createdTo(), b.createdTo()) &&
-            Objects.equals(a.lastModifiedFrom(), b.lastModifiedFrom()) &&
-            Objects.equals(a.lastModifiedTo(), b.lastModifiedTo()) &&
-            Objects.equals(a.lastClaimedFrom(), b.lastClaimedFrom()) &&
-            Objects.equals(a.lastClaimedTo(), b.lastClaimedTo()) &&
-            Objects.equals(a.dueDateFrom(), b.dueDateFrom()) &&
-            Objects.equals(a.dueDateTo(), b.dueDateTo()) &&
-            Objects.equals(a.completedFrom(), b.completedFrom()) &&
-            Objects.equals(a.completedTo(), b.completedTo()) &&
-            Objects.equals(a.candidateUserId(), b.candidateUserId()) &&
-            Objects.equals(a.candidateGroupId(), b.candidateGroupId()) &&
-            Objects.equals(a.taskVariableFilters(), b.taskVariableFilters()) &&
-            Objects.equals(a.processVariableFilters(), b.processVariableFilters()) &&
-            Objects.equals(a.processVariableKeys(), b.processVariableKeys()) &&
-            Objects.equals(a.sort(), b.sort())
-        );
-    }
-
-    private static int taskSearchRequestHashCodeIgnoringRequestId(TaskSearchRequest r) {
-        if (r == null) {
-            return 0;
-        }
-        return Objects.hash(
+        return new TaskSearchRequest(
+            null,
             r.onlyStandalone(),
             r.onlyRoot(),
             r.id(),

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKeyTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/RestrictedTaskCountCacheKeyTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+import org.activiti.api.task.model.Task;
+import org.activiti.cloud.services.query.model.ProcessVariableKey;
+import org.activiti.cloud.services.query.rest.filter.FilterOperator;
+import org.activiti.cloud.services.query.rest.filter.VariableFilter;
+import org.activiti.cloud.services.query.rest.filter.VariableType;
+import org.activiti.cloud.services.query.rest.payload.CloudRuntimeEntitySort;
+import org.activiti.cloud.services.query.rest.payload.TaskSearchRequest;
+import org.activiti.cloud.services.query.util.TaskSearchRequestBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+class RestrictedTaskCountCacheKeyTest {
+
+    private static final String USER = "user";
+    private static final List<String> GROUPS = List.of("group-a");
+    private static final Date DATE_A = new Date(1_000L);
+    private static final Date DATE_B = new Date(2_000L);
+    private static final VariableFilter TASK_FILTER = new VariableFilter(
+        "pdk",
+        "tvar",
+        VariableType.STRING,
+        "a",
+        FilterOperator.EQUALS
+    );
+    private static final VariableFilter PROCESS_FILTER = new VariableFilter(
+        "pdk",
+        "pvar",
+        VariableType.STRING,
+        "a",
+        FilterOperator.EQUALS
+    );
+    private static final ProcessVariableKey PROCESS_KEY = new ProcessVariableKey("pdk", "key");
+    private static final CloudRuntimeEntitySort SORT = new CloudRuntimeEntitySort(
+        "field",
+        Sort.Direction.ASC,
+        false,
+        null,
+        null
+    );
+
+    @Test
+    void should_produceEqualCountCacheKeys_whenOnlyRequestIdDiffers() {
+        RestrictedTaskCountCacheKey firstKey = new RestrictedTaskCountCacheKey(USER, GROUPS, fullyPopulated("poll-1"));
+        RestrictedTaskCountCacheKey secondKey = new RestrictedTaskCountCacheKey(USER, GROUPS, fullyPopulated("poll-2"));
+
+        assertThat(firstKey).isEqualTo(secondKey).hasSameHashCodeAs(secondKey);
+    }
+
+    @Test
+    void should_produceDifferentCountCacheKeys_whenABooleanFieldDiffers() {
+        TaskSearchRequest standalone = new TaskSearchRequestBuilder().onlyStandalone().build();
+        TaskSearchRequest notStandalone = new TaskSearchRequestBuilder().build();
+
+        RestrictedTaskCountCacheKey standaloneKey = new RestrictedTaskCountCacheKey(USER, GROUPS, standalone);
+        RestrictedTaskCountCacheKey notStandaloneKey = new RestrictedTaskCountCacheKey(USER, GROUPS, notStandalone);
+
+        assertThat(standaloneKey).isNotEqualTo(notStandaloneKey);
+    }
+
+    @Test
+    void should_produceDifferentCountCacheKeys_whenAFilterFieldDiffers() {
+        TaskSearchRequest assigned = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.ASSIGNED).build();
+        TaskSearchRequest completed = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.COMPLETED).build();
+
+        RestrictedTaskCountCacheKey assignedKey = new RestrictedTaskCountCacheKey(USER, GROUPS, assigned);
+        RestrictedTaskCountCacheKey completedKey = new RestrictedTaskCountCacheKey(USER, GROUPS, completed);
+
+        assertThat(assignedKey).isNotEqualTo(completedKey);
+    }
+
+    private static TaskSearchRequest fullyPopulated(String requestId) {
+        return new TaskSearchRequestBuilder()
+            .withRequestId(requestId)
+            .onlyStandalone()
+            .onlyRoot()
+            .withId("id")
+            .withParentId("parent")
+            .withProcessInstanceId("pi")
+            .withName("name")
+            .withDescription("desc")
+            .withProcessDefinitionName("pdn")
+            .withPriority(1)
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .withCompletedBy("completedBy")
+            .withAssignees("assignee")
+            .withCreatedFrom(DATE_A)
+            .withCreatedTo(DATE_B)
+            .withLastModifiedFrom(DATE_A)
+            .withLastModifiedTo(DATE_B)
+            .withLastClaimedFrom(DATE_A)
+            .withLastClaimedTo(DATE_B)
+            .withDueDateFrom(DATE_A)
+            .withDueDateTo(DATE_B)
+            .withCompletedFrom(DATE_A)
+            .withCompletedTo(DATE_B)
+            .withCandidateUserId("candidateUser")
+            .withCandidateGroupId("candidateGroup")
+            .withTaskVariableFilters(TASK_FILTER)
+            .withProcessVariableFilters(PROCESS_FILTER)
+            .withProcessVariableKeys(PROCESS_KEY)
+            .withSort(SORT)
+            .build();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerHelperTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/TaskControllerHelperTest.java
@@ -257,4 +257,49 @@ public class TaskControllerHelperTest {
         assertThat(secondCount).isEqualTo(6L);
         verify(taskRepository, times(2)).count(any(Specification.class));
     }
+
+    @Test
+    void countTasksRestricted_should_hitCache_whenOnlyRequestIdChanges() {
+        FeatureToggleHolder.initialize(QueryFeatureToggles.FEATURE_TASK_COUNT_CACHE::equals);
+        given(securityManager.getAuthenticatedUserId()).willReturn("test-user");
+        given(securityManager.getAuthenticatedUserGroups()).willReturn(List.of("group-a"));
+        given(taskRepository.count(any(Specification.class))).willReturn(5L);
+
+        var firstPoll = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+        var secondPoll = new TaskSearchRequestBuilder()
+            .withRequestId("poll-2")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+
+        Long firstCount = taskControllerHelper.countTasksRestricted(firstPoll);
+        Long secondCount = taskControllerHelper.countTasksRestricted(secondPoll);
+
+        assertThat(firstCount).isEqualTo(5L);
+        assertThat(secondCount).isEqualTo(5L);
+        verify(taskRepository, times(1)).count(any(Specification.class));
+    }
+
+    @Test
+    void countTasksRestricted_should_hitCache_whenRequestIdGoesFromNullToNonNull() {
+        FeatureToggleHolder.initialize(QueryFeatureToggles.FEATURE_TASK_COUNT_CACHE::equals);
+        given(securityManager.getAuthenticatedUserId()).willReturn("test-user");
+        given(securityManager.getAuthenticatedUserGroups()).willReturn(List.of("group-a"));
+        given(taskRepository.count(any(Specification.class))).willReturn(5L);
+
+        var unidentifiedPoll = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.ASSIGNED).build();
+        var correlatedPoll = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+
+        Long firstCount = taskControllerHelper.countTasksRestricted(unidentifiedPoll);
+        Long secondCount = taskControllerHelper.countTasksRestricted(correlatedPoll);
+
+        assertThat(firstCount).isEqualTo(5L);
+        assertThat(secondCount).isEqualTo(5L);
+        verify(taskRepository, times(1)).count(any(Specification.class));
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/payload/TaskSearchRequestTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/rest/payload/TaskSearchRequestTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.rest.payload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.api.task.model.Task;
+import org.activiti.cloud.services.query.util.TaskSearchRequestBuilder;
+import org.junit.jupiter.api.Test;
+
+class TaskSearchRequestTest {
+
+    @Test
+    void should_beEqualAndShareHashCode_forIdenticalRequests() {
+        TaskSearchRequest first = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+        TaskSearchRequest second = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+
+        assertThat(first).isEqualTo(second).hasSameHashCodeAs(second);
+    }
+
+    @Test
+    void should_notBeEqual_whenRequestIdDiffers() {
+        TaskSearchRequest firstPoll = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+        TaskSearchRequest secondPoll = new TaskSearchRequestBuilder()
+            .withRequestId("poll-2")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+
+        assertThat(firstPoll).isNotEqualTo(secondPoll);
+    }
+
+    @Test
+    void should_notBeEqual_whenRequestIdGoesFromNullToNonNull() {
+        TaskSearchRequest unidentified = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.ASSIGNED).build();
+        TaskSearchRequest correlated = new TaskSearchRequestBuilder()
+            .withRequestId("poll-1")
+            .withStatus(Task.TaskStatus.ASSIGNED)
+            .build();
+
+        assertThat(unidentified).isNotEqualTo(correlated);
+    }
+
+    @Test
+    void should_notBeEqual_whenFilterFieldsDiffer() {
+        TaskSearchRequest assigned = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.ASSIGNED).build();
+        TaskSearchRequest completed = new TaskSearchRequestBuilder().withStatus(Task.TaskStatus.COMPLETED).build();
+
+        assertThat(assigned).isNotEqualTo(completed);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/TaskSearchRequestBuilder.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-rest/src/test/java/org/activiti/cloud/services/query/util/TaskSearchRequestBuilder.java
@@ -36,6 +36,7 @@ public class TaskSearchRequestBuilder {
         )
         .build();
 
+    private String requestId;
     private boolean onlyStandalone;
     private boolean onlyRoot;
     private Set<String> id;
@@ -64,6 +65,11 @@ public class TaskSearchRequestBuilder {
     private Set<VariableFilter> processVariableFilters;
     private Set<ProcessVariableKey> processVariableKeys;
     private CloudRuntimeEntitySort sort;
+
+    public TaskSearchRequestBuilder withRequestId(String requestId) {
+        this.requestId = requestId;
+        return this;
+    }
 
     public TaskSearchRequestBuilder onlyStandalone() {
         this.onlyStandalone = true;
@@ -234,7 +240,7 @@ public class TaskSearchRequestBuilder {
             }
         }
         return new TaskSearchRequest(
-            null,
+            requestId,
             onlyStandalone,
             onlyRoot,
             id,


### PR DESCRIPTION
This PR targets the query service's restricted task-count caching behaviour by ensuring client-supplied requestId correlation values do not influence the cache key, preventing unnecessary cache misses between polls with otherwise-identical filters.

Changes:
- Override RestrictedTaskCountCacheKey.equals() / [hashCode() to exclude requestId, while leaving TaskSearchRequest equality unchanged.