### PR TITLE
AAE-43165 Add dependabot pre-commit ecosystem support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,3 +74,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: c4a0b883114b00d8d76b479c820ce7950211c99b  # frozen: v4.5.0
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b # frozen: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: fix-byte-order-marker
@@ -15,7 +15,7 @@ repos:
         exclude: ^.*invalid.*\.json$
       - id: check-xml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea  # frozen: v4.0.0-alpha.8
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or:
@@ -26,14 +26,14 @@ repos:
           - prettier-plugin-java@2.8.1
         exclude: ^\.github/workflows/.*\.(lock\.yml|md)$
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3  # frozen: 0.37.4
+    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3 # frozen: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-actions
       - id: check-github-workflows
         exclude: ^\.github/workflows/.*\.lock\.yml$
   - repo: https://github.com/returntocorp/semgrep
-    rev: 16f6e92bb512558496b05c1b695e482245876fc0  # frozen: v1.59.1
+    rev: 16f6e92bb512558496b05c1b695e482245876fc0 # frozen: v1.59.1
     hooks:
       - id: semgrep
         types_or:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b  # frozen: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: fix-byte-order-marker
@@ -15,7 +15,7 @@ repos:
         exclude: ^.*invalid.*\.json$
       - id: check-xml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea  # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or:
@@ -26,14 +26,14 @@ repos:
           - prettier-plugin-java@2.8.1
         exclude: ^\.github/workflows/.*\.(lock\.yml|md)$
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.37.4
+    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3  # frozen: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-actions
       - id: check-github-workflows
         exclude: ^\.github/workflows/.*\.lock\.yml$
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.59.1
+    rev: 16f6e92bb512558496b05c1b695e482245876fc0  # frozen: v1.59.1
     hooks:
       - id: semgrep
         types_or:


### PR DESCRIPTION
Adds package-ecosystem: "pre-commit" to the Dependabot config so hook revisions in .pre-commit-config.yaml (SHA/tag pinned) are updated automatically, with a 3-day cooldown before updates land.

AAE-43165

Also SHA-pins every pre-commit hook rev (with a frozen: comment) so Dependabot's new pre-commit ecosystem can manage them per AAE-43165's acceptance criteria.