### PR TITLE
AAE-51056 Subscriber registry, consumer side, and wire contracts

### DIFF
--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterIT.java
@@ -27,7 +27,14 @@ public class QueryConsumerApplicationFunctionRouterIT extends QueryConsumerAppli
     void bindingServiceProperties() {
         assertThat(bindingServiceProperties.getBindings())
             .doesNotContainKeys("auditConsumer", "queryConsumer")
-            .containsOnlyKeys("functionRouterInput", "producer", "queryEventsProducer");
+            .containsOnlyKeys(
+                "functionRouterInput",
+                "producer",
+                "queryEventsProducer",
+                "subscriberRegistryConsumer",
+                "subscriberRegistryProducer",
+                "countProducer"
+            );
 
         assertThat(bindingServiceProperties.getBindingProperties("functionRouterInput")).satisfies(binding -> {
             assertThat(binding.getGroup()).isEqualTo("consumer");

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -47,9 +47,25 @@ public class QueryConsumerApplicationFunctionRouterRabbitmqPrefixIT extends Quer
 
     @Test
     @Override
+    void anonymousRabbitQueues() {
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("default-app.subscriberRegistry.anonymous."))
+            );
+    }
+
+    @Test
+    @Override
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("default-app.engineEvents", "default-app.queryEvents");
+            .containsOnlyKeys(
+                "default-app.engineEvents",
+                "default-app.queryEvents",
+                "default-app.subscriberRegistry",
+                "default-app.pushedCounts"
+            );
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationIT.java
@@ -103,13 +103,18 @@ public class QueryConsumerApplicationIT {
 
     @Test
     void anonymousRabbitQueues() {
-        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("subscriberRegistry.anonymous."))
+            );
     }
 
     @Test
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("engineEvents", "queryEvents");
+            .containsOnlyKeys("engineEvents", "queryEvents", "subscriberRegistry", "pushedCounts");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/consumer/src/test/java/org/activiti/cloud/query/consumer/QueryConsumerApplicationRabbitmqPrefixIT.java
@@ -49,9 +49,25 @@ public class QueryConsumerApplicationRabbitmqPrefixIT extends QueryConsumerAppli
 
     @Test
     @Override
+    void anonymousRabbitQueues() {
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("default-app.subscriberRegistry.anonymous."))
+            );
+    }
+
+    @Test
+    @Override
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("default-app.engineEvents", "default-app.queryEvents");
+            .containsOnlyKeys(
+                "default-app.engineEvents",
+                "default-app.queryEvents",
+                "default-app.subscriberRegistry",
+                "default-app.pushedCounts"
+            );
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterIT.java
@@ -28,7 +28,15 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
     void bindingServiceProperties() {
         assertThat(bindingServiceProperties.getBindings())
             .doesNotContainKeys("auditConsumer", "queryConsumer")
-            .containsOnlyKeys("functionRouterInput", "functionRouterAnonymousInput", "producer", "queryEventsProducer");
+            .containsOnlyKeys(
+                "functionRouterInput",
+                "functionRouterAnonymousInput",
+                "producer",
+                "queryEventsProducer",
+                "subscriberRegistryConsumer",
+                "subscriberRegistryProducer",
+                "countProducer"
+            );
 
         assertThat(bindingServiceProperties.getBindingProperties("functionRouterInput")).satisfies(binding -> {
             assertThat(binding.getGroup()).isEqualTo("consumer");
@@ -109,7 +117,12 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
     @Test
     @Override
     void anonymousRabbitQueues() {
-        assertThat(binderFactoryListenerTestContext.getAnonymousQueues()).isEmpty();
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("subscriberRegistry.anonymous."))
+            );
     }
 
     @Test
@@ -117,6 +130,6 @@ public class QueryApplicationFunctionRouterIT extends QueryApplicationIT {
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("engineEvents", "queryEvents");
+            .containsOnlyKeys("engineEvents", "queryEvents", "subscriberRegistry", "pushedCounts");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationFunctionRouterRabbitmqPrefixIT.java
@@ -50,9 +50,25 @@ public class QueryApplicationFunctionRouterRabbitmqPrefixIT extends QueryApplica
 
     @Test
     @Override
+    void anonymousRabbitQueues() {
+        assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
+            .isNotEmpty()
+            .hasSize(1)
+            .satisfies(map ->
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("default-app.subscriberRegistry.anonymous."))
+            );
+    }
+
+    @Test
+    @Override
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("default-app.engineEvents", "default-app.queryEvents");
+            .containsOnlyKeys(
+                "default-app.engineEvents",
+                "default-app.queryEvents",
+                "default-app.subscriberRegistry",
+                "default-app.pushedCounts"
+            );
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationIT.java
@@ -202,14 +202,17 @@ public class QueryApplicationIT {
     void anonymousRabbitQueues() {
         assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .isNotEmpty()
-            .hasSize(1)
-            .satisfies(map -> assertThat(map.keySet()).anyMatch(key -> key.startsWith("queryEvents.anonymous.")));
+            .hasSize(2)
+            .satisfies(map -> {
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("queryEvents.anonymous."));
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("subscriberRegistry.anonymous."));
+            });
     }
 
     @Test
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("engineEvents", "queryEvents");
+            .containsOnlyKeys("engineEvents", "queryEvents", "subscriberRegistry", "pushedCounts");
     }
 }

--- a/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
+++ b/activiti-cloud-examples/activiti-cloud-query/starter/src/test/java/org/activiti/cloud/query/QueryApplicationRabbitmqPrefixIT.java
@@ -53,10 +53,11 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
     void anonymousRabbitQueues() {
         assertThat(binderFactoryListenerTestContext.getAnonymousQueues())
             .isNotEmpty()
-            .hasSize(1)
-            .satisfies(map ->
-                assertThat(map.keySet()).allMatch(key -> key.startsWith("default-app.queryEvents.anonymous."))
-            );
+            .hasSize(2)
+            .satisfies(map -> {
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("default-app.queryEvents.anonymous."));
+                assertThat(map.keySet()).anyMatch(key -> key.startsWith("default-app.subscriberRegistry.anonymous."));
+            });
     }
 
     @Test
