### PR TITLE
AAE-50657 Bump amqp-client to 5.33.1

### DIFF
--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -33,8 +33,8 @@
     <httpcore5.version>5.4.3</httpcore5.version>
     <!-- Security fix AAE-50658: override httpclient5 (incl. httpclient5-cache/-fluent) transitive version. -->
     <httpclient5.version>5.6.4</httpclient5.version>
-    <!-- Security fix AAE-50657: override RabbitMQ amqp-client. Remove once the managed Spring Boot BOM ships amqp-client 5.33.0+. -->
-    <amqp-client.version>5.33.0</amqp-client.version>
+    <!-- Security fix AAE-50657: override RabbitMQ amqp-client. Remove once the managed Spring Boot BOM ships amqp-client 5.33.1+. -->
+    <amqp-client.version>5.33.1</amqp-client.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -206,9 +206,10 @@
         <artifactId>httpclient5</artifactId>
         <version>${httpclient5.version}</version>
       </dependency>
+
       <!-- Security fix AAE-50658: com.rabbitmq:amqp-client transitive version. Managed by the import-scope
            Spring Boot BOM, so a property alone does not override it; an explicit dependencyManagement entry is
-           required. Remove once the managed Spring Boot BOM ships amqp-client 5.33.0+. -->
+           required. Remove once the managed Spring Boot BOM ships amqp-client 5.33.1+. -->
       <dependency>
         <groupId>com.rabbitmq</groupId>
         <artifactId>amqp-client</artifactId>

--- a/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
+++ b/activiti-cloud-build/activiti-cloud-build-dependencies-parent/pom.xml
@@ -33,6 +33,8 @@
     <httpcore5.version>5.4.3</httpcore5.version>
     <!-- Security fix AAE-50658: override httpclient5 (incl. httpclient5-cache/-fluent) transitive version. -->
     <httpclient5.version>5.6.4</httpclient5.version>
+    <!-- Security fix AAE-50657: override RabbitMQ amqp-client. Remove once the managed Spring Boot BOM ships amqp-client 5.33.0+. -->
+    <amqp-client.version>5.33.0</amqp-client.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -203,6 +205,14 @@
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
         <version>${httpclient5.version}</version>
+      </dependency>
+      <!-- Security fix AAE-50658: com.rabbitmq:amqp-client transitive version. Managed by the import-scope
+           Spring Boot BOM, so a property alone does not override it; an explicit dependencyManagement entry is
+           required. Remove once the managed Spring Boot BOM ships amqp-client 5.33.0+. -->
+      <dependency>
+        <groupId>com.rabbitmq</groupId>
+        <artifactId>amqp-client</artifactId>
+        <version>${amqp-client.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is to fix six CVEs (three HIGH, two MEDIUM, one LOW) all against com.rabbitmq:amqp-client.

https://hyland.atlassian.net/browse/AAE-50657