### PR TITLE
AAE-51054 Fix the released task status prerequisite bug fix

### DIFF
--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/QueryFeatureToggles.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/QueryFeatureToggles.java
@@ -41,4 +41,12 @@ public final class QueryFeatureToggles {
      * Enables the short-lived in-memory cache for restricted process instance counts.
      */
     public static final String FEATURE_PROCESS_INSTANCE_COUNT_CACHE = "query.process-instance-count.cache";
+
+    /**
+     * Enables serving counts from pre-aggregated values pushed as events are consumed instead of
+     * computing them on demand. Resolved from
+     * {@code activiti.features.query.pushed-counts.enabled}, disabled by default. Evaluated on
+     * every call, so it can be toggled at runtime without a restart.
+     */
+    public static final String FEATURE_PUSHED_COUNTS = "query.pushed-counts";
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskAssignedEventHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/main/java/org/activiti/cloud/services/query/events/handlers/TaskAssignedEventHandler.java
@@ -41,8 +41,13 @@ public class TaskAssignedEventHandler implements QueryEventHandler {
         TaskEntity queryTaskEntity = findResult.orElseThrow(() ->
             new QueryException("Unable to find task with id: " + eventTask.getId())
         );
-        queryTaskEntity.setAssignee(eventTask.getAssignee());
-        queryTaskEntity.setStatus(Task.TaskStatus.ASSIGNED);
+        String assignee = eventTask.getAssignee();
+        queryTaskEntity.setAssignee(assignee);
+        if (assignee != null && !assignee.isEmpty()) {
+            queryTaskEntity.setStatus(Task.TaskStatus.ASSIGNED);
+        } else {
+            queryTaskEntity.setStatus(Task.TaskStatus.CREATED);
+        }
         queryTaskEntity.setLastModified(new Date(taskAssignedEvent.getTimestamp()));
         queryTaskEntity.setServiceName(taskAssignedEvent.getServiceName());
         queryTaskEntity.setServiceFullName(taskAssignedEvent.getServiceFullName());

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskAssignedEventHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-events/src/test/java/org/activiti/cloud/services/query/events/handlers/TaskAssignedEventHandlerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.events.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManager;
+import org.activiti.api.task.model.Task;
+import org.activiti.api.task.model.events.TaskRuntimeEvent;
+import org.activiti.api.task.model.impl.TaskImpl;
+import org.activiti.cloud.api.task.model.impl.events.CloudTaskAssignedEventImpl;
+import org.activiti.cloud.services.query.model.TaskEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TaskAssignedEventHandlerTest {
+
+    private static final String TASK_ID = "task-id";
+
+    @InjectMocks
+    private TaskAssignedEventHandler handler;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Test
+    void handleShouldSetStatusAssignedWhenAssigneeIsPresent() {
+        TaskEntity queryTaskEntity = givenExistingTask(Task.TaskStatus.CREATED, null);
+
+        handler.handle(taskAssignedEvent("testuser"));
+
+        assertThat(queryTaskEntity.getAssignee()).isEqualTo("testuser");
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.ASSIGNED);
+    }
+
+    @Test
+    void handleShouldSetStatusCreatedWhenAssigneeIsNull() {
+        TaskEntity queryTaskEntity = givenExistingTask(Task.TaskStatus.ASSIGNED, "testuser");
+
+        handler.handle(taskAssignedEvent(null));
+
+        assertThat(queryTaskEntity.getAssignee()).isNull();
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.CREATED);
+    }
+
+    @Test
+    void handleShouldSetStatusCreatedWhenAssigneeIsEmpty() {
+        TaskEntity queryTaskEntity = givenExistingTask(Task.TaskStatus.ASSIGNED, "testuser");
+
+        handler.handle(taskAssignedEvent(""));
+
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.CREATED);
+    }
+
+    @Test
+    void handleShouldRestoreCreatedStatusAcrossClaimReleaseClaimCycle() {
+        TaskEntity queryTaskEntity = givenExistingTask(Task.TaskStatus.CREATED, null);
+
+        handler.handle(taskAssignedEvent("testuser"));
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.ASSIGNED);
+
+        handler.handle(taskAssignedEvent(null));
+        assertThat(queryTaskEntity.getAssignee()).isNull();
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.CREATED);
+
+        handler.handle(taskAssignedEvent("testuser"));
+        assertThat(queryTaskEntity.getAssignee()).isEqualTo("testuser");
+        assertThat(queryTaskEntity.getStatus()).isEqualTo(Task.TaskStatus.ASSIGNED);
+    }
+
+    @Test
+    void getHandledEventShouldReturnTaskAssignedEvent() {
+        assertThat(handler.getHandledEvent()).isEqualTo(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED.name());
+    }
+
+    private TaskEntity givenExistingTask(Task.TaskStatus status, String assignee) {
+        TaskEntity queryTaskEntity = new TaskEntity();
+        queryTaskEntity.setId(TASK_ID);
+        queryTaskEntity.setStatus(status);
+        queryTaskEntity.setAssignee(assignee);
+        when(entityManager.find(TaskEntity.class, TASK_ID)).thenReturn(queryTaskEntity);
+        return queryTaskEntity;
+    }
+
+    private static CloudTaskAssignedEventImpl taskAssignedEvent(String assignee) {
+        boolean assigned = assignee != null && !assignee.isEmpty();
+        TaskImpl task = new TaskImpl(TASK_ID, "task", assigned ? Task.TaskStatus.ASSIGNED : Task.TaskStatus.CREATED);
+        task.setAssignee(assignee);
+        return new CloudTaskAssignedEventImpl("event-id", System.currentTimeMillis(), task);
+    }
+}


### PR DESCRIPTION
Fixes how the query service updates task assignment state when consuming TASK_ASSIGNED events, addressing the “release” scenario where the assignee is cleared and the task should return to CREATED.

Changes:

- Update TaskAssignedEventHandler to set task status to ASSIGNED only when an assignee is present, otherwise set it to CREATED.

- Add a focused unit test suite covering claim/release/claim cycles and empty/null assignee cases.

- Add a new query feature toggle constant (FEATURE_PUSHED_COUNTS) for future pushed/pre-aggregated count support.