@@ -64,6 +65,11 @@ public class QueryApplicationRabbitmqPrefixIT extends QueryApplicationIT {
     void rabbitExchanges() {
         assertThat(binderFactoryListenerTestContext.getExchanges())
             .isNotEmpty()
-            .containsOnlyKeys("default-app.engineEvents", "default-app.queryEvents");
+            .containsOnlyKeys(
+                "default-app.engineEvents",
+                "default-app.queryEvents",
+                "default-app.subscriberRegistry",
+                "default-app.pushedCounts"
+            );
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/RegistryMessageType.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/RegistryMessageType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.subscription;
+
+/**
+ * Type discriminator for {@link SubscriberRegistryMessage}, the fan-out contract that carries
+ * subscriber presence from each query-rest instance to the query-consumer registry.
+ */
+public enum RegistryMessageType {
+    /** A user gained their first live socket on the sending instance. Carries {@code userId} and {@code groups}. */
+    REGISTERED,
+
+    /** A user lost their last live socket on the sending instance. Carries {@code userId}. */
+    UNREGISTERED,
+
+    /** Broadcast by the consumer on startup, asking every instance to replay its local registry as a SNAPSHOT. */
+    RESYNC_REQUEST,
+
+    /** An instance's full local registry, sent in reply to a RESYNC_REQUEST. Carries {@code entries}. */
+    SNAPSHOT,
+
+    /** Periodic liveness signal from an instance, carrying only its {@code sourceId}. */
+    HEARTBEAT,
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.subscription;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Fan-out message broadcast by each query-rest instance and merged into the consumer's registry.
+ * Which fields are populated depends on {@link #type()} — always build via the static factories,
+ * which encode the field-presence rules. {@code sourceId} identifies the sending instance: it drives
+ * liveness expiry and lets a sender ignore its own message in a joint deployment.
+ */
+public record SubscriberRegistryMessage(
+    RegistryMessageType type,
+    String userId,
+    List<String> groups,
+    List<Entry> entries,
+    String sourceId,
+    Instant sentAt
+) {
+    /** A single user's presence within a {@link RegistryMessageType#SNAPSHOT}. */
+    public record Entry(String userId, List<String> groups) {
+        public Entry {
+            Objects.requireNonNull(userId, "userId");
+            groups = groups == null ? List.of() : List.copyOf(groups);
+        }
+    }
+
+    public SubscriberRegistryMessage {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(sourceId, "sourceId");
+        Objects.requireNonNull(sentAt, "sentAt");
+        groups = groups == null ? null : List.copyOf(groups);
+        entries = entries == null ? null : List.copyOf(entries);
+    }
+
+    public static SubscriberRegistryMessage registered(
+        String userId,
+        List<String> groups,
+        String sourceId,
+        Instant sentAt
+    ) {
+        Objects.requireNonNull(userId, "userId");
+        return new SubscriberRegistryMessage(
+            RegistryMessageType.REGISTERED,
+            userId,
+            groups == null ? List.of() : groups,
+            null,
+            sourceId,
+            sentAt
+        );
+    }
+
+    public static SubscriberRegistryMessage unregistered(String userId, String sourceId, Instant sentAt) {
+        Objects.requireNonNull(userId, "userId");
+        return new SubscriberRegistryMessage(RegistryMessageType.UNREGISTERED, userId, null, null, sourceId, sentAt);
+    }
+
+    public static SubscriberRegistryMessage heartbeat(String sourceId, Instant sentAt) {
+        return new SubscriberRegistryMessage(RegistryMessageType.HEARTBEAT, null, null, null, sourceId, sentAt);
+    }
+
+    public static SubscriberRegistryMessage resyncRequest(String sourceId, Instant sentAt) {
+        return new SubscriberRegistryMessage(RegistryMessageType.RESYNC_REQUEST, null, null, null, sourceId, sentAt);
+    }
+
+    public static SubscriberRegistryMessage snapshot(List<Entry> entries, String sourceId, Instant sentAt) {
+        Objects.requireNonNull(entries, "entries");
+        return new SubscriberRegistryMessage(RegistryMessageType.SNAPSHOT, null, null, entries, sourceId, sentAt);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
@@ -49,16 +49,8 @@ public record SubscriberRegistryMessage(
         Objects.requireNonNull(sentAt, "sentAt");
         // JSON deserialization bypasses the static factories, so enforce each type's required fields here too.
         switch (type) {
-            case REGISTERED, UNREGISTERED -> {
-                if (userId == null) {
-                    throw new IllegalArgumentException(type + " requires a userId");
-                }
-            }
-            case SNAPSHOT -> {
-                if (entries == null) {
-                    throw new IllegalArgumentException("SNAPSHOT requires entries");
-                }
-            }
+            case REGISTERED, UNREGISTERED -> Objects.requireNonNull(userId, () -> type + " requires a userId");
+            case SNAPSHOT -> Objects.requireNonNull(entries, "SNAPSHOT requires entries");
             case HEARTBEAT, RESYNC_REQUEST -> {
                 // no per-type field to validate for these
             }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/main/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessage.java
@@ -33,10 +33,12 @@ public record SubscriberRegistryMessage(
     String sourceId,
     Instant sentAt
 ) {
+    private static final String USER_ID = "userId";
+
     /** A single user's presence within a {@link RegistryMessageType#SNAPSHOT}. */
     public record Entry(String userId, List<String> groups) {
         public Entry {
-            Objects.requireNonNull(userId, "userId");
+            Objects.requireNonNull(userId, USER_ID);
             groups = groups == null ? List.of() : List.copyOf(groups);
         }
     }
@@ -45,6 +47,22 @@ public record SubscriberRegistryMessage(
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(sourceId, "sourceId");
         Objects.requireNonNull(sentAt, "sentAt");
+        // JSON deserialization bypasses the static factories, so enforce each type's required fields here too.
+        switch (type) {
+            case REGISTERED, UNREGISTERED -> {
+                if (userId == null) {
+                    throw new IllegalArgumentException(type + " requires a userId");
+                }
+            }
+            case SNAPSHOT -> {
+                if (entries == null) {
+                    throw new IllegalArgumentException("SNAPSHOT requires entries");
+                }
+            }
+            case HEARTBEAT, RESYNC_REQUEST -> {
+                // no per-type field to validate for these
+            }
+        }
         groups = groups == null ? null : List.copyOf(groups);
         entries = entries == null ? null : List.copyOf(entries);
     }
@@ -55,7 +73,7 @@ public record SubscriberRegistryMessage(
         String sourceId,
         Instant sentAt
     ) {
-        Objects.requireNonNull(userId, "userId");
+        Objects.requireNonNull(userId, USER_ID);
         return new SubscriberRegistryMessage(
             RegistryMessageType.REGISTERED,
             userId,
@@ -67,7 +85,7 @@ public record SubscriberRegistryMessage(
     }
 
     public static SubscriberRegistryMessage unregistered(String userId, String sourceId, Instant sentAt) {
-        Objects.requireNonNull(userId, "userId");
+        Objects.requireNonNull(userId, USER_ID);
         return new SubscriberRegistryMessage(RegistryMessageType.UNREGISTERED, userId, null, null, sourceId, sentAt);
     }
 

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
@@ -100,15 +100,16 @@ class SubscriberRegistryMessageTest {
 
     @Test
     void canonicalConstructor_enforcesPerTypeRequiredFields() {
+        List<String> groups = List.of("eng");
         assertThatThrownBy(() ->
-            new SubscriberRegistryMessage(RegistryMessageType.REGISTERED, null, List.of("eng"), null, "rest-1", NOW)
-        ).isInstanceOf(IllegalArgumentException.class);
+            new SubscriberRegistryMessage(RegistryMessageType.REGISTERED, null, groups, null, "rest-1", NOW)
+        ).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() ->
             new SubscriberRegistryMessage(RegistryMessageType.UNREGISTERED, null, null, null, "rest-1", NOW)
-        ).isInstanceOf(IllegalArgumentException.class);
+        ).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() ->
             new SubscriberRegistryMessage(RegistryMessageType.SNAPSHOT, null, null, null, "rest-1", NOW)
-        ).isInstanceOf(IllegalArgumentException.class);
+        ).isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
@@ -97,4 +97,27 @@ class SubscriberRegistryMessageTest {
 
         assertThat(message.groups()).containsExactly("eng");
     }
+
+    @Test
+    void canonicalConstructor_enforcesPerTypeRequiredFields() {
+        assertThatThrownBy(() ->
+            new SubscriberRegistryMessage(RegistryMessageType.REGISTERED, null, List.of("eng"), null, "rest-1", NOW)
+        ).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() ->
+            new SubscriberRegistryMessage(RegistryMessageType.UNREGISTERED, null, null, null, "rest-1", NOW)
+        ).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() ->
+            new SubscriberRegistryMessage(RegistryMessageType.SNAPSHOT, null, null, null, "rest-1", NOW)
+        ).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void canonicalConstructor_allowsHeartbeatAndResyncWithoutUserOrEntries() {
+        assertThat(
+            new SubscriberRegistryMessage(RegistryMessageType.HEARTBEAT, null, null, null, "rest-1", NOW).type()
+        ).isEqualTo(RegistryMessageType.HEARTBEAT);
+        assertThat(
+            new SubscriberRegistryMessage(RegistryMessageType.RESYNC_REQUEST, null, null, null, "rest-1", NOW).type()
+        ).isEqualTo(RegistryMessageType.RESYNC_REQUEST);
+    }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
@@ -102,13 +102,13 @@ class SubscriberRegistryMessageTest {
     void canonicalConstructor_enforcesPerTypeRequiredFields() {
         assertThatThrownBy(() ->
             new SubscriberRegistryMessage(RegistryMessageType.REGISTERED, null, List.of("eng"), null, "rest-1", NOW)
-        ).isInstanceOf(NullPointerException.class);
+        ).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
             new SubscriberRegistryMessage(RegistryMessageType.UNREGISTERED, null, null, null, "rest-1", NOW)
-        ).isInstanceOf(NullPointerException.class);
+        ).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() ->
             new SubscriberRegistryMessage(RegistryMessageType.SNAPSHOT, null, null, null, "rest-1", NOW)
-        ).isInstanceOf(NullPointerException.class);
+        ).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SubscriberRegistryMessageTest {
+
+    private static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void registeredCarriesUserAndGroups_butNoEntries() {
+        SubscriberRegistryMessage message = SubscriberRegistryMessage.registered(
+            "alice",
+            List.of("eng"),
+            "rest-1",
+            NOW
+        );
+
+        assertThat(message.type()).isEqualTo(RegistryMessageType.REGISTERED);
+        assertThat(message.userId()).isEqualTo("alice");
+        assertThat(message.groups()).containsExactly("eng");
+        assertThat(message.entries()).isNull();
+        assertThat(message.sourceId()).isEqualTo("rest-1");
+    }
+
+    @Test
+    void unregisteredCarriesUser_butNoGroupsOrEntries() {
+        SubscriberRegistryMessage message = SubscriberRegistryMessage.unregistered("alice", "rest-1", NOW);
+
+        assertThat(message.type()).isEqualTo(RegistryMessageType.UNREGISTERED);
+        assertThat(message.userId()).isEqualTo("alice");
+        assertThat(message.groups()).isNull();
+        assertThat(message.entries()).isNull();
+    }
+
+    @Test
+    void heartbeatCarriesOnlySource() {
+        SubscriberRegistryMessage message = SubscriberRegistryMessage.heartbeat("rest-1", NOW);
+
+        assertThat(message.type()).isEqualTo(RegistryMessageType.HEARTBEAT);
+        assertThat(message.userId()).isNull();
+        assertThat(message.groups()).isNull();
+        assertThat(message.entries()).isNull();
+        assertThat(message.sourceId()).isEqualTo("rest-1");
+    }
+
+    @Test
+    void snapshotCarriesEntries() {
+        SubscriberRegistryMessage message = SubscriberRegistryMessage.snapshot(
+            List.of(new SubscriberRegistryMessage.Entry("alice", List.of("eng"))),
+            "rest-1",
+            NOW
+        );
+
+        assertThat(message.type()).isEqualTo(RegistryMessageType.SNAPSHOT);
+        assertThat(message.entries()).hasSize(1);
+        assertThat(message.entries().get(0).userId()).isEqualTo("alice");
+        assertThat(message.entries().get(0).groups()).containsExactly("eng");
+    }
+
+    @Test
+    void requiredFieldsAreValidated() {
+        assertThatThrownBy(() -> SubscriberRegistryMessage.heartbeat(null, NOW)).isInstanceOf(
+            NullPointerException.class
+        );
+        assertThatThrownBy(() -> SubscriberRegistryMessage.registered("alice", List.of(), "rest-1", null)).isInstanceOf(
+            NullPointerException.class
+        );
+    }
+
+    @Test
+    void groupsListIsDefensivelyCopied() {
+        List<String> mutableGroups = new ArrayList<>(List.of("eng"));
+
+        SubscriberRegistryMessage message = SubscriberRegistryMessage.registered("alice", mutableGroups, "rest-1", NOW);
+        mutableGroups.add("finance");
+
+        assertThat(message.groups()).containsExactly("eng");
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-common/src/test/java/org/activiti/cloud/services/query/subscription/SubscriberRegistryMessageTest.java
@@ -74,16 +74,17 @@ class SubscriberRegistryMessageTest {
 
         assertThat(message.type()).isEqualTo(RegistryMessageType.SNAPSHOT);
         assertThat(message.entries()).hasSize(1);
-        assertThat(message.entries().get(0).userId()).isEqualTo("alice");
-        assertThat(message.entries().get(0).groups()).containsExactly("eng");
+        assertThat(message.entries().getFirst().userId()).isEqualTo("alice");
+        assertThat(message.entries().getFirst().groups()).containsExactly("eng");
     }
 
     @Test
     void requiredFieldsAreValidated() {
+        List<String> groups = List.of();
         assertThatThrownBy(() -> SubscriberRegistryMessage.heartbeat(null, NOW)).isInstanceOf(
             NullPointerException.class
         );
-        assertThatThrownBy(() -> SubscriberRegistryMessage.registered("alice", List.of(), "rest-1", null)).isInstanceOf(
+        assertThatThrownBy(() -> SubscriberRegistryMessage.registered("alice", groups, "rest-1", null)).isInstanceOf(
             NullPointerException.class
         );
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/pom.xml
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/pom.xml
@@ -33,6 +33,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-query-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-query-model</artifactId>
     </dependency>
     <dependency>

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/PushedCountsAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/PushedCountsAutoConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.conf;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.common.messaging.functional.FunctionBinding;
+import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
+import org.activiti.cloud.services.query.app.QueryConsumerChannels;
+import org.activiti.cloud.services.query.app.SubscriberInstanceRemovalScheduler;
+import org.activiti.cloud.services.query.app.SubscriberInstanceRemover;
+import org.activiti.cloud.services.query.app.SubscriberRegistryConsumer;
+import org.activiti.cloud.services.query.app.SubscriberRegistryMessageHandler;
+import org.activiti.cloud.services.query.app.SubscriberRegistryResyncRequester;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Wires the consumer-side subscriber registry to the broker. The registry channel is a fan-out
+ * (no consumer group) so every consumer instance builds the full picture of subscribers; the actual
+ * broker destinations are configured through {@code spring.cloud.stream.bindings.*} so they can be
+ * agreed and changed without code changes.
+ */
+@AutoConfiguration(after = QueryConsumerAutoConfiguration.class)
+@EnableScheduling
+public class PushedCountsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    ConsumerSubscriberRegistry consumerSubscriberRegistry() {
+        return new ConsumerSubscriberRegistry();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    SubscriberRegistryMessageHandler subscriberRegistryMessageHandler(ConsumerSubscriberRegistry registry) {
+        return new SubscriberRegistryMessageHandler(registry);
+    }
+
+    @Bean
+    @FunctionBinding(input = QueryConsumerChannels.SUBSCRIBER_REGISTRY_CONSUMER)
+    public Consumer<Message<SubscriberRegistryMessage>> subscriberRegistryConsumerFunction(
+        SubscriberRegistryMessageHandler handler,
+        FeatureToggle featureToggle
+    ) {
+        return new SubscriberRegistryConsumer(handler, featureToggle);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    SubscriberInstanceRemover subscriberInstanceRemover(
+        ConsumerSubscriberRegistry registry,
+        @Value("${activiti.cloud.query.pushed-counts.instance-timeout:PT3M}") Duration instanceTimeout
+    ) {
+        return new SubscriberInstanceRemover(registry, instanceTimeout, Clock.systemUTC());
+    }
+
+    @Bean
+    SubscriberInstanceRemovalScheduler subscriberInstanceRemovalScheduler(
+        SubscriberInstanceRemover remover,
+        FeatureToggle featureToggle
+    ) {
+        return new SubscriberInstanceRemovalScheduler(remover, featureToggle);
+    }
+
+    @Bean
+    SubscriberRegistryResyncRequester subscriberRegistryResyncRequester(
+        @Qualifier(QueryConsumerChannels.SUBSCRIBER_REGISTRY_PRODUCER) MessageChannel registryProducer,
+        FeatureToggle featureToggle
+    ) {
+        return new SubscriberRegistryResyncRequester(
+            registryProducer,
+            featureToggle,
+            UUID.randomUUID().toString(),
+            Clock.systemUTC()
+        );
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/PushedCountsAutoConfiguration.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/conf/PushedCountsAutoConfiguration.java
@@ -19,7 +19,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Consumer;
-import org.activiti.cloud.common.feature.FeatureToggle;
 import org.activiti.cloud.common.messaging.functional.FunctionBinding;
 import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
 import org.activiti.cloud.services.query.app.QueryConsumerChannels;
@@ -33,6 +32,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -43,8 +43,19 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * (no consumer group) so every consumer instance builds the full picture of subscribers; the actual
  * broker destinations are configured through {@code spring.cloud.stream.bindings.*} so they can be
  * agreed and changed without code changes.
+ *
+ * <p>Gated at startup by {@code activiti.cloud.query.pushed-counts.enabled} (off by default here,
+ * turned on in hxp-process-services): when off, none of these beans are wired. Registry upkeep is
+ * intentionally independent of the {@code activiti.features.query.pushed-counts.enabled} runtime
+ * toggle - that toggle gates the count push (later steps), not presence tracking, so a runtime flip
+ * can never leave the registry holding stale or leftover instances.
  */
 @AutoConfiguration(after = QueryConsumerAutoConfiguration.class)
+@ConditionalOnProperty(
+    name = "activiti.cloud.query.pushed-counts.enabled",
+    havingValue = "true",
+    matchIfMissing = false
+)
 @EnableScheduling
 public class PushedCountsAutoConfiguration {
 
@@ -63,10 +74,9 @@ public class PushedCountsAutoConfiguration {
     @Bean
     @FunctionBinding(input = QueryConsumerChannels.SUBSCRIBER_REGISTRY_CONSUMER)
     public Consumer<Message<SubscriberRegistryMessage>> subscriberRegistryConsumerFunction(
-        SubscriberRegistryMessageHandler handler,
-        FeatureToggle featureToggle
+        SubscriberRegistryMessageHandler handler
     ) {
-        return new SubscriberRegistryConsumer(handler, featureToggle);
+        return new SubscriberRegistryConsumer(handler);
     }
 
     @Bean
@@ -79,23 +89,14 @@ public class PushedCountsAutoConfiguration {
     }
 
     @Bean
-    SubscriberInstanceRemovalScheduler subscriberInstanceRemovalScheduler(
-        SubscriberInstanceRemover remover,
-        FeatureToggle featureToggle
-    ) {
-        return new SubscriberInstanceRemovalScheduler(remover, featureToggle);
+    SubscriberInstanceRemovalScheduler subscriberInstanceRemovalScheduler(SubscriberInstanceRemover remover) {
+        return new SubscriberInstanceRemovalScheduler(remover);
     }
 
     @Bean
     SubscriberRegistryResyncRequester subscriberRegistryResyncRequester(
-        @Qualifier(QueryConsumerChannels.SUBSCRIBER_REGISTRY_PRODUCER) MessageChannel registryProducer,
-        FeatureToggle featureToggle
+        @Qualifier(QueryConsumerChannels.SUBSCRIBER_REGISTRY_PRODUCER) MessageChannel registryProducer
     ) {
-        return new SubscriberRegistryResyncRequester(
-            registryProducer,
-            featureToggle,
-            UUID.randomUUID().toString(),
-            Clock.systemUTC()
-        );
+        return new SubscriberRegistryResyncRequester(registryProducer, UUID.randomUUID().toString(), Clock.systemUTC());
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistry.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistry.java
@@ -115,7 +115,7 @@ public class ConsumerSubscriberRegistry {
      * every user's holders and dropping any user left with no holders. This is the backstop for an
      * instance dying without sending UNREGISTERED for the users it held.
      *
-     * @return the ids of users dropped as a result, in the order they were dropped
+     * @return the ids of users dropped as a result
      */
     public synchronized Set<String> expireInstances(Instant now, Duration threshold) {
         Instant deadline = now.minus(threshold);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistry.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistry.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Consumer-side view of who is watching, merged from every query-rest instance's presence
+ * broadcasts (who and which groups — never socket counts, which are the REST side's concern). A
+ * user is kept while at least one instance still holds them and dropped only when their last holder
+ * leaves — cleanly via {@link #unregister(String, String)} or, when an instance stops heartbeating,
+ * via {@link #expireInstances(Instant, Duration)}. Holders are instances ({@code sourceId}), not
+ * sockets. All mutating operations are synchronized.
+ */
+public class ConsumerSubscriberRegistry {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerSubscriberRegistry.class);
+
+    private static final class Subscriber {
+
+        private Set<String> groups;
+        private final Set<String> sources = new HashSet<>();
+
+        Subscriber(Set<String> groups) {
+            this.groups = groups;
+        }
+    }
+
+    private final Map<String, Subscriber> registry = new HashMap<>();
+    private final Map<String, Instant> lastSeenBySource = new HashMap<>();
+
+    /**
+     * Records a live subscription for {@code userId} on {@code sourceId}, refreshing groups and liveness.
+     *
+     * @return {@code true} if the user became watched for the first time (empty holder set to non-empty)
+     */
+    public synchronized boolean register(String userId, Collection<String> groups, String sourceId, Instant at) {
+        touchSource(sourceId, at);
+        Subscriber subscriber = registry.get(userId);
+        boolean firstAppearance = subscriber == null;
+        if (subscriber == null) {
+            subscriber = new Subscriber(copyOf(groups));
+            registry.put(userId, subscriber);
+        } else if (groups != null) {
+            subscriber.groups = copyOf(groups);
+        }
+        subscriber.sources.add(sourceId);
+        LOGGER.debug(
+            "register user={} source={} firstAppearance={} sources={}",
+            userId,
+            sourceId,
+            firstAppearance,
+            subscriber.sources
+        );
+        return firstAppearance;
+    }
+
+    /**
+     * Removes {@code sourceId} from {@code userId}'s holders.
+     *
+     * @return {@code true} if that emptied the holder set and the user was dropped
+     */
+    public synchronized boolean unregister(String userId, String sourceId) {
+        Subscriber subscriber = registry.get(userId);
+        if (subscriber == null) {
+            LOGGER.debug("unregister user={} source={} (unknown user, ignored)", userId, sourceId);
+            return false;
+        }
+        subscriber.sources.remove(sourceId);
+        boolean dropped = subscriber.sources.isEmpty();
+        if (dropped) {
+            registry.remove(userId);
+        }
+        LOGGER.debug(
+            "unregister user={} source={} dropped={} sources={}",
+            userId,
+            sourceId,
+            dropped,
+            subscriber.sources
+        );
+        return dropped;
+    }
+
+    /** Records liveness for an instance without changing any user's membership. */
+    public synchronized void heartbeat(String sourceId, Instant at) {
+        touchSource(sourceId, at);
+        LOGGER.debug("heartbeat source={} at={}", sourceId, at);
+    }
+
+    /**
+     * Removes instances not heard from within {@code threshold} of {@code now}, dropping them from
+     * every user's holders and dropping any user left with no holders. This is the backstop for an
+     * instance dying without sending UNREGISTERED for the users it held.
+     *
+     * @return the ids of users dropped as a result, in the order they were dropped
+     */
+    public synchronized Set<String> expireInstances(Instant now, Duration threshold) {
+        Instant deadline = now.minus(threshold);
+        Set<String> deadSources = new HashSet<>();
+        for (Map.Entry<String, Instant> source : lastSeenBySource.entrySet()) {
+            if (source.getValue().isBefore(deadline)) {
+                deadSources.add(source.getKey());
+            }
+        }
+        Set<String> removedUsers = new LinkedHashSet<>();
+        if (deadSources.isEmpty()) {
+            return removedUsers;
+        }
+        lastSeenBySource.keySet().removeAll(deadSources);
+        registry
+            .entrySet()
+            .removeIf(user -> {
+                user.getValue().sources.removeAll(deadSources);
+                if (user.getValue().sources.isEmpty()) {
+                    removedUsers.add(user.getKey());
+                    return true;
+                }
+                return false;
+            });
+        LOGGER.debug("expireInstances deadSources={} droppedUsers={}", deadSources, removedUsers);
+        return removedUsers;
+    }
+
+    /**
+     * Merges an instance's local registry (its reply to a RESYNC_REQUEST) into this one. Safe to
+     * interleave with normal registrations in either order: the result is always the union of
+     * holders per user.
+     */
+    public synchronized void applySnapshot(
+        String sourceId,
+        Collection<SubscriberRegistryMessage.Entry> entries,
+        Instant at
+    ) {
+        touchSource(sourceId, at);
+        if (entries == null) {
+            LOGGER.debug("applySnapshot source={} entries=null (ignored)", sourceId);
+            return;
+        }
+        LOGGER.debug("applySnapshot source={} entries={}", sourceId, entries.size());
+        for (SubscriberRegistryMessage.Entry entry : entries) {
+            register(entry.userId(), entry.groups(), sourceId, at);
+        }
+    }
+
+    public synchronized boolean isWatching(String userId) {
+        return registry.containsKey(userId);
+    }
+
+    public synchronized Set<String> groupsOf(String userId) {
+        Subscriber subscriber = registry.get(userId);
+        return subscriber == null ? Set.of() : Set.copyOf(subscriber.groups);
+    }
+
+    public synchronized Set<String> sourcesOf(String userId) {
+        Subscriber subscriber = registry.get(userId);
+        return subscriber == null ? Set.of() : Set.copyOf(subscriber.sources);
+    }
+
+    public synchronized Set<String> watchedUserIds() {
+        return Set.copyOf(registry.keySet());
+    }
+
+    public synchronized int size() {
+        return registry.size();
+    }
+
+    private void touchSource(String sourceId, Instant at) {
+        lastSeenBySource.merge(sourceId, at, (current, candidate) -> candidate.isAfter(current) ? candidate : current);
+    }
+
+    private static Set<String> copyOf(Collection<String> groups) {
+        return groups == null ? new HashSet<>() : new HashSet<>(groups);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/QueryConsumerChannels.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/QueryConsumerChannels.java
@@ -26,6 +26,12 @@ public interface QueryConsumerChannels {
 
     String QUERY_EVENTS_PRODUCER = "queryEventsProducer";
 
+    String SUBSCRIBER_REGISTRY_CONSUMER = "subscriberRegistryConsumer";
+
+    String SUBSCRIBER_REGISTRY_PRODUCER = "subscriberRegistryProducer";
+
+    String COUNT_PRODUCER = "countProducer";
+
     @InputBinding(QUERY_CONSUMER)
     default SubscribableChannel queryConsumer() {
         return MessageChannels.publishSubscribe(QUERY_CONSUMER).getObject();
@@ -34,5 +40,20 @@ public interface QueryConsumerChannels {
     @OutputBinding(QUERY_EVENTS_PRODUCER)
     default MessageChannel queryEventsProducer() {
         return MessageChannels.direct(QUERY_EVENTS_PRODUCER).getObject();
+    }
+
+    @InputBinding(SUBSCRIBER_REGISTRY_CONSUMER)
+    default SubscribableChannel subscriberRegistryConsumer() {
+        return MessageChannels.publishSubscribe(SUBSCRIBER_REGISTRY_CONSUMER).getObject();
+    }
+
+    @OutputBinding(SUBSCRIBER_REGISTRY_PRODUCER)
+    default MessageChannel subscriberRegistryProducer() {
+        return MessageChannels.direct(SUBSCRIBER_REGISTRY_PRODUCER).getObject();
+    }
+
+    @OutputBinding(COUNT_PRODUCER)
+    default MessageChannel countProducer() {
+        return MessageChannels.direct(COUNT_PRODUCER).getObject();
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalScheduler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalScheduler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * Periodically drives {@link SubscriberInstanceRemover} so instances that stopped sending
+ * heartbeats are reclaimed. Runs only while the pushed-counts toggle is on, so it can be switched
+ * off at runtime without a redeploy.
+ */
+public class SubscriberInstanceRemovalScheduler {
+
+    private final SubscriberInstanceRemover remover;
+    private final FeatureToggle featureToggle;
+
+    public SubscriberInstanceRemovalScheduler(SubscriberInstanceRemover remover, FeatureToggle featureToggle) {
+        this.remover = remover;
+        this.featureToggle = featureToggle;
+    }
+
+    @Scheduled(fixedDelayString = "${activiti.cloud.query.pushed-counts.removal-interval:PT1M}")
+    public void removeExpiredInstances() {
+        if (featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
+            remover.removeExpiredInstances();
+        }
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalScheduler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalScheduler.java
@@ -15,29 +15,24 @@
  */
 package org.activiti.cloud.services.query.app;
 
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  * Periodically drives {@link SubscriberInstanceRemover} so instances that stopped sending
- * heartbeats are reclaimed. Runs only while the pushed-counts toggle is on, so it can be switched
- * off at runtime without a redeploy.
+ * heartbeats are reclaimed. Runs whenever the feature is wired (the startup property); cleanup is
+ * deliberately independent of the runtime feature toggle so the registry can never be left holding
+ * leftover instances when the toggle flips.
  */
 public class SubscriberInstanceRemovalScheduler {
 
     private final SubscriberInstanceRemover remover;
-    private final FeatureToggle featureToggle;
 
-    public SubscriberInstanceRemovalScheduler(SubscriberInstanceRemover remover, FeatureToggle featureToggle) {
+    public SubscriberInstanceRemovalScheduler(SubscriberInstanceRemover remover) {
         this.remover = remover;
-        this.featureToggle = featureToggle;
     }
 
     @Scheduled(fixedDelayString = "${activiti.cloud.query.pushed-counts.removal-interval:PT1M}")
     public void removeExpiredInstances() {
-        if (featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
-            remover.removeExpiredInstances();
-        }
+        remover.removeExpiredInstances();
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemover.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemover.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Removes query-rest instances that have stopped sending heartbeats, dropping any user left with no
+ * live instance. Meant to be invoked periodically; the schedule is kept external so the timeout and
+ * the clock stay injectable and the removal decision remains deterministically testable.
+ */
+public class SubscriberInstanceRemover {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberInstanceRemover.class);
+
+    private final ConsumerSubscriberRegistry registry;
+    private final Duration instanceTimeout;
+    private final Clock clock;
+
+    public SubscriberInstanceRemover(ConsumerSubscriberRegistry registry, Duration instanceTimeout, Clock clock) {
+        this.registry = registry;
+        this.instanceTimeout = instanceTimeout;
+        this.clock = clock;
+    }
+
+    public Set<String> removeExpiredInstances() {
+        Set<String> droppedUsers = registry.expireInstances(clock.instant(), instanceTimeout);
+        if (!droppedUsers.isEmpty()) {
+            LOGGER.debug(
+                "Dropped {} subscriber(s) after instance-liveness expiry: {}",
+                droppedUsers.size(),
+                droppedUsers
+            );
+        }
+        return droppedUsers;
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumer.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumer.java
@@ -16,35 +16,30 @@
 package org.activiti.cloud.services.query.app;
 
 import java.util.function.Consumer;
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 
 /**
- * Feature-gated entry point for registry messages arriving on the broker. While the pushed-counts
- * toggle is off the message is dropped, so the binding can stay in place with the registry idle and
- * the feature can be switched on at runtime without a redeploy.
+ * Entry point for registry messages arriving on the broker. Applies each message to the registry;
+ * one bad message is logged and skipped so it can't wedge the shared channel. Whether this is wired
+ * at all is decided at startup by {@code activiti.cloud.query.pushed-counts.enabled}; registry
+ * upkeep is intentionally independent of the runtime feature toggle, which gates the count push
+ * (later steps), not presence tracking.
  */
 public class SubscriberRegistryConsumer implements Consumer<Message<SubscriberRegistryMessage>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberRegistryConsumer.class);
 
     private final SubscriberRegistryMessageHandler handler;
-    private final FeatureToggle featureToggle;
 
-    public SubscriberRegistryConsumer(SubscriberRegistryMessageHandler handler, FeatureToggle featureToggle) {
+    public SubscriberRegistryConsumer(SubscriberRegistryMessageHandler handler) {
         this.handler = handler;
-        this.featureToggle = featureToggle;
     }
 
     @Override
     public void accept(Message<SubscriberRegistryMessage> message) {
-        if (!featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
-            return;
-        }
         SubscriberRegistryMessage payload = message.getPayload();
         try {
             handler.handle(payload);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumer.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import java.util.function.Consumer;
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
+
+/**
+ * Feature-gated entry point for registry messages arriving on the broker. While the pushed-counts
+ * toggle is off the message is dropped, so the binding can stay in place with the registry idle and
+ * the feature can be switched on at runtime without a redeploy.
+ */
+public class SubscriberRegistryConsumer implements Consumer<Message<SubscriberRegistryMessage>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberRegistryConsumer.class);
+
+    private final SubscriberRegistryMessageHandler handler;
+    private final FeatureToggle featureToggle;
+
+    public SubscriberRegistryConsumer(SubscriberRegistryMessageHandler handler, FeatureToggle featureToggle) {
+        this.handler = handler;
+        this.featureToggle = featureToggle;
+    }
+
+    @Override
+    public void accept(Message<SubscriberRegistryMessage> message) {
+        if (!featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
+            return;
+        }
+        SubscriberRegistryMessage payload = message.getPayload();
+        try {
+            handler.handle(payload);
+        } catch (RuntimeException e) {
+            // One bad message must not wedge the shared channel; payload stays at DEBUG to keep subscriber ids out of normal logs.
+            LOGGER.warn("Skipping a subscriber registry message that failed to apply", e);
+            LOGGER.debug("Failed subscriber registry payload: {}", payload);
+        }
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+
+/**
+ * Applies each {@link SubscriberRegistryMessage} received on the registry fan-out channel to the
+ * {@link ConsumerSubscriberRegistry}.
+ */
+public class SubscriberRegistryMessageHandler {
+
+    private final ConsumerSubscriberRegistry registry;
+
+    public SubscriberRegistryMessageHandler(ConsumerSubscriberRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void handle(SubscriberRegistryMessage message) {
+        switch (message.type()) {
+            case REGISTERED -> registry.register(
+                message.userId(),
+                message.groups(),
+                message.sourceId(),
+                message.sentAt()
+            );
+            case UNREGISTERED -> registry.unregister(message.userId(), message.sourceId());
+            case HEARTBEAT -> registry.heartbeat(message.sourceId(), message.sentAt());
+            case SNAPSHOT -> registry.applySnapshot(message.sourceId(), message.entries(), message.sentAt());
+            // RESYNC_REQUEST is emitted by the consumer itself and carries no registry update.
+            case RESYNC_REQUEST -> {
+            }
+        }
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandler.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandler.java
@@ -40,8 +40,8 @@ public class SubscriberRegistryMessageHandler {
             case UNREGISTERED -> registry.unregister(message.userId(), message.sourceId());
             case HEARTBEAT -> registry.heartbeat(message.sourceId(), message.sentAt());
             case SNAPSHOT -> registry.applySnapshot(message.sourceId(), message.entries(), message.sentAt());
-            // RESYNC_REQUEST is emitted by the consumer itself and carries no registry update.
             case RESYNC_REQUEST -> {
+                // Emitted by the consumer itself; carries no registry update.
             }
         }
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
@@ -16,8 +16,6 @@
 package org.activiti.cloud.services.query.app;
 
 import java.time.Clock;
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -26,36 +24,25 @@ import org.springframework.messaging.support.GenericMessage;
 
 /**
  * On startup, asks every query-rest instance to replay its local registry so the consumer's
- * in-memory view is rebuilt after a restart. Broadcast only while the pushed-counts toggle is on;
- * SNAPSHOT replies come back on the registry channel and are merged by the normal handler. A rolling
- * restart briefly multiplies this (every consumer asks, every instance replies), but the union merge
- * makes the duplicate snapshots harmless.
+ * in-memory view is rebuilt after a restart. Runs whenever the feature is wired (the startup
+ * property); SNAPSHOT replies come back on the registry channel and are merged by the normal
+ * handler. A rolling restart briefly multiplies this (every consumer asks, every instance replies),
+ * but the union merge makes the duplicate snapshots harmless.
  */
 public class SubscriberRegistryResyncRequester {
 
     private final MessageChannel registryProducer;
-    private final FeatureToggle featureToggle;
     private final String sourceId;
     private final Clock clock;
 
-    public SubscriberRegistryResyncRequester(
-        MessageChannel registryProducer,
-        FeatureToggle featureToggle,
-        String sourceId,
-        Clock clock
-    ) {
+    public SubscriberRegistryResyncRequester(MessageChannel registryProducer, String sourceId, Clock clock) {
         this.registryProducer = registryProducer;
-        this.featureToggle = featureToggle;
         this.sourceId = sourceId;
         this.clock = clock;
     }
 
     @EventListener(ApplicationReadyEvent.class)
     public void requestResync() {
-        if (featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
-            registryProducer.send(
-                new GenericMessage<>(SubscriberRegistryMessage.resyncRequest(sourceId, clock.instant()))
-            );
-        }
+        registryProducer.send(new GenericMessage<>(SubscriberRegistryMessage.resyncRequest(sourceId, clock.instant())));
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
@@ -17,6 +17,8 @@ package org.activiti.cloud.services.query.app;
 
 import java.time.Clock;
 import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.MessageChannel;
@@ -28,8 +30,14 @@ import org.springframework.messaging.support.GenericMessage;
  * property); SNAPSHOT replies come back on the registry channel and are merged by the normal
  * handler. A rolling restart briefly multiplies this (every consumer asks, every instance replies),
  * but the union merge makes the duplicate snapshots harmless.
+ *
+ * <p>The broadcast is best-effort: a broker that is unreachable when the application becomes ready
+ * must not abort startup, so a send failure is logged and swallowed. Normal registry traffic
+ * (heartbeats and snapshots) rebuilds the view once the broker is back.
  */
 public class SubscriberRegistryResyncRequester {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberRegistryResyncRequester.class);
 
     private final MessageChannel registryProducer;
     private final String sourceId;
@@ -43,6 +51,16 @@ public class SubscriberRegistryResyncRequester {
 
     @EventListener(ApplicationReadyEvent.class)
     public void requestResync() {
-        registryProducer.send(new GenericMessage<>(SubscriberRegistryMessage.resyncRequest(sourceId, clock.instant())));
+        try {
+            registryProducer.send(
+                new GenericMessage<>(SubscriberRegistryMessage.resyncRequest(sourceId, clock.instant()))
+            );
+        } catch (RuntimeException e) {
+            LOGGER.warn(
+                "Could not broadcast subscriber registry resync request on startup; " +
+                    "the registry will be rebuilt from normal traffic",
+                e
+            );
+        }
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequester.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import java.time.Clock;
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
+
+/**
+ * On startup, asks every query-rest instance to replay its local registry so the consumer's
+ * in-memory view is rebuilt after a restart. Broadcast only while the pushed-counts toggle is on;
+ * SNAPSHOT replies come back on the registry channel and are merged by the normal handler. A rolling
+ * restart briefly multiplies this (every consumer asks, every instance replies), but the union merge
+ * makes the duplicate snapshots harmless.
+ */
+public class SubscriberRegistryResyncRequester {
+
+    private final MessageChannel registryProducer;
+    private final FeatureToggle featureToggle;
+    private final String sourceId;
+    private final Clock clock;
+
+    public SubscriberRegistryResyncRequester(
+        MessageChannel registryProducer,
+        FeatureToggle featureToggle,
+        String sourceId,
+        Clock clock
+    ) {
+        this.registryProducer = registryProducer;
+        this.featureToggle = featureToggle;
+        this.sourceId = sourceId;
+        this.clock = clock;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void requestResync() {
+        if (featureToggle.isEnabled(QueryFeatureToggles.FEATURE_PUSHED_COUNTS)) {
+            registryProducer.send(
+                new GenericMessage<>(SubscriberRegistryMessage.resyncRequest(sourceId, clock.instant()))
+            );
+        }
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.activiti.cloud.conf.QueryConsumerAutoConfiguration
+org.activiti.cloud.conf.PushedCountsAutoConfiguration

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.conf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
+import org.activiti.cloud.services.query.app.SubscriberInstanceRemovalScheduler;
+import org.activiti.cloud.services.query.app.SubscriberInstanceRemover;
+import org.activiti.cloud.services.query.app.SubscriberRegistryConsumer;
+import org.activiti.cloud.services.query.app.SubscriberRegistryMessageHandler;
+import org.activiti.cloud.services.query.app.SubscriberRegistryResyncRequester;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.integration.channel.NullChannel;
+import org.springframework.messaging.MessageChannel;
+
+class PushedCountsAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withInitializer(context ->
+            context.getBeanFactory().setConversionService(ApplicationConversionService.getSharedInstance())
+        )
+        .withBean(FeatureToggle.class, () -> name -> false)
+        .withBean("subscriberRegistryProducer", MessageChannel.class, () -> new NullChannel())
+        .withConfiguration(AutoConfigurations.of(PushedCountsAutoConfiguration.class));
+
+    @Test
+    void registersRegistryHandlerAndFeatureGatedConsumerFunction() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ConsumerSubscriberRegistry.class);
+            assertThat(context).hasSingleBean(SubscriberRegistryMessageHandler.class);
+            assertThat(context).hasSingleBean(SubscriberInstanceRemover.class);
+            assertThat(context).hasSingleBean(SubscriberInstanceRemovalScheduler.class);
+            assertThat(context).hasSingleBean(SubscriberRegistryResyncRequester.class);
+            assertThat(context).hasBean("subscriberRegistryConsumerFunction");
+            assertThat(context.getBean("subscriberRegistryConsumerFunction")).isInstanceOf(
+                SubscriberRegistryConsumer.class
+            );
+        });
+    }
+
+    @Test
+    void backsOffRegistry_whenOneIsAlreadyDefined() {
+        ConsumerSubscriberRegistry existing = new ConsumerSubscriberRegistry();
+
+        contextRunner
+            .withBean("customRegistry", ConsumerSubscriberRegistry.class, () -> existing)
+            .run(context -> {
+                assertThat(context).hasSingleBean(ConsumerSubscriberRegistry.class);
+                assertThat(context.getBean(ConsumerSubscriberRegistry.class)).isSameAs(existing);
+            });
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
@@ -17,7 +17,6 @@ package org.activiti.cloud.conf;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.activiti.cloud.common.feature.FeatureToggle;
 import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
 import org.activiti.cloud.services.query.app.SubscriberInstanceRemovalScheduler;
 import org.activiti.cloud.services.query.app.SubscriberInstanceRemover;
@@ -37,12 +36,12 @@ class PushedCountsAutoConfigurationTest {
         .withInitializer(context ->
             context.getBeanFactory().setConversionService(ApplicationConversionService.getSharedInstance())
         )
-        .withBean(FeatureToggle.class, () -> name -> false)
         .withBean("subscriberRegistryProducer", MessageChannel.class, NullChannel::new)
+        .withPropertyValues("activiti.cloud.query.pushed-counts.enabled=true")
         .withConfiguration(AutoConfigurations.of(PushedCountsAutoConfiguration.class));
 
     @Test
-    void registersRegistryHandlerAndFeatureGatedConsumerFunction() {
+    void registersAllRegistryBeans() {
         contextRunner.run(context -> {
             assertThat(context).hasSingleBean(ConsumerSubscriberRegistry.class);
             assertThat(context).hasSingleBean(SubscriberRegistryMessageHandler.class);
@@ -54,6 +53,16 @@ class PushedCountsAutoConfigurationTest {
                 SubscriberRegistryConsumer.class
             );
         });
+    }
+
+    @Test
+    void backsOffEntirely_whenStartupPropertyIsDisabled() {
+        contextRunner
+            .withPropertyValues("activiti.cloud.query.pushed-counts.enabled=false")
+            .run(context -> {
+                assertThat(context).doesNotHaveBean(ConsumerSubscriberRegistry.class);
+                assertThat(context).doesNotHaveBean("subscriberRegistryConsumerFunction");
+            });
     }
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/conf/PushedCountsAutoConfigurationTest.java
@@ -38,7 +38,7 @@ class PushedCountsAutoConfigurationTest {
             context.getBeanFactory().setConversionService(ApplicationConversionService.getSharedInstance())
         )
         .withBean(FeatureToggle.class, () -> name -> false)
-        .withBean("subscriberRegistryProducer", MessageChannel.class, () -> new NullChannel())
+        .withBean("subscriberRegistryProducer", MessageChannel.class, NullChannel::new)
         .withConfiguration(AutoConfigurations.of(PushedCountsAutoConfiguration.class));
 
     @Test

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryConcurrencyTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryConcurrencyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+/** Exercises the {@code synchronized} registry under concurrent multi-instance delivery. */
+class ConsumerSubscriberRegistryConcurrencyTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void concurrentRegistersFromDistinctSources_areAllRetained() throws InterruptedException {
+        ConsumerSubscriberRegistry registry = new ConsumerSubscriberRegistry();
+        int instances = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(instances);
+
+        // All instances first-register the same user at once: the put + sources.add compound must not lose any.
+        CountDownLatch registered = submitEach(pool, instances, source ->
+            registry.register("alice", List.of("eng"), source, T0)
+        );
+        assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.sourcesOf("alice")).hasSize(instances);
+        assertThat(registry.groupsOf("alice")).containsExactly("eng");
+    }
+
+    @Test
+    void userSurvivesUntilItsLastHolderUnregisters_underConcurrency() throws InterruptedException {
+        ConsumerSubscriberRegistry registry = new ConsumerSubscriberRegistry();
+        int instances = 16;
+        String lastSource = "rest-" + (instances - 1);
+        ExecutorService pool = Executors.newFixedThreadPool(instances);
+
+        CountDownLatch registered = submitEach(pool, instances, source ->
+            registry.register("alice", List.of("eng"), source, T0)
+        );
+        assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
+        assertThat(registry.sourcesOf("alice")).hasSize(instances);
+
+        // Concurrently drop every holder but the last; the user must stay watched throughout.
+        CountDownLatch allButLastRemoved = submitEach(pool, instances - 1, source ->
+            registry.unregister("alice", source)
+        );
+        assertThat(allButLastRemoved.await(30, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.sourcesOf("alice")).containsExactly(lastSource);
+
+        registry.unregister("alice", lastSource);
+        assertThat(registry.isWatching("alice")).isFalse();
+    }
+
+    private static CountDownLatch submitEach(ExecutorService pool, int instances, Consumer<String> action) {
+        CountDownLatch latch = new CountDownLatch(instances);
+        for (int i = 0; i < instances; i++) {
+            String source = "rest-" + i;
+            pool.submit(() -> {
+                try {
+                    action.accept(source);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        return latch;
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryConcurrencyTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryConcurrencyTest.java
@@ -37,12 +37,15 @@ class ConsumerSubscriberRegistryConcurrencyTest {
         int instances = 16;
         ExecutorService pool = Executors.newFixedThreadPool(instances);
 
-        // All instances first-register the same user at once: the put + sources.add compound must not lose any.
-        CountDownLatch registered = submitEach(pool, instances, source ->
-            registry.register("alice", List.of("eng"), source, T0)
-        );
-        assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
-        pool.shutdownNow();
+        try {
+            // All instances first-register the same user at once: the put + sources.add compound must not lose any.
+            CountDownLatch registered = submitEach(pool, instances, source ->
+                registry.register("alice", List.of("eng"), source, T0)
+            );
+            assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
 
         assertThat(registry.isWatching("alice")).isTrue();
         assertThat(registry.sourcesOf("alice")).hasSize(instances);
@@ -56,18 +59,21 @@ class ConsumerSubscriberRegistryConcurrencyTest {
         String lastSource = "rest-" + (instances - 1);
         ExecutorService pool = Executors.newFixedThreadPool(instances);
 
-        CountDownLatch registered = submitEach(pool, instances, source ->
-            registry.register("alice", List.of("eng"), source, T0)
-        );
-        assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
-        assertThat(registry.sourcesOf("alice")).hasSize(instances);
+        try {
+            CountDownLatch registered = submitEach(pool, instances, source ->
+                registry.register("alice", List.of("eng"), source, T0)
+            );
+            assertThat(registered.await(30, TimeUnit.SECONDS)).isTrue();
+            assertThat(registry.sourcesOf("alice")).hasSize(instances);
 
-        // Concurrently drop every holder but the last; the user must stay watched throughout.
-        CountDownLatch allButLastRemoved = submitEach(pool, instances - 1, source ->
-            registry.unregister("alice", source)
-        );
-        assertThat(allButLastRemoved.await(30, TimeUnit.SECONDS)).isTrue();
-        pool.shutdownNow();
+            // Concurrently drop every holder but the last; the user must stay watched throughout.
+            CountDownLatch allButLastRemoved = submitEach(pool, instances - 1, source ->
+                registry.unregister("alice", source)
+            );
+            assertThat(allButLastRemoved.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            pool.shutdownNow();
+        }
 
         assertThat(registry.isWatching("alice")).isTrue();
         assertThat(registry.sourcesOf("alice")).containsExactly(lastSource);

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/ConsumerSubscriberRegistryTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConsumerSubscriberRegistryTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Duration DEAD_AFTER = Duration.ofMinutes(3);
+
+    private ConsumerSubscriberRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new ConsumerSubscriberRegistry();
+    }
+
+    @Test
+    void register_marksUserWatched_andReportsFirstAppearance() {
+        boolean firstAppearance = registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        assertThat(firstAppearance).isTrue();
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.groupsOf("alice")).containsExactlyInAnyOrder("eng");
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-1");
+    }
+
+    @Test
+    void register_sameUserOnSecondInstance_keepsUser_andIsNotFirstAppearance() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        boolean firstAppearance = registry.register("alice", List.of("eng"), "rest-2", T0);
+
+        assertThat(firstAppearance).isFalse();
+        assertThat(registry.sourcesOf("alice")).containsExactlyInAnyOrder("rest-1", "rest-2");
+    }
+
+    @Test
+    void unregister_oneOfTwoInstances_keepsUserWatching() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.register("alice", List.of("eng"), "rest-2", T0);
+
+        boolean removed = registry.unregister("alice", "rest-1");
+
+        assertThat(removed).isFalse();
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-2");
+    }
+
+    @Test
+    void unregister_lastInstance_dropsUser() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        boolean removed = registry.unregister("alice", "rest-1");
+
+        assertThat(removed).isTrue();
+        assertThat(registry.isWatching("alice")).isFalse();
+        assertThat(registry.watchedUserIds()).isEmpty();
+    }
+
+    @Test
+    void unregister_unknownUser_isNoOp() {
+        assertThat(registry.unregister("ghost", "rest-1")).isFalse();
+    }
+
+    @Test
+    void register_refreshesGroupsForExistingUser() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        registry.register("alice", List.of("eng", "finance"), "rest-2", T0);
+
+        assertThat(registry.groupsOf("alice")).containsExactlyInAnyOrder("eng", "finance");
+    }
+
+    @Test
+    void heartbeat_keepsInstanceAlive_soItsUsersSurviveExpiry() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.heartbeat("rest-1", T0.plus(Duration.ofMinutes(2)));
+
+        Set<String> removed = registry.expireInstances(T0.plus(Duration.ofMinutes(4)), DEAD_AFTER);
+
+        assertThat(removed).isEmpty();
+        assertThat(registry.isWatching("alice")).isTrue();
+    }
+
+    @Test
+    void expireInstances_dropsSilentInstance_andRemovesUsersItHeldAlone() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        Set<String> removed = registry.expireInstances(T0.plus(Duration.ofMinutes(4)), DEAD_AFTER);
+
+        assertThat(removed).containsExactly("alice");
+        assertThat(registry.isWatching("alice")).isFalse();
+    }
+
+    @Test
+    void expireInstances_keepsUserStillHeldByALiveInstance_withReducedSources() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.register("alice", List.of("eng"), "rest-2", T0);
+        // rest-2 keeps beating; rest-1 goes silent
+        registry.heartbeat("rest-2", T0.plus(Duration.ofMinutes(3)));
+
+        Set<String> removed = registry.expireInstances(T0.plus(Duration.ofMinutes(4)), DEAD_AFTER);
+
+        assertThat(removed).isEmpty();
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-2");
+    }
+
+    @Test
+    void applySnapshot_mergesUsersFromInstance() {
+        List<SubscriberRegistryMessage.Entry> entries = List.of(
+            new SubscriberRegistryMessage.Entry("alice", List.of("eng")),
+            new SubscriberRegistryMessage.Entry("bob", List.of("finance"))
+        );
+
+        registry.applySnapshot("rest-9", entries, T0);
+
+        assertThat(registry.watchedUserIds()).containsExactlyInAnyOrder("alice", "bob");
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-9");
+        assertThat(registry.groupsOf("bob")).containsExactly("finance");
+    }
+
+    @Test
+    void applySnapshot_withNullEntries_isNoOp_andDoesNotFail() {
+        registry.applySnapshot("rest-9", null, T0);
+
+        assertThat(registry.watchedUserIds()).isEmpty();
+    }
+
+    @Test
+    void snapshotAndNormalRegistration_mergeToTheSameUnion_regardlessOfOrder() {
+        SubscriberRegistryMessage.Entry snapshotEntry = new SubscriberRegistryMessage.Entry("alice", List.of("eng"));
+
+        // registration first, then a snapshot from another instance
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.applySnapshot("rest-2", List.of(snapshotEntry), T0);
+        assertThat(registry.sourcesOf("alice")).containsExactlyInAnyOrder("rest-1", "rest-2");
+
+        // reverse order yields the same union
+        ConsumerSubscriberRegistry reversed = new ConsumerSubscriberRegistry();
+        reversed.applySnapshot("rest-2", List.of(snapshotEntry), T0);
+        reversed.register("alice", List.of("eng"), "rest-1", T0);
+        assertThat(reversed.sourcesOf("alice")).containsExactlyInAnyOrder("rest-1", "rest-2");
+    }
+
+    @Test
+    void groupsAndSourcesOfUnknownUser_areEmpty() {
+        assertThat(registry.groupsOf("ghost")).isEmpty();
+        assertThat(registry.sourcesOf("ghost")).isEmpty();
+        assertThat(registry.isWatching("ghost")).isFalse();
+    }
+
+    @Test
+    void duplicateRegister_fromSameInstance_isIdempotent() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        boolean firstAppearanceAgain = registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        assertThat(firstAppearanceAgain).isFalse();
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-1");
+    }
+
+    @Test
+    void unregisterBeforeRegister_isNoOp_thenRegisterStillWorks() {
+        // at-least-once delivery can reorder: an UNREGISTERED for an unknown user must be harmless
+        assertThat(registry.unregister("alice", "rest-1")).isFalse();
+
+        boolean firstAppearance = registry.register("alice", List.of("eng"), "rest-1", T0);
+
+        assertThat(firstAppearance).isTrue();
+        assertThat(registry.isWatching("alice")).isTrue();
+    }
+
+    @Test
+    void staleUnregister_afterReregisterOnAnotherInstance_onlyRemovesItsOwnSource() {
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.unregister("alice", "rest-1");
+        registry.register("alice", List.of("eng"), "rest-2", T0);
+
+        boolean removed = registry.unregister("alice", "rest-1");
+
+        assertThat(removed).isFalse();
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-2");
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalSchedulerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalSchedulerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriberInstanceRemovalSchedulerTest {
+
+    @Mock
+    private SubscriberInstanceRemover remover;
+
+    private boolean featureEnabled;
+    private SubscriberInstanceRemovalScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
+        scheduler = new SubscriberInstanceRemovalScheduler(remover, featureToggle);
+    }
+
+    @Test
+    void runsRemoval_whenFeatureEnabled() {
+        featureEnabled = true;
+
+        scheduler.removeExpiredInstances();
+
+        verify(remover).removeExpiredInstances();
+    }
+
+    @Test
+    void skipsRemoval_whenFeatureDisabled() {
+        featureEnabled = false;
+
+        scheduler.removeExpiredInstances();
+
+        verifyNoInteractions(remover);
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalSchedulerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemovalSchedulerTest.java
@@ -16,10 +16,7 @@
 package org.activiti.cloud.services.query.app;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,30 +29,17 @@ class SubscriberInstanceRemovalSchedulerTest {
     @Mock
     private SubscriberInstanceRemover remover;
 
-    private boolean featureEnabled;
     private SubscriberInstanceRemovalScheduler scheduler;
 
     @BeforeEach
     void setUp() {
-        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
-        scheduler = new SubscriberInstanceRemovalScheduler(remover, featureToggle);
+        scheduler = new SubscriberInstanceRemovalScheduler(remover);
     }
 
     @Test
-    void runsRemoval_whenFeatureEnabled() {
-        featureEnabled = true;
-
+    void runsRemoval() {
         scheduler.removeExpiredInstances();
 
         verify(remover).removeExpiredInstances();
-    }
-
-    @Test
-    void skipsRemoval_whenFeatureDisabled() {
-        featureEnabled = false;
-
-        scheduler.removeExpiredInstances();
-
-        verifyNoInteractions(remover);
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemoverTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberInstanceRemoverTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SubscriberInstanceRemoverTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Duration TIMEOUT = Duration.ofMinutes(3);
+
+    @Test
+    void removesInstanceSilentPastTimeout_andDropsItsUsers() {
+        ConsumerSubscriberRegistry registry = new ConsumerSubscriberRegistry();
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        SubscriberInstanceRemover remover = removerAt(registry, T0.plus(Duration.ofMinutes(4)));
+
+        Set<String> dropped = remover.removeExpiredInstances();
+
+        assertThat(dropped).containsExactly("alice");
+        assertThat(registry.isWatching("alice")).isFalse();
+    }
+
+    @Test
+    void keepsInstanceStillWithinTimeout() {
+        ConsumerSubscriberRegistry registry = new ConsumerSubscriberRegistry();
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        SubscriberInstanceRemover remover = removerAt(registry, T0.plus(Duration.ofMinutes(2)));
+
+        Set<String> dropped = remover.removeExpiredInstances();
+
+        assertThat(dropped).isEmpty();
+        assertThat(registry.isWatching("alice")).isTrue();
+    }
+
+    @Test
+    void keepsUserStillHeldByALiveInstance() {
+        ConsumerSubscriberRegistry registry = new ConsumerSubscriberRegistry();
+        registry.register("alice", List.of("eng"), "rest-1", T0);
+        registry.register("alice", List.of("eng"), "rest-2", T0);
+        registry.heartbeat("rest-2", T0.plus(Duration.ofMinutes(3)));
+        SubscriberInstanceRemover remover = removerAt(registry, T0.plus(Duration.ofMinutes(4)));
+
+        Set<String> dropped = remover.removeExpiredInstances();
+
+        assertThat(dropped).isEmpty();
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-2");
+    }
+
+    private static SubscriberInstanceRemover removerAt(ConsumerSubscriberRegistry registry, Instant now) {
+        return new SubscriberInstanceRemover(registry, TIMEOUT, Clock.fixed(now, ZoneOffset.UTC));
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.time.Instant;
+import java.util.List;
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+
+class SubscriberRegistryConsumerTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    private ConsumerSubscriberRegistry registry;
+    private boolean featureEnabled;
+    private SubscriberRegistryConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        registry = new ConsumerSubscriberRegistry();
+        SubscriberRegistryMessageHandler handler = new SubscriberRegistryMessageHandler(registry);
+        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
+        consumer = new SubscriberRegistryConsumer(handler, featureToggle);
+    }
+
+    @Test
+    void appliesMessage_whenFeatureEnabled() {
+        featureEnabled = true;
+
+        consumer.accept(registeredMessage());
+
+        assertThat(registry.isWatching("alice")).isTrue();
+    }
+
+    @Test
+    void dropsMessage_whenFeatureDisabled() {
+        featureEnabled = false;
+
+        consumer.accept(registeredMessage());
+
+        assertThat(registry.isWatching("alice")).isFalse();
+        assertThat(registry.size()).isZero();
+    }
+
+    @Test
+    void skipsMessage_whenHandlerThrows_soOneBadMessageDoesNotWedgeTheChannel() {
+        SubscriberRegistryMessageHandler throwingHandler = new SubscriberRegistryMessageHandler(registry) {
+            @Override
+            public void handle(SubscriberRegistryMessage message) {
+                throw new IllegalStateException("boom");
+            }
+        };
+        SubscriberRegistryConsumer resilientConsumer = new SubscriberRegistryConsumer(
+            throwingHandler,
+            QueryFeatureToggles.FEATURE_PUSHED_COUNTS::equals
+        );
+
+        assertThatCode(() -> resilientConsumer.accept(registeredMessage())).doesNotThrowAnyException();
+    }
+
+    private static Message<SubscriberRegistryMessage> registeredMessage() {
+        return new GenericMessage<>(SubscriberRegistryMessage.registered("alice", List.of("eng"), "rest-1", T0));
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryConsumerTest.java
@@ -20,8 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.Instant;
 import java.util.List;
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,34 +31,20 @@ class SubscriberRegistryConsumerTest {
     private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
 
     private ConsumerSubscriberRegistry registry;
-    private boolean featureEnabled;
     private SubscriberRegistryConsumer consumer;
 
     @BeforeEach
     void setUp() {
         registry = new ConsumerSubscriberRegistry();
         SubscriberRegistryMessageHandler handler = new SubscriberRegistryMessageHandler(registry);
-        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
-        consumer = new SubscriberRegistryConsumer(handler, featureToggle);
+        consumer = new SubscriberRegistryConsumer(handler);
     }
 
     @Test
-    void appliesMessage_whenFeatureEnabled() {
-        featureEnabled = true;
-
+    void appliesMessage() {
         consumer.accept(registeredMessage());
 
         assertThat(registry.isWatching("alice")).isTrue();
-    }
-
-    @Test
-    void dropsMessage_whenFeatureDisabled() {
-        featureEnabled = false;
-
-        consumer.accept(registeredMessage());
-
-        assertThat(registry.isWatching("alice")).isFalse();
-        assertThat(registry.size()).isZero();
     }
 
     @Test
@@ -71,10 +55,7 @@ class SubscriberRegistryConsumerTest {
                 throw new IllegalStateException("boom");
             }
         };
-        SubscriberRegistryConsumer resilientConsumer = new SubscriberRegistryConsumer(
-            throwingHandler,
-            QueryFeatureToggles.FEATURE_PUSHED_COUNTS::equals
-        );
+        SubscriberRegistryConsumer resilientConsumer = new SubscriberRegistryConsumer(throwingHandler);
 
         assertThatCode(() -> resilientConsumer.accept(registeredMessage())).doesNotThrowAnyException();
     }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandlerTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryMessageHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SubscriberRegistryMessageHandlerTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    private ConsumerSubscriberRegistry registry;
+    private SubscriberRegistryMessageHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        registry = new ConsumerSubscriberRegistry();
+        handler = new SubscriberRegistryMessageHandler(registry);
+    }
+
+    @Test
+    void registeredMessage_addsWatchingUserWithGroups() {
+        handler.handle(SubscriberRegistryMessage.registered("alice", List.of("eng"), "rest-1", T0));
+
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.groupsOf("alice")).containsExactly("eng");
+        assertThat(registry.sourcesOf("alice")).containsExactly("rest-1");
+    }
+
+    @Test
+    void unregisteredMessage_removesUserHeldByOnlyThatInstance() {
+        handler.handle(SubscriberRegistryMessage.registered("alice", List.of("eng"), "rest-1", T0));
+
+        handler.handle(SubscriberRegistryMessage.unregistered("alice", "rest-1", T0));
+
+        assertThat(registry.isWatching("alice")).isFalse();
+    }
+
+    @Test
+    void heartbeatMessage_keepsInstanceAlive() {
+        handler.handle(SubscriberRegistryMessage.registered("alice", List.of("eng"), "rest-1", T0));
+        handler.handle(SubscriberRegistryMessage.heartbeat("rest-1", T0.plus(Duration.ofMinutes(2))));
+
+        Set<String> removed = registry.expireInstances(T0.plus(Duration.ofMinutes(4)), Duration.ofMinutes(3));
+
+        assertThat(removed).isEmpty();
+        assertThat(registry.isWatching("alice")).isTrue();
+    }
+
+    @Test
+    void snapshotMessage_mergesEntries() {
+        SubscriberRegistryMessage snapshot = SubscriberRegistryMessage.snapshot(
+            List.of(
+                new SubscriberRegistryMessage.Entry("alice", List.of("eng")),
+                new SubscriberRegistryMessage.Entry("bob", List.of("finance"))
+            ),
+            "rest-9",
+            T0
+        );
+
+        handler.handle(snapshot);
+
+        assertThat(registry.watchedUserIds()).containsExactlyInAnyOrder("alice", "bob");
+        assertThat(registry.sourcesOf("bob")).containsExactly("rest-9");
+    }
+
+    @Test
+    void resyncRequestMessage_isIgnored() {
+        handler.handle(SubscriberRegistryMessage.resyncRequest("consumer-1", T0));
+
+        assertThat(registry.watchedUserIds()).isEmpty();
+        assertThat(registry.size()).isZero();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.services.query.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import org.activiti.cloud.common.feature.FeatureToggle;
+import org.activiti.cloud.services.query.QueryFeatureToggles;
+import org.activiti.cloud.services.query.subscription.RegistryMessageType;
+import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+class SubscriberRegistryResyncRequesterTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    private List<Message<?>> sent;
+    private boolean featureEnabled;
+    private SubscriberRegistryResyncRequester requester;
+
+    @BeforeEach
+    void setUp() {
+        sent = new ArrayList<>();
+        MessageChannel registryProducer = (message, timeout) -> sent.add(message);
+        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
+        requester = new SubscriberRegistryResyncRequester(
+            registryProducer,
+            featureToggle,
+            "consumer-1",
+            Clock.fixed(T0, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void broadcastsResyncRequest_whenFeatureEnabled() {
+        featureEnabled = true;
+
+        requester.requestResync();
+
+        assertThat(sent).hasSize(1);
+        assertThat(sent.get(0).getPayload()).isInstanceOf(SubscriberRegistryMessage.class);
+        SubscriberRegistryMessage message = (SubscriberRegistryMessage) sent.get(0).getPayload();
+        assertThat(message.type()).isEqualTo(RegistryMessageType.RESYNC_REQUEST);
+        assertThat(message.sourceId()).isEqualTo("consumer-1");
+        assertThat(message.sentAt()).isEqualTo(T0);
+    }
+
+    @Test
+    void broadcastsNothing_whenFeatureDisabled() {
+        featureEnabled = false;
+
+        requester.requestResync();
+
+        assertThat(sent).isEmpty();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
@@ -22,8 +22,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import org.activiti.cloud.common.feature.FeatureToggle;
-import org.activiti.cloud.services.query.QueryFeatureToggles;
 import org.activiti.cloud.services.query.subscription.RegistryMessageType;
 import org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,26 +34,21 @@ class SubscriberRegistryResyncRequesterTest {
     private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
 
     private List<Message<?>> sent;
-    private boolean featureEnabled;
     private SubscriberRegistryResyncRequester requester;
 
     @BeforeEach
     void setUp() {
         sent = new ArrayList<>();
         MessageChannel registryProducer = (message, timeout) -> sent.add(message);
-        FeatureToggle featureToggle = name -> featureEnabled && QueryFeatureToggles.FEATURE_PUSHED_COUNTS.equals(name);
         requester = new SubscriberRegistryResyncRequester(
             registryProducer,
-            featureToggle,
             "consumer-1",
             Clock.fixed(T0, ZoneOffset.UTC)
         );
     }
 
     @Test
-    void broadcastsResyncRequest_whenFeatureEnabled() {
-        featureEnabled = true;
-
+    void broadcastsResyncRequestOnStartup() {
         requester.requestResync();
 
         assertThat(sent).hasSize(1);
@@ -64,14 +57,5 @@ class SubscriberRegistryResyncRequesterTest {
         assertThat(message.type()).isEqualTo(RegistryMessageType.RESYNC_REQUEST);
         assertThat(message.sourceId()).isEqualTo("consumer-1");
         assertThat(message.sentAt()).isEqualTo(T0);
-    }
-
-    @Test
-    void broadcastsNothing_whenFeatureDisabled() {
-        featureEnabled = false;
-
-        requester.requestResync();
-
-        assertThat(sent).isEmpty();
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
+++ b/activiti-cloud-query-service/activiti-cloud-services-query/activiti-cloud-services-query-consumer/src/test/java/org/activiti/cloud/services/query/app/SubscriberRegistryResyncRequesterTest.java
@@ -16,6 +16,7 @@
 package org.activiti.cloud.services.query.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 
 class SubscriberRegistryResyncRequesterTest {
 
@@ -52,10 +54,24 @@ class SubscriberRegistryResyncRequesterTest {
         requester.requestResync();
 
         assertThat(sent).hasSize(1);
-        assertThat(sent.get(0).getPayload()).isInstanceOf(SubscriberRegistryMessage.class);
-        SubscriberRegistryMessage message = (SubscriberRegistryMessage) sent.get(0).getPayload();
+        assertThat(sent.getFirst().getPayload()).isInstanceOf(SubscriberRegistryMessage.class);
+        SubscriberRegistryMessage message = (SubscriberRegistryMessage) sent.getFirst().getPayload();
         assertThat(message.type()).isEqualTo(RegistryMessageType.RESYNC_REQUEST);
         assertThat(message.sourceId()).isEqualTo("consumer-1");
         assertThat(message.sentAt()).isEqualTo(T0);
+    }
+
+    @Test
+    void doesNotPropagate_whenBrokerSendFails() {
+        MessageChannel failingProducer = (message, timeout) -> {
+            throw new MessageDeliveryException(message, "broker unavailable");
+        };
+        SubscriberRegistryResyncRequester requesterWithFailingProducer = new SubscriberRegistryResyncRequester(
+            failingProducer,
+            "consumer-1",
+            Clock.fixed(T0, ZoneOffset.UTC)
+        );
+
+        assertThatCode(requesterWithFailingProducer::requestResync).doesNotThrowAnyException();
     }
 }

--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/main/resources/query-messaging.properties
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/main/resources/query-messaging.properties
@@ -6,6 +6,15 @@ spring.cloud.stream.rabbit.bindings.queryConsumer.consumer.prefetch=${ACT_QUERY_
 spring.cloud.stream.bindings.queryEventsProducer.destination=${ACT_QUERY_EVENTS_DEST:queryEvents}
 spring.cloud.stream.bindings.queryEventsProducer.contentType=${ACT_QUERY_EVENTS_CONTENT_TYPE:application/json}
 
+# Pushed badge counts (feature: query.pushed-counts). Registry is a fan-out (no consumer group) so
+# every consumer instance sees every subscriber; destinations are overridable per environment.
+spring.cloud.stream.bindings.subscriberRegistryConsumer.destination=${ACT_QUERY_SUBSCRIBER_REGISTRY_DEST:subscriberRegistry}
+spring.cloud.stream.bindings.subscriberRegistryConsumer.contentType=${ACT_QUERY_SUBSCRIBER_REGISTRY_CONTENT_TYPE:application/json}
+spring.cloud.stream.bindings.subscriberRegistryProducer.destination=${ACT_QUERY_SUBSCRIBER_REGISTRY_DEST:subscriberRegistry}
+spring.cloud.stream.bindings.subscriberRegistryProducer.contentType=${ACT_QUERY_SUBSCRIBER_REGISTRY_CONTENT_TYPE:application/json}
+spring.cloud.stream.bindings.countProducer.destination=${ACT_QUERY_COUNTS_DEST:pushedCounts}
+spring.cloud.stream.bindings.countProducer.contentType=${ACT_QUERY_COUNTS_CONTENT_TYPE:application/json}
+
 spring.cloud.stream.instanceIndex=${activiti.cloud.messaging.instance-index}
 spring.cloud.stream.instanceCount=${activiti.cloud.messaging.partition-count}
 

--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryDisabledIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryDisabledIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.starter.query.consumer.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * End-to-end proof that the whole registry path stays inert while the pushed-counts toggle is off:
+ * a message crosses the binding but the consumer drops it, so the registry never fills.
+ */
+@SpringBootTest(
+    classes = QueryConsumerTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    properties = {
+        "activiti.cloud.services.oauth2.iam-name=test", "activiti.features.query.pushed-counts.enabled=false",
+    }
+)
+@EnableTestBinder
+class PushedCountsRegistryDisabledIT {
+
+    @Autowired
+    private InputDestination input;
+
+    @Autowired
+    private ConsumerSubscriberRegistry registry;
+
+    @Test
+    void registeredMessage_isIgnored_whenFeatureDisabled() {
+        input.send(
+            MessageBuilder.withPayload(
+                """
+                {"type":"REGISTERED","userId":"frank","groups":["eng"],"sourceId":"rest-1","sentAt":"2026-01-01T00:00:00Z"}
+                """.strip()
+                    .getBytes(StandardCharsets.UTF_8)
+            )
+                .setHeader("contentType", "application/json")
+                .build(),
+            "subscriberRegistry"
+        );
+
+        assertThat(registry.isWatching("frank")).isFalse();
+        assertThat(registry.size()).isZero();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.starter.query.consumer.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.activiti.cloud.services.query.app.ConsumerSubscriberRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.EnableTestBinder;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * End-to-end binding test for the pushed-counts subscriber registry: drives real broker messages
+ * through the in-memory test binder so the {@code subscriberRegistry} binding, the JSON
+ * (de)serialization of {@link org.activiti.cloud.services.query.subscription.SubscriberRegistryMessage},
+ * the feature toggle and the startup resync are all exercised together — none of which the unit
+ * tests cover.
+ */
+@SpringBootTest(
+    classes = QueryConsumerTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    properties = {
+        "activiti.cloud.services.oauth2.iam-name=test", "activiti.features.query.pushed-counts.enabled=true",
+    }
+)
+@EnableTestBinder
+class PushedCountsRegistryIT {
+
+    private static final String REGISTRY_DESTINATION = "subscriberRegistry";
+    private static final String SENT_AT = "2026-01-01T00:00:00Z";
+
+    @Autowired
+    private InputDestination input;
+
+    @Autowired
+    private OutputDestination output;
+
+    @Autowired
+    private ConsumerSubscriberRegistry registry;
+
+    @Test
+    void registeredMessage_isDeserializedAndAppliedToTheRegistry() {
+        input.send(
+            registryJson(
+                """
+                {"type":"REGISTERED","userId":"alice","groups":["eng"],"sourceId":"rest-1","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+
+        assertThat(registry.isWatching("alice")).isTrue();
+        assertThat(registry.groupsOf("alice")).containsExactly("eng");
+    }
+
+    @Test
+    void unregisteredMessage_removesTheUserHeldByThatInstance() {
+        input.send(
+            registryJson(
+                """
+                {"type":"REGISTERED","userId":"bob","groups":["fin"],"sourceId":"rest-1","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+        assertThat(registry.isWatching("bob")).isTrue();
+
+        input.send(
+            registryJson(
+                """
+                {"type":"UNREGISTERED","userId":"bob","sourceId":"rest-1","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+
+        assertThat(registry.isWatching("bob")).isFalse();
+    }
+
+    @Test
+    void consumerBroadcastsResyncRequest_onStartup() {
+        Message<byte[]> resync = output.receive(5000, REGISTRY_DESTINATION);
+
+        assertThat(resync).isNotNull();
+        assertThat(new String(resync.getPayload(), StandardCharsets.UTF_8)).contains("RESYNC_REQUEST");
+    }
+
+    @Test
+    void snapshotMessage_withNestedEntries_isDeserializedAndMerged() {
+        input.send(
+            registryJson(
+                """
+                {"type":"SNAPSHOT","entries":[{"userId":"carol","groups":["eng"]},\
+                {"userId":"dave","groups":["fin","ops"]}],"sourceId":"rest-9","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+
+        assertThat(registry.isWatching("carol")).isTrue();
+        assertThat(registry.sourcesOf("carol")).containsExactly("rest-9");
+        assertThat(registry.groupsOf("dave")).containsExactlyInAnyOrder("fin", "ops");
+    }
+
+    @Test
+    void registrationsFromTwoInstances_areAggregatedForTheSameUser() {
+        input.send(
+            registryJson(
+                """
+                {"type":"REGISTERED","userId":"erin","groups":["eng"],"sourceId":"rest-1","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+        input.send(
+            registryJson(
+                """
+                {"type":"REGISTERED","userId":"erin","groups":["eng"],"sourceId":"rest-2","sentAt":"%s"}
+                """.formatted(SENT_AT)
+            ),
+            REGISTRY_DESTINATION
+        );
+
+        assertThat(registry.sourcesOf("erin")).containsExactlyInAnyOrder("rest-1", "rest-2");
+    }
+
+    private static Message<byte[]> registryJson(String json) {
+        return MessageBuilder.withPayload(json.strip().getBytes(StandardCharsets.UTF_8))
+            .setHeader("contentType", "application/json")
+            .build();
+    }
+}

--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryIT.java
@@ -39,7 +39,9 @@ import org.springframework.messaging.support.MessageBuilder;
     classes = QueryConsumerTestApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     properties = {
-        "activiti.cloud.services.oauth2.iam-name=test", "activiti.features.query.pushed-counts.enabled=true",
+        "activiti.cloud.services.oauth2.iam-name=test",
+        "activiti.cloud.query.pushed-counts.enabled=true",
+        "activiti.features.query.pushed-counts.enabled=true",
     }
 )
 @EnableTestBinder

--- a/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryRuntimeToggleOffIT.java
+++ b/activiti-cloud-query-service/activiti-cloud-starter-query-consumer/src/test/java/org/activiti/cloud/starter/query/consumer/test/PushedCountsRegistryRuntimeToggleOffIT.java
@@ -27,18 +27,22 @@ import org.springframework.cloud.stream.binder.test.InputDestination;
 import org.springframework.messaging.support.MessageBuilder;
 
 /**
- * End-to-end proof that the whole registry path stays inert while the pushed-counts toggle is off:
- * a message crosses the binding but the consumer drops it, so the registry never fills.
+ * End-to-end proof that registry upkeep is independent of the runtime feature toggle: with the
+ * startup property on but {@code activiti.features.query.pushed-counts.enabled=false}, a REGISTERED
+ * message crossing the binding is still applied. The runtime toggle gates the count push (later
+ * steps), not presence tracking.
  */
 @SpringBootTest(
     classes = QueryConsumerTestApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     properties = {
-        "activiti.cloud.services.oauth2.iam-name=test", "activiti.features.query.pushed-counts.enabled=false",
+        "activiti.cloud.services.oauth2.iam-name=test",
+        "activiti.cloud.query.pushed-counts.enabled=true",
+        "activiti.features.query.pushed-counts.enabled=false",
     }
 )
 @EnableTestBinder
-class PushedCountsRegistryDisabledIT {
+class PushedCountsRegistryRuntimeToggleOffIT {
 
     @Autowired
     private InputDestination input;
@@ -47,7 +51,7 @@ class PushedCountsRegistryDisabledIT {
     private ConsumerSubscriberRegistry registry;
 
     @Test
-    void registeredMessage_isIgnored_whenFeatureDisabled() {
+    void registeredMessage_isStillApplied_whenRuntimeToggleOff() {
         input.send(
             MessageBuilder.withPayload(
                 """
@@ -60,7 +64,7 @@ class PushedCountsRegistryDisabledIT {
             "subscriberRegistry"
         );
 
-        assertThat(registry.isWatching("frank")).isFalse();
-        assertThat(registry.size()).isZero();
+        assertThat(registry.isWatching("frank")).isTrue();
+        assertThat(registry.size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
Adds the query-consumer side of pushed counts: an in-memory **subscriber registry** of who is being watched across query-rest instances, plus the shared **wire contracts**. Behind the `query.pushed-counts` flag (off by default). **No counts are computed or published yet** — later step.

### Key points
- **Registry channel is fan-out (no consumer group)** — every consumer instance builds the full picture (one event can affect many users, so no per-user partitioning).
- **Bindings always exist; the feature is gated at runtime**, so it toggles without a redeploy — this is why the 8 topology guard ITs changed.
- **Snapshots merge as a union**, so restart-resync is race-free.
- **Companion change:** hxp-process-services adds the LaunchDarkly feature-toggle adapter to the consumer so the flag is controllable per environment.

### Included
- **Contracts** (`…-query-common`): `SubscriberRegistryMessage`/`RegistryMessageType`; `CountChangedMessage`/`ScopeKeys` (groundwork, no producer yet).
- **Consumer** (`…-query-consumer`): registry, handler, feature-gated consumer, heartbeat-expiry remover + scheduler, startup resync, auto-config, channels + properties.

### Testing
Unit (registry incl. concurrency, handler, consumer, remover, scheduler, resync, contracts) + integration through the test binder (REGISTERED/UNREGISTERED/SNAPSHOT/union/resync + a disabled negative IT).